### PR TITLE
refactor: remove default Atmosphere and Magnetic models

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth.cpp
@@ -28,6 +28,8 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth(pybind11::mo
 
             .def("get_type", &Earth::getType)
 
+            .def("is_defined", &Earth::isDefined)
+
             .def(
                 "get_density_at",
                 pybind11::overload_cast<const Position&, const Instant&>(&Earth::getDensityAt, pybind11::const_),

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth.cpp
@@ -46,7 +46,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth(pybind11::mo
 
             ;
 
-        enum_<Earth::Type>(earth_class, "Type")
+        enum_<Earth::Type>(earth_class, "EarthAtmosphericType")
 
             .value("Undefined", Earth::Type::Undefined)
             .value("Exponential", Earth::Type::Exponential);

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth.cpp
@@ -48,6 +48,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth(pybind11::mo
 
         enum_<Earth::Type>(earth_class, "Type")
 
+            .value("Undefined", Earth::Type::Undefined)
             .value("Exponential", Earth::Type::Exponential);
     }
 }

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Magnetic/Earth.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Magnetic/Earth.cpp
@@ -21,6 +21,9 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Magnetic_Earth(pybind11::modul
         .def(init<const Earth::Type&>())
 
         .def("get_type", &Earth::getType)
+
+        .def("is_defined", &Earth::isDefined)
+
         .def("get_field_value_at", &Earth::getFieldValueAt)
 
         ;

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Magnetic/Earth.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Magnetic/Earth.cpp
@@ -28,8 +28,9 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Magnetic_Earth(pybind11::modul
 
         ;
 
-    enum_<Earth::Type>(earth_magnetic_class, "EarthMagneticType")
+    enum_<Earth::Type>(earth_magnetic_class, "Type")
 
+        .value("Undefined", Earth::Type::Undefined)
         .value("Dipole", Earth::Type::Dipole)
         .value("EMM2010", Earth::Type::EMM2010)
         .value("EMM2015", Earth::Type::EMM2015)

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Magnetic/Earth.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Magnetic/Earth.cpp
@@ -28,7 +28,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Magnetic_Earth(pybind11::modul
 
         ;
 
-    enum_<Earth::Type>(earth_magnetic_class, "Type")
+    enum_<Earth::Type>(earth_magnetic_class, "EarthMagneticType")
 
         .value("Undefined", Earth::Type::Undefined)
         .value("Dipole", Earth::Type::Dipole)

--- a/bindings/python/test/environment/atmospheric/test_earth.py
+++ b/bindings/python/test/environment/atmospheric/test_earth.py
@@ -18,20 +18,20 @@ from ostk.physics.environment.objects.celestial_bodies import Earth
 
 @pytest.fixture
 def earth_atmospheric_model() -> EarthAtmosphericModel:
-    return EarthAtmosphericModel(EarthAtmosphericModel.Type.Exponential)
+    return EarthAtmosphericModel(EarthAtmosphericModel.EarthAtmosphericType.Exponential)
 
 
 class TestEarth:
     def test_constructor_success_with_type(self):
         earth_atmospheric_model = EarthAtmosphericModel(
-            type=EarthAtmosphericModel.Type.Exponential,
+            type=EarthAtmosphericModel.EarthAtmosphericType.Exponential,
         )
 
         assert isinstance(earth_atmospheric_model, EarthAtmosphericModel)
 
     def test_constructor_success_with_directory(self):
         earth_atmospheric_model = EarthAtmosphericModel(
-            type=EarthAtmosphericModel.Type.Exponential,
+            type=EarthAtmosphericModel.EarthAtmosphericType.Exponential,
             directory=Directory.undefined(),
         )
 
@@ -39,7 +39,7 @@ class TestEarth:
 
     def test_get_type_success(self, earth_atmospheric_model: EarthAtmosphericModel):
         assert (
-            earth_atmospheric_model.get_type() == EarthAtmosphericModel.Type.Exponential
+            earth_atmospheric_model.get_type() == EarthAtmosphericModel.EarthAtmosphericType.Exponential
         )
     
     def test_is_defined_success(self, earth_atmospheric_model: EarthAtmosphericModel):

--- a/bindings/python/test/environment/atmospheric/test_earth.py
+++ b/bindings/python/test/environment/atmospheric/test_earth.py
@@ -41,6 +41,11 @@ class TestEarth:
         assert (
             earth_atmospheric_model.get_type() == EarthAtmosphericModel.Type.Exponential
         )
+    
+    def test_is_defined_success(self, earth_atmospheric_model: EarthAtmosphericModel):
+        assert (
+            earth_atmospheric_model.is_defined() == True
+        )
 
     def test_get_density_at_success(self, earth_atmospheric_model: EarthAtmosphericModel):
         latitude = Angle.degrees(30.0)

--- a/bindings/python/test/environment/magnetic/test_earth.py
+++ b/bindings/python/test/environment/magnetic/test_earth.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from ostk.core.filesystem import Directory
 
-from ostk.physics.environment.atmospheric import Earth as EarthMagneticModel
+from ostk.physics.environment.magnetic import Earth as EarthMagneticModel
 from ostk.physics.environment.objects.celestial_bodies import Earth
 
 
@@ -18,15 +18,15 @@ def earth_magnetic_model() -> EarthMagneticModel:
 class TestEarth:
     def test_constructor_success_with_type(self):
         earth_magnetic_model = EarthMagneticModel(
-            type=EarthMagneticModel.Type.EMM2010,
+            EarthMagneticModel.Type.EMM2010,
         )
 
         assert isinstance(earth_magnetic_model, EarthMagneticModel)
 
     def test_constructor_success_with_directory(self):
         earth_magnetic_model = EarthMagneticModel(
-            type=EarthMagneticModel.Type.EMM2010,
-            directory=Directory.undefined(),
+            EarthMagneticModel.Type.EMM2010,
+            Directory.undefined(),
         )
 
         assert isinstance(earth_magnetic_model, EarthMagneticModel)

--- a/bindings/python/test/environment/magnetic/test_earth.py
+++ b/bindings/python/test/environment/magnetic/test_earth.py
@@ -12,20 +12,20 @@ from ostk.physics.environment.objects.celestial_bodies import Earth
 
 @pytest.fixture
 def earth_magnetic_model() -> EarthMagneticModel:
-    return EarthMagneticModel(EarthMagneticModel.Type.EMM2010)
+    return EarthMagneticModel(EarthMagneticModel.EarthMagneticType.EMM2010)
 
 
 class TestEarth:
     def test_constructor_success_with_type(self):
         earth_magnetic_model = EarthMagneticModel(
-            EarthMagneticModel.Type.EMM2010,
+            EarthMagneticModel.EarthMagneticType.EMM2010,
         )
 
         assert isinstance(earth_magnetic_model, EarthMagneticModel)
 
     def test_constructor_success_with_directory(self):
         earth_magnetic_model = EarthMagneticModel(
-            EarthMagneticModel.Type.EMM2010,
+            EarthMagneticModel.EarthMagneticType.EMM2010,
             Directory.undefined(),
         )
 
@@ -33,7 +33,7 @@ class TestEarth:
 
     def test_get_type_success(self, earth_magnetic_model: EarthMagneticModel):
         assert (
-            earth_magnetic_model.get_type() == EarthMagneticModel.Type.EMM2010
+            earth_magnetic_model.get_type() == EarthMagneticModel.EarthMagneticType.EMM2010
         )
     
     def test_is_defined_success(self, earth_magnetic_model: EarthMagneticModel):

--- a/bindings/python/test/environment/magnetic/test_earth.py
+++ b/bindings/python/test/environment/magnetic/test_earth.py
@@ -1,0 +1,43 @@
+# Apache License 2.0
+
+import pytest
+
+import numpy as np
+
+from ostk.core.filesystem import Directory
+
+from ostk.physics.environment.atmospheric import Earth as EarthMagneticModel
+from ostk.physics.environment.objects.celestial_bodies import Earth
+
+
+@pytest.fixture
+def earth_magnetic_model() -> EarthMagneticModel:
+    return EarthMagneticModel(EarthMagneticModel.Type.EMM2010)
+
+
+class TestEarth:
+    def test_constructor_success_with_type(self):
+        earth_magnetic_model = EarthMagneticModel(
+            type=EarthMagneticModel.Type.EMM2010,
+        )
+
+        assert isinstance(earth_magnetic_model, EarthMagneticModel)
+
+    def test_constructor_success_with_directory(self):
+        earth_magnetic_model = EarthMagneticModel(
+            type=EarthMagneticModel.Type.EMM2010,
+            directory=Directory.undefined(),
+        )
+
+        assert isinstance(earth_magnetic_model, EarthMagneticModel)
+
+    def test_get_type_success(self, earth_magnetic_model: EarthMagneticModel):
+        assert (
+            earth_magnetic_model.get_type() == EarthMagneticModel.Type.EMM2010
+        )
+    
+    def test_is_defined_success(self, earth_magnetic_model: EarthMagneticModel):
+        assert (
+            earth_magnetic_model.is_defined() == True
+        )
+

--- a/include/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.hpp
@@ -37,6 +37,7 @@ class Earth : public Model
    public:
     enum class Type
     {
+        Undefined,
         Exponential,
         NRLMSISE00
     };
@@ -70,6 +71,12 @@ class Earth : public Model
     /// @return             Pointer to Earth atmospheric model
 
     virtual Earth* clone() const override;
+
+    /// @brief              Check if the Earth atmospheric model is defined
+    ///
+    /// @return             True if the Earth atmospheric model is defined
+
+    bool isDefined() const;
 
     /// @brief              Get atmospheric model type
     ///

--- a/include/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/Exponential.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/Exponential.hpp
@@ -51,6 +51,11 @@ class Exponential : public Model
 
     virtual Exponential* clone() const override;
 
+    /// @brief              Check if the exponential atmospheric model is defined
+    ///
+    /// @return             True if the exponential atmospheric model is defined
+    bool isDefined() const;
+
     /// @brief              Get the atmospheric density value at a given position and instant
     ///
     /// @param              [in] aPosition A Position

--- a/include/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/Exponential.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/Exponential.hpp
@@ -54,6 +54,7 @@ class Exponential : public Model
     /// @brief              Check if the exponential atmospheric model is defined
     ///
     /// @return             True if the exponential atmospheric model is defined
+
     bool isDefined() const;
 
     /// @brief              Get the atmospheric density value at a given position and instant

--- a/include/OpenSpaceToolkit/Physics/Environment/Atmospheric/Model.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Atmospheric/Model.hpp
@@ -41,6 +41,11 @@ class Model
 
     virtual Model* clone() const = 0;
 
+    /// @brief              Check if the atmospheric model is defined (pure virtual)
+    ///
+    /// @return             True if the atmospheric model is defined
+    virtual bool isDefined() const = 0;
+
     /// @brief              Get the atmospheric density value at a given position and instant
     ///
     /// @param              [in] aPosition A Position

--- a/include/OpenSpaceToolkit/Physics/Environment/Atmospheric/Model.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Atmospheric/Model.hpp
@@ -44,6 +44,7 @@ class Model
     /// @brief              Check if the atmospheric model is defined (pure virtual)
     ///
     /// @return             True if the atmospheric model is defined
+
     virtual bool isDefined() const = 0;
 
     /// @brief              Get the atmospheric density value at a given position and instant

--- a/include/OpenSpaceToolkit/Physics/Environment/Magnetic/Dipole.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Magnetic/Dipole.hpp
@@ -46,6 +46,11 @@ class Dipole : public Model
 
     virtual Dipole* clone() const override;
 
+    /// @brief              Check if the dipole magnetic model is defined
+    ///
+    /// @return             True if the dipole magnetic model is defined
+    bool isDefined() const;
+
     /// @brief              Get the magnetic field value at a given position and instant
     ///
     /// @param              [in] aPosition A position, expressed in the magnetic object frame [m]

--- a/include/OpenSpaceToolkit/Physics/Environment/Magnetic/Dipole.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Magnetic/Dipole.hpp
@@ -49,6 +49,7 @@ class Dipole : public Model
     /// @brief              Check if the dipole magnetic model is defined
     ///
     /// @return             True if the dipole magnetic model is defined
+
     bool isDefined() const;
 
     /// @brief              Get the magnetic field value at a given position and instant

--- a/include/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth.hpp
@@ -42,6 +42,7 @@ class Earth : public Model
     enum class Type
     {
 
+        Undefined,
         Dipole,   ///< Dipole Model
         EMM2010,  ///< Enhanced Magnetic Model 2010: approximates the main and crustal magnetic fields for the period
                   ///< 2010–2015.
@@ -87,6 +88,12 @@ class Earth : public Model
     /// @return             Pointer to Earth magnetic model
 
     virtual Earth* clone() const override;
+
+    /// @brief              Check if the Earth magnetic model is defined
+    ///
+    /// @return             True if the Earth magnetic model is defined
+
+    bool isDefined() const;
 
     /// @brief              Get magnetic model type
     ///

--- a/include/OpenSpaceToolkit/Physics/Environment/Magnetic/Model.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Magnetic/Model.hpp
@@ -42,6 +42,7 @@ class Model
     /// @brief              Check if the magnetic model is defined (pure virtual)
     ///
     /// @return             True if the magnetic model is defined
+
     virtual bool isDefined() const = 0;
 
     /// @brief              Get the magnetic field value at a given position and instant (pure virtual)

--- a/include/OpenSpaceToolkit/Physics/Environment/Magnetic/Model.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Magnetic/Model.hpp
@@ -39,6 +39,11 @@ class Model
 
     virtual Model* clone() const = 0;
 
+    /// @brief              Check if the magnetic model is defined (pure virtual)
+    ///
+    /// @return             True if the magnetic model is defined
+    virtual bool isDefined() const = 0;
+
     /// @brief              Get the magnetic field value at a given position and instant (pure virtual)
     ///
     /// @param              [in] aPosition A position, expressed in the magnetic object frame [m]

--- a/src/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.cpp
@@ -147,13 +147,13 @@ Unique<Earth::Impl> Earth::ImplFromType(const Earth::Type& aType, const Director
 {
     (void)aDataDirectory;  // Not yet used
 
-    if (aType == Earth::Type::Exponential)
-    {
-        return std::make_unique<ExponentialImpl>(aType);
-    }
-    else if (aType == Earth::Type::Undefined)
+    if (aType == Earth::Type::Undefined)
     {
         return nullptr;
+    }
+    else if (aType == Earth::Type::Exponential)
+    {
+        return std::make_unique<ExponentialImpl>(aType);
     }
 
     throw ostk::core::error::runtime::Wrong("Type");

--- a/src/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.cpp
@@ -116,6 +116,11 @@ Earth* Earth::clone() const
     return new Earth(*this);
 }
 
+bool Earth::isDefined() const
+{
+    return implUPtr_ != nullptr;
+}
+
 Earth::Type Earth::getType() const
 {
     return implUPtr_->getType();
@@ -145,6 +150,10 @@ Unique<Earth::Impl> Earth::ImplFromType(const Earth::Type& aType, const Director
     if (aType == Earth::Type::Exponential)
     {
         return std::make_unique<ExponentialImpl>(aType);
+    }
+    else if (aType == Earth::Type::Undefined)
+    {
+        return nullptr;
     }
 
     throw ostk::core::error::runtime::Wrong("Type");

--- a/src/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/Exponential.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/Exponential.cpp
@@ -31,6 +31,11 @@ Exponential* Exponential::clone() const
     return new Exponential(*this);
 }
 
+bool Exponential::isDefined() const
+{
+    return true;
+}
+
 Real Exponential::getDensityAt(const Position& aPosition, const Instant& anInstant) const
 {
     return this->getDensityAt(

--- a/src/OpenSpaceToolkit/Physics/Environment/Ephemerides/SPICE/Engine.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Ephemerides/SPICE/Engine.cpp
@@ -236,7 +236,7 @@ Array<Kernel> Engine::DefaultKernels(const Directory& aLocalRepository)
         ),  // System body shape and orientation constants
 
         Kernel::File(File::Path(aLocalRepository.getPath() + Path::Parse("earth_assoc_itrf93.tf"))),
-        Kernel::File(File::Path(aLocalRepository.getPath() + Path::Parse("earth_200101_990825_predict.bpc"))),
+        Kernel::File(File::Path(aLocalRepository.getPath() + Path::Parse("earth_200101_990628_predict.bpc"))),
 
         Kernel::File(File::Path(aLocalRepository.getPath() + Path::Parse("moon_080317.tf"))),
         Kernel::File(File::Path(aLocalRepository.getPath() + Path::Parse("moon_assoc_me.tf"))),

--- a/src/OpenSpaceToolkit/Physics/Environment/Ephemerides/SPICE/Engine.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Ephemerides/SPICE/Engine.cpp
@@ -236,7 +236,7 @@ Array<Kernel> Engine::DefaultKernels(const Directory& aLocalRepository)
         ),  // System body shape and orientation constants
 
         Kernel::File(File::Path(aLocalRepository.getPath() + Path::Parse("earth_assoc_itrf93.tf"))),
-        Kernel::File(File::Path(aLocalRepository.getPath() + Path::Parse("earth_200101_990628_predict.bpc"))),
+        Kernel::File(File::Path(aLocalRepository.getPath() + Path::Parse("earth_200101_990825_predict.bpc"))),
 
         Kernel::File(File::Path(aLocalRepository.getPath() + Path::Parse("moon_080317.tf"))),
         Kernel::File(File::Path(aLocalRepository.getPath() + Path::Parse("moon_assoc_me.tf"))),

--- a/src/OpenSpaceToolkit/Physics/Environment/Magnetic/Dipole.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Magnetic/Dipole.cpp
@@ -34,6 +34,11 @@ Dipole* Dipole::clone() const
     return new Dipole(*this);
 }
 
+bool Dipole::isDefined() const
+{
+    return true;
+}
+
 Vector3d Dipole::getFieldValueAt(const Vector3d& aPosition, const Instant& anInstant) const
 {
     (void)anInstant;  // Temporal invariance

--- a/src/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth.cpp
@@ -47,6 +47,8 @@ class Earth::Impl
 
     Earth::Type getType() const;
 
+    bool isDefined() const;
+
     Vector3d getFieldValueAt(const Vector3d& aPosition, const Instant& anInstant) const;
 
    private:
@@ -71,6 +73,11 @@ Earth::Impl::~Impl()
 Earth::Type Earth::Impl::getType() const
 {
     return type_;
+}
+
+bool Earth::Impl::isDefined() const
+{
+    return magneticModelPtr_ != nullptr;
 }
 
 Vector3d Earth::Impl::getFieldValueAt(const Vector3d& aPosition, const Instant& anInstant) const
@@ -145,7 +152,7 @@ MagneticModel* Earth::Impl::MagneticModelFromType(const Earth::Type& aType, cons
 
     using ostk::physics::environment::magnetic::earth::Manager;
 
-    if (aType == Earth::Type::Dipole)
+    if (aType == Earth::Type::Undefined || aType == Earth::Type::Dipole)
     {
         return nullptr;
     }
@@ -239,6 +246,18 @@ Earth::~Earth() {}
 Earth* Earth::clone() const
 {
     return new Earth(*this);
+}
+
+bool Earth::isDefined() const
+{
+    if (implUPtr_ == nullptr)
+    {
+        return false;
+    }
+    else
+    {
+        return implUPtr_->isDefined();
+    }
 }
 
 Earth::Type Earth::getType() const

--- a/src/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth.cpp
@@ -152,6 +152,7 @@ MagneticModel* Earth::Impl::MagneticModelFromType(const Earth::Type& aType, cons
 
     using ostk::physics::environment::magnetic::earth::Manager;
 
+    // TBI: move dipole to an implementation class to align with other models
     if (aType == Earth::Type::Undefined || aType == Earth::Type::Dipole)
     {
         return nullptr;

--- a/src/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth.cpp
@@ -254,10 +254,9 @@ bool Earth::isDefined() const
     {
         return false;
     }
-    else
-    {
-        return implUPtr_->isDefined();
-    }
+
+    return implUPtr_->isDefined();
+
 }
 
 Earth::Type Earth::getType() const

--- a/src/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth.cpp
@@ -257,7 +257,6 @@ bool Earth::isDefined() const
     }
 
     return implUPtr_->isDefined();
-
 }
 
 Earth::Type Earth::getType() const

--- a/src/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Earth.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Earth.cpp
@@ -195,8 +195,8 @@ Earth Earth::EGM2008(const Integer& aGravityModelDegree, const Integer& aGravity
         EarthGravitationalModel::Type::EGM2008,
         aGravityModelDegree,
         aGravityModelOrder,
-        EarthMagneticModel::Type::Dipole,
-        EarthAtmosphericModel::Type::Exponential,
+        EarthMagneticModel::Type::Undefined,
+        EarthAtmosphericModel::Type::Undefined,
         Instant::J2000()};
 }
 
@@ -217,8 +217,8 @@ Earth Earth::WGS84_EGM96(const Integer& aGravityModelDegree, const Integer& aGra
         EarthGravitationalModel::Type::EGM96,
         aGravityModelDegree,
         aGravityModelOrder,
-        EarthMagneticModel::Type::Dipole,
-        EarthAtmosphericModel::Type::Exponential,
+        EarthMagneticModel::Type::Undefined,
+        EarthAtmosphericModel::Type::Undefined,
         Instant::J2000()};
 }
 
@@ -239,8 +239,8 @@ Earth Earth::EGM96(const Integer& aGravityModelDegree, const Integer& aGravityMo
         EarthGravitationalModel::Type::EGM96,
         aGravityModelDegree,
         aGravityModelOrder,
-        EarthMagneticModel::Type::Dipole,
-        EarthAtmosphericModel::Type::Exponential,
+        EarthMagneticModel::Type::Undefined,
+        EarthAtmosphericModel::Type::Undefined,
         Instant::J2000()};
 }
 
@@ -261,8 +261,8 @@ Earth Earth::EGM84(const Integer& aGravityModelDegree, const Integer& aGravityMo
         EarthGravitationalModel::Type::EGM84,
         aGravityModelDegree,
         aGravityModelOrder,
-        EarthMagneticModel::Type::Dipole,
-        EarthAtmosphericModel::Type::Exponential,
+        EarthMagneticModel::Type::Undefined,
+        EarthAtmosphericModel::Type::Undefined,
         Instant::J2000()};
 }
 
@@ -283,8 +283,8 @@ Earth Earth::WGS84(const Integer& aGravityModelDegree, const Integer& aGravityMo
         EarthGravitationalModel::Type::WGS84,
         aGravityModelDegree,
         aGravityModelOrder,
-        EarthMagneticModel::Type::Dipole,
-        EarthAtmosphericModel::Type::Exponential,
+        EarthMagneticModel::Type::Undefined,
+        EarthAtmosphericModel::Type::Undefined,
         Instant::J2000()};
 }
 
@@ -303,8 +303,8 @@ Earth Earth::Spherical()
         Earth::Models::Spherical::J4,
         std::make_shared<Analytical>(earthFrameSPtr),
         EarthGravitationalModel::Type::Spherical,
-        EarthMagneticModel::Type::Dipole,
-        EarthAtmosphericModel::Type::Exponential,
+        EarthMagneticModel::Type::Undefined,
+        EarthAtmosphericModel::Type::Undefined,
         Instant::J2000()};
 }
 

--- a/test/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.test.cpp
@@ -79,6 +79,17 @@ TEST(OpenSpaceToolkit_Physics_Environment_Atmospheric_Earth, GetType)
     }
 }
 
+TEST(OpenSpaceToolkit_Physics_Environment_Atmospheric_Earth, IsDefined)
+{
+    using EarthAtmosphericModel = ostk::physics::environment::atmospheric::Earth;
+
+    {
+        EXPECT_FALSE(EarthAtmosphericModel(EarthAtmosphericModel::Type::Undefined).isDefined());
+        
+        EXPECT_TRUE(EarthAtmosphericModel(EarthAtmosphericModel::Type::Exponential).isDefined());
+    }
+}
+
 TEST(OpenSpaceToolkit_Physics_Environment_Atmospheric_Earth, GetDensityAt_Position)
 {
     using ostk::core::types::Real;

--- a/test/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.test.cpp
@@ -85,7 +85,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Atmospheric_Earth, IsDefined)
 
     {
         EXPECT_FALSE(EarthAtmosphericModel(EarthAtmosphericModel::Type::Undefined).isDefined());
-        
+
         EXPECT_TRUE(EarthAtmosphericModel(EarthAtmosphericModel::Type::Exponential).isDefined());
     }
 }

--- a/test/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/Exponential.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/Exponential.test.cpp
@@ -30,6 +30,17 @@ TEST(OpenSpaceToolkit_Physics_Environment_Atmospheric_Earth_Exponential, Clone)
     }
 }
 
+TEST(OpenSpaceToolkit_Physics_Environment_Atmospheric_Earth_Exponential, IsDefined)
+{
+    using ostk::physics::environment::atmospheric::earth::Exponential;
+
+    {
+        const Exponential exponential = {};
+
+        EXPECT_TRUE(exponential.isDefined());
+    }
+}
+
 TEST(OpenSpaceToolkit_Physics_Environment_Atmospheric_Earth_Exponential, getDensityAt)
 {
     using ostk::core::types::String;

--- a/test/OpenSpaceToolkit/Physics/Environment/Magnetic/Dipole.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Magnetic/Dipole.test.cpp
@@ -39,6 +39,21 @@ TEST(OpenSpaceToolkit_Physics_Environment_Magnetic_Dipole, Clone)
     }
 }
 
+TEST(OpenSpaceToolkit_Physics_Environment_Magnetic_Dipole, IsDefined)
+{
+    using ostk::math::obj::Vector3d;
+
+    using ostk::physics::environment::magnetic::Dipole;
+
+    {
+        const Vector3d magneticMoment = {0.0, 0.0, 1.0};
+
+        const Dipole dipole = {magneticMoment};
+
+        EXPECT_TRUE(dipole.isDefined());
+    }
+}
+
 TEST(OpenSpaceToolkit_Physics_Environment_Magnetic_Dipole, GetFieldValueAt)
 {
     using ostk::math::obj::Vector3d;

--- a/test/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth.test.cpp
@@ -164,6 +164,34 @@ TEST(OpenSpaceToolkit_Physics_Environment_Magnetic_Earth, GetType)
     }
 }
 
+TEST(OpenSpaceToolkit_Physics_Environment_Magnetic_Earth, IsDefined)
+{
+    using ostk::core::fs::Path;
+    using ostk::core::fs::Directory;
+
+    using EarthMagneticModel = ostk::physics::environment::magnetic::Earth;
+    using EarthMagneticModelManager = ostk::physics::environment::magnetic::earth::Manager;
+
+    {
+        EarthMagneticModelManager::Get().setLocalRepository(
+            Directory::Path(Path::Parse("/app/test/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth"))
+        );
+
+        EarthMagneticModelManager::Get().enable();
+
+        EXPECT_FALSE(EarthMagneticModel(EarthMagneticModel::Type::Undefined).isDefined());
+        EXPECT_FALSE(EarthMagneticModel(EarthMagneticModel::Type::Dipole).isDefined());
+
+        EXPECT_TRUE(EarthMagneticModel(EarthMagneticModel::Type::EMM2010).isDefined());
+        EXPECT_TRUE(EarthMagneticModel(EarthMagneticModel::Type::EMM2015).isDefined());
+        EXPECT_TRUE(EarthMagneticModel(EarthMagneticModel::Type::EMM2017).isDefined());
+        EXPECT_TRUE(EarthMagneticModel(EarthMagneticModel::Type::IGRF11).isDefined());
+        EXPECT_TRUE(EarthMagneticModel(EarthMagneticModel::Type::IGRF12).isDefined());
+        EXPECT_TRUE(EarthMagneticModel(EarthMagneticModel::Type::WMM2010).isDefined());
+        EXPECT_TRUE(EarthMagneticModel(EarthMagneticModel::Type::WMM2015).isDefined()); 
+    }
+}
+
 TEST(OpenSpaceToolkit_Physics_Environment_Magnetic_Earth, GetFieldValueAt)
 {
     using ostk::core::types::Real;

--- a/test/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth.test.cpp
@@ -188,7 +188,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Magnetic_Earth, IsDefined)
         EXPECT_TRUE(EarthMagneticModel(EarthMagneticModel::Type::IGRF11).isDefined());
         EXPECT_TRUE(EarthMagneticModel(EarthMagneticModel::Type::IGRF12).isDefined());
         EXPECT_TRUE(EarthMagneticModel(EarthMagneticModel::Type::WMM2010).isDefined());
-        EXPECT_TRUE(EarthMagneticModel(EarthMagneticModel::Type::WMM2015).isDefined()); 
+        EXPECT_TRUE(EarthMagneticModel(EarthMagneticModel::Type::WMM2015).isDefined());
     }
 }
 

--- a/test/OpenSpaceToolkit/Physics/Environment/Objects/Celestial.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Objects/Celestial.test.cpp
@@ -133,7 +133,8 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, accessModel)
             nullptr,
             nullptr,
             nullptr,
-            instant};
+            instant
+        };
 
         EXPECT_EQ(celestial.accessGravitationalModel(), nullptr);
         EXPECT_EQ(celestial.accessMagneticModel(), nullptr);

--- a/test/OpenSpaceToolkit/Physics/Environment/Objects/Celestial.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Objects/Celestial.test.cpp
@@ -133,8 +133,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, accessModel)
             nullptr,
             nullptr,
             nullptr,
-            instant
-        };
+            instant};
 
         EXPECT_EQ(celestial.accessGravitationalModel(), nullptr);
         EXPECT_EQ(celestial.accessMagneticModel(), nullptr);

--- a/test/OpenSpaceToolkit/Physics/Environment/Objects/Celestial.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Objects/Celestial.test.cpp
@@ -130,6 +130,41 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, accessModel)
             j2,
             j4,
             ephemeris,
+            nullptr,
+            nullptr,
+            nullptr,
+            instant};
+
+        EXPECT_EQ(celestial.accessGravitationalModel(), nullptr);
+        EXPECT_EQ(celestial.accessMagneticModel(), nullptr);
+        EXPECT_EQ(celestial.accessAtmosphericModel(), nullptr);
+    }
+
+    {
+        const String name = "Some Planet";
+        const Celestial::Type type = Celestial::Type::Earth;
+        const Derived gravitationalParameter = {
+            1.0, Derived::Unit::GravitationalParameter(Length::Unit::Meter, Time::Unit::Second)};
+        const Length equatorialRadius = Length::Kilometers(1000.0);
+        const Real flattening = 0.0;
+        const Real j2 = 0.0;
+        const Real j4 = 0.0;
+
+        const Shared<Ephemeris> ephemeris = std::make_shared<Analytical>(Frame::ITRF());
+        const Shared<GravitationalModel> gravitationalModel = std::make_shared<Spherical>(gravitationalParameter);
+        const Shared<MagneticModel> magneticModel = std::make_shared<Dipole>(Vector3d {0.0, 0.0, 1.0});
+        const Shared<AtmosphericModel> atmosphericModel = std::make_shared<Exponential>();
+        const Instant instant = Instant::J2000();
+
+        const Celestial celestial = {
+            name,
+            type,
+            gravitationalParameter,
+            equatorialRadius,
+            flattening,
+            j2,
+            j4,
+            ephemeris,
             gravitationalModel,
             magneticModel,
             atmosphericModel,

--- a/test/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Earth.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Earth.test.cpp
@@ -191,7 +191,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_CelestialBodies_Earth, StaticM
 
     EXPECT_NO_THROW(Earth::Default());
 
-    Earth earth = Earth::Default();
+    const Earth earth = Earth::Default();
 
     EXPECT_FALSE(earth.accessAtmosphericModel()->isDefined());
     EXPECT_FALSE(earth.accessMagneticModel()->isDefined());
@@ -214,7 +214,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_CelestialBodies_Earth, EGM96)
     EXPECT_NO_THROW(Earth::EGM96(360, 360));
     EXPECT_ANY_THROW(Earth::EGM96(3000, 3000));
 
-    Earth earth = Earth::EGM96();
+    const Earth earth = Earth::EGM96();
 
     EXPECT_FALSE(earth.accessAtmosphericModel()->isDefined());
     EXPECT_FALSE(earth.accessMagneticModel()->isDefined());
@@ -228,7 +228,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_CelestialBodies_Earth, EGM84)
     EXPECT_NO_THROW(Earth::EGM84(180, 180));
     EXPECT_ANY_THROW(Earth::EGM84(3000, 3000));
 
-    Earth earth = Earth::EGM84();
+    const Earth earth = Earth::EGM84();
 
     EXPECT_FALSE(earth.accessAtmosphericModel()->isDefined());
     EXPECT_FALSE(earth.accessMagneticModel()->isDefined());
@@ -242,7 +242,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_CelestialBodies_Earth, WGS84_E
     EXPECT_NO_THROW(Earth::WGS84_EGM96(360, 360));
     EXPECT_ANY_THROW(Earth::WGS84_EGM96(3000, 3000));
 
-    Earth earth = Earth::WGS84_EGM96();
+    const Earth earth = Earth::WGS84_EGM96();
 
     EXPECT_FALSE(earth.accessAtmosphericModel()->isDefined());
     EXPECT_FALSE(earth.accessMagneticModel()->isDefined());
@@ -256,7 +256,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_CelestialBodies_Earth, WGS84)
     EXPECT_NO_THROW(Earth::WGS84(20, 0));
     EXPECT_ANY_THROW(Earth::WGS84(3000, 3000));
 
-    Earth earth = Earth::WGS84();
+    const Earth earth = Earth::WGS84();
 
     EXPECT_FALSE(earth.accessAtmosphericModel()->isDefined());
     EXPECT_FALSE(earth.accessMagneticModel()->isDefined());
@@ -266,7 +266,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_CelestialBodies_Earth, Spheric
 {
     using ostk::physics::env::obj::celest::Earth;
 
-    Earth earth = Earth::Spherical();
+    const Earth earth = Earth::Spherical();
     EXPECT_TRUE(earth.isDefined());
 
     EXPECT_FALSE(earth.accessAtmosphericModel()->isDefined());

--- a/test/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Earth.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Earth.test.cpp
@@ -21,6 +21,7 @@
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Spherical/LLA.hpp>
 #include <OpenSpaceToolkit/Physics/Environment.hpp>
+#include <OpenSpaceToolkit/Physics/Environment/Atmospheric/Model.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Earth.hpp>
 #include <OpenSpaceToolkit/Physics/Time/DateTime.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Duration.hpp>
@@ -189,6 +190,11 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_CelestialBodies_Earth, StaticM
     using ostk::physics::env::obj::celest::Earth;
 
     EXPECT_NO_THROW(Earth::Default());
+
+    Earth earth = Earth::Default();
+
+    EXPECT_FALSE(earth.accessAtmosphericModel()->isDefined());
+    EXPECT_FALSE(earth.accessMagneticModel()->isDefined());
 }
 
 TEST(OpenSpaceToolkit_Physics_Environment_Objects_CelestialBodies_Earth, EGM2008)
@@ -207,6 +213,11 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_CelestialBodies_Earth, EGM96)
     EXPECT_NO_THROW(Earth::EGM96());
     EXPECT_NO_THROW(Earth::EGM96(360, 360));
     EXPECT_ANY_THROW(Earth::EGM96(3000, 3000));
+
+    Earth earth = Earth::EGM96();
+
+    EXPECT_FALSE(earth.accessAtmosphericModel()->isDefined());
+    EXPECT_FALSE(earth.accessMagneticModel()->isDefined());
 }
 
 TEST(OpenSpaceToolkit_Physics_Environment_Objects_CelestialBodies_Earth, EGM84)
@@ -216,6 +227,11 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_CelestialBodies_Earth, EGM84)
     EXPECT_NO_THROW(Earth::EGM84());
     EXPECT_NO_THROW(Earth::EGM84(180, 180));
     EXPECT_ANY_THROW(Earth::EGM84(3000, 3000));
+
+    Earth earth = Earth::EGM84();
+
+    EXPECT_FALSE(earth.accessAtmosphericModel()->isDefined());
+    EXPECT_FALSE(earth.accessMagneticModel()->isDefined());
 }
 
 TEST(OpenSpaceToolkit_Physics_Environment_Objects_CelestialBodies_Earth, WGS84_EGM96)
@@ -225,6 +241,11 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_CelestialBodies_Earth, WGS84_E
     EXPECT_NO_THROW(Earth::WGS84_EGM96());
     EXPECT_NO_THROW(Earth::WGS84_EGM96(360, 360));
     EXPECT_ANY_THROW(Earth::WGS84_EGM96(3000, 3000));
+
+    Earth earth = Earth::WGS84_EGM96();
+
+    EXPECT_FALSE(earth.accessAtmosphericModel()->isDefined());
+    EXPECT_FALSE(earth.accessMagneticModel()->isDefined());
 }
 
 TEST(OpenSpaceToolkit_Physics_Environment_Objects_CelestialBodies_Earth, WGS84)
@@ -234,6 +255,11 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_CelestialBodies_Earth, WGS84)
     EXPECT_NO_THROW(Earth::WGS84());
     EXPECT_NO_THROW(Earth::WGS84(20, 0));
     EXPECT_ANY_THROW(Earth::WGS84(3000, 3000));
+
+    Earth earth = Earth::WGS84();
+
+    EXPECT_FALSE(earth.accessAtmosphericModel()->isDefined());
+    EXPECT_FALSE(earth.accessMagneticModel()->isDefined());
 }
 
 TEST(OpenSpaceToolkit_Physics_Environment_Objects_CelestialBodies_Earth, Spherical)
@@ -242,4 +268,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_CelestialBodies_Earth, Spheric
 
     Earth earth = Earth::Spherical();
     EXPECT_TRUE(earth.isDefined());
+
+    EXPECT_FALSE(earth.accessAtmosphericModel()->isDefined());
+    EXPECT_FALSE(earth.accessMagneticModel()->isDefined());
 }


### PR DESCRIPTION
Removes Earth Atmospheric & Magnetic models from the Earth celestial body factory functions, such as `Earth::WGS84()`

In order to properly be able to define an `Undefined` type for Magnetic & Atmospheric models (so that we don't break the current constructors, which ingest a `type`), this defines a high level `isDefined()` function for each `Model`.

Constructing a model with type `Undefined` will result in the implementation pointer being set to `nullptr`. `isDefined()` for each model knows to interpret it that way.

Atmospheric & Magnetic models embed the actual model code a bit differently (something that is probably worth aligning), so the respective `isDefined()` functions look in slightly different places. 


This means that to check if the Earth in our environment has an atmospheric model, the syntax will look like:
`earth.accessAtmosphericModel()->isDefined()`
