### PR TITLE
fix: allow [H]our/[M]inute/[S]econd carry over in Duration::Parse

### DIFF
--- a/src/OpenSpaceToolkit/Physics/Time/Duration.cpp
+++ b/src/OpenSpaceToolkit/Physics/Time/Duration.cpp
@@ -878,7 +878,7 @@ Duration                        Duration::Parse                             (   
             boost::smatch match ;
 
             // if (boost::regex_match(aString, match, boost::regex("^([-])?P(?:([0-9]+)Y)?(?:([0-9]+)M)?(?:([0-9]+)D)?(?:T(?:([0-9]{1,2})H)?(?:([0-9]{1,2})M)?(?:(?:([0-9]{1,2})(?:\\.([0-9]{1,9}))?)S)?)?$")))
-            if (boost::regex_match(aString, match, boost::regex("^([-])?P(?:([0-9]+)D)?(?:T(?:([0-9]{1,2})H)?(?:([0-9]{1,2})M)?(?:(?:([0-9]{1,2})(?:\\.([0-9]{1,9}))?)S)?)?$"))) // Does not support [M]onth and [Y]ear groups
+            if (boost::regex_match(aString, match, boost::regex("^([-])?P(?:([0-9]+)D)?(?:T(?:([0-9]+)H)?(?:([0-9]+)M)?(?:(?:([0-9]+)(?:\\.([0-9]{1,9}))?)S)?)?$"))) // Does not support [M]onth and [Y]ear groups, allow [H]our, [M]inute and [S]econd carry over
             {
 
                 try

--- a/test/OpenSpaceToolkit/Physics/Time/Duration.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Time/Duration.test.cpp
@@ -2237,6 +2237,10 @@ TEST (OpenSpaceToolkit_Physics_Time_Duration, Parse)
         EXPECT_EQ((Duration::Hours(+1.0) + Duration::Minutes(+2.0) + Duration::Seconds(+3.0)), Duration::Parse("PT1H2M3S", Duration::Format::ISO8601)) ;
         EXPECT_EQ((Duration::Hours(+12.0) + Duration::Minutes(+34.0) + Duration::Seconds(+56.0)), Duration::Parse("PT12H34M56S", Duration::Format::ISO8601)) ;
 
+        EXPECT_EQ(Duration::Seconds(+123.0), Duration::Parse("PT123S", Duration::Format::ISO8601)) ;
+        EXPECT_EQ((Duration::Minutes(+123.0) + Duration::Seconds(+45.0)), Duration::Parse("PT123M45S", Duration::Format::ISO8601)) ;
+        EXPECT_EQ((Duration::Hours(+123.0) + Duration::Minutes(+45.0) + Duration::Seconds(+60.0)), Duration::Parse("PT123H45M60S", Duration::Format::ISO8601)) ;
+
         EXPECT_EQ((Duration::Days(+1.0)), Duration::Parse("P1D", Duration::Format::ISO8601)) ;
         EXPECT_EQ((Duration::Days(+1.0) + Duration::Hours(+1.0)), Duration::Parse("P1DT1H", Duration::Format::ISO8601)) ;
         EXPECT_EQ((Duration::Days(+1.0) + Duration::Hours(+1.0) + Duration::Minutes(+2.0)), Duration::Parse("P1DT1H2M", Duration::Format::ISO8601)) ;
@@ -2274,6 +2278,10 @@ TEST (OpenSpaceToolkit_Physics_Time_Duration, Parse)
 
         EXPECT_EQ((-(Duration::Hours(+1.0) + Duration::Minutes(+2.0) + Duration::Seconds(+3.0))), Duration::Parse("-PT1H2M3S", Duration::Format::ISO8601)) ;
         EXPECT_EQ((-(Duration::Hours(+12.0) + Duration::Minutes(+34.0) + Duration::Seconds(+56.0))), Duration::Parse("-PT12H34M56S", Duration::Format::ISO8601)) ;
+
+        EXPECT_EQ(Duration::Seconds(-123.0), Duration::Parse("-PT123S", Duration::Format::ISO8601)) ;
+        EXPECT_EQ((-(Duration::Minutes(+123.0) + Duration::Seconds(+45.0))), Duration::Parse("-PT123M45S", Duration::Format::ISO8601)) ;
+        EXPECT_EQ((-(Duration::Hours(+123.0) + Duration::Minutes(+45.0) + Duration::Seconds(+60.0))), Duration::Parse("-PT123H45M60S", Duration::Format::ISO8601)) ;
 
         EXPECT_EQ((-(Duration::Days(+1.0))), Duration::Parse("-P1D", Duration::Format::ISO8601)) ;
         EXPECT_EQ((-(Duration::Days(+1.0) + Duration::Hours(+1.0))), Duration::Parse("-P1DT1H", Duration::Format::ISO8601)) ;


### PR DESCRIPTION
This MR proposes to fully support parsing ISO-8601 durations with [H]our/[M]inute/[S]econd component(s) exceeding their "carry over points":

> The standard does not prohibit date and time values in a duration representation from exceeding their "carry over points" except as noted below. Thus, "PT36H" could be used as well as "P1DT12H" for representing the same duration.
https://en.wikipedia.org/wiki/ISO_8601#Durations

It does _not_ modify the `Duration::toString` method.

