### PR TITLE
Use Shared Pointers for Celestial Class Bindings

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Object.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Object.cpp
@@ -25,7 +25,7 @@ inline void                     OpenSpaceToolkitPhysicsPy_Environment_Object (  
     using ostk::physics::env::Object ;
 
     // Binding class "Object"
-    class_<Object>(aModule, "Object")
+    class_<Object, Shared<Object>>(aModule, "Object")
 
         // no init
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Objects/Celestial.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Objects/Celestial.cpp
@@ -29,7 +29,7 @@ inline void                     OpenSpaceToolkitPhysicsPy_Environment_Objects_Ce
     using GravitationalModel = ostk::physics::environment::gravitational::Model ;
     using MagneticModel = ostk::physics::environment::magnetic::Model ;
 
-    class_<Celestial, Object> celestial_class(aModule, "Celestial") ;
+    class_<Celestial, Shared<Celestial>, Object> celestial_class(aModule, "Celestial") ;
 
     celestial_class.def(init<const String&, const Celestial::Type&, const Derived& , const Length&, const Real&, const Real&, const Shared<Ephemeris>&, const Shared<GravitationalModel>&, const Shared<MagneticModel>&, const Instant&>())
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Objects/CelestialBodies/Earth.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Objects/CelestialBodies/Earth.cpp
@@ -30,7 +30,7 @@ inline void                     OpenSpaceToolkitPhysicsPy_Environment_Objects_Ce
 
     {
 
-        class_<Earth, Celestial>(aModule, "Earth")
+        class_<Earth, Shared<Earth>, Celestial>(aModule, "Earth")
 
             .def(init<const Derived&, const Length&, const Real&, const Real&, const Shared<Ephemeris>&, const EarthGravitationalModel::Type&, const EarthMagneticModel::Type&, const Instant&>())
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Objects/CelestialBodies/Moon.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Objects/CelestialBodies/Moon.cpp
@@ -25,7 +25,7 @@ inline void                     OpenSpaceToolkitPhysicsPy_Environment_Objects_Ce
 
     {
 
-        class_<Moon, Celestial>(aModule, "Moon")
+        class_<Moon, Shared<Moon>, Celestial>(aModule, "Moon")
 
             .def(init<const Shared<Ephemeris>&, const Instant&>())
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Objects/CelestialBodies/Sun.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Objects/CelestialBodies/Sun.cpp
@@ -25,7 +25,7 @@ inline void                     OpenSpaceToolkitPhysicsPy_Environment_Objects_Ce
 
     {
 
-        class_<Sun, Celestial>(aModule, "Sun")
+        class_<Sun, Shared<Sun>, Celestial>(aModule, "Sun")
 
             .def(init<const Shared<Ephemeris>&, const Instant&>())
 


### PR DESCRIPTION
fix to be propagated and used in creating orbit in astrodynamics