### PR TITLE
refactor: remove instant from object/celestial classes

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Object.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Object.cpp
@@ -25,18 +25,14 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Object(pybind11::module& aModu
         .def("is_defined", &Object::isDefined)
 
         // .def("access_name", &Object::accessName, return_value_policy<reference_existing_object>())
-        // .def("access_instant", &Object::accessInstant, return_value_policy<reference_existing_object>())
         .def("access_name", &Object::accessName, return_value_policy::reference)
-        .def("access_instant", &Object::accessInstant, return_value_policy::reference)
         .def("access_frame", &Object::accessFrame)
         .def("get_name", &Object::getName)
-        .def("get_instant", &Object::getInstant)
         .def("get_geometry", &Object::getGeometry)
         .def("get_position_in", &Object::getPositionIn)
         .def("get_transform_to", &Object::getTransformTo)
         .def("get_axes_in", &Object::getAxesIn)
         .def("get_geometry_in", &Object::getGeometryIn)
-        .def("set_instant", &Object::setInstant)
 
         ;
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Objects/Celestial.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Objects/Celestial.cpp
@@ -23,34 +23,59 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Objects_Celestial(pybind11::mo
     class_<Celestial, Shared<Celestial>, Object> celestial_class(aModule, "Celestial");
 
     celestial_class
-        .def(init<
-             const String&,
-             const Celestial::Type&,
-             const Derived&,
-             const Length&,
-             const Real&,
-             const Real&,
-             const Real&,
-             const Shared<Ephemeris>&,
-             const Shared<GravitationalModel>&,
-             const Shared<MagneticModel>&,
-             const Shared<AtmosphericModel>&,
-             const Instant&>())
+        .def(
+            init<
+                const String&,
+                const Celestial::Type&,
+                const Derived&,
+                const Length&,
+                const Real&,
+                const Real&,
+                const Real&,
+                const Shared<Ephemeris>&,
+                const Shared<GravitationalModel>&,
+                const Shared<MagneticModel>&,
+                const Shared<AtmosphericModel>&>(),
+            arg("name"),
+            arg("type"),
+            arg("gravitational_parameter"),
+            arg("equatorial_radius"),
+            arg("flattening"),
+            arg("J2_parameter_value"),
+            arg("J4_parameter_value"),
+            arg("ephemeris"),
+            arg("gravitational_model"),
+            arg("magnetic_model"),
+            arg("atmospheric_model")
+        )
 
-        .def(init<
-             const String&,
-             const Celestial::Type&,
-             const Derived&,
-             const Length&,
-             const Real&,
-             const Real&,
-             const Real&,
-             const Shared<Ephemeris>&,
-             const Shared<GravitationalModel>&,
-             const Shared<MagneticModel>&,
-             const Shared<AtmosphericModel>&,
-             const Instant&,
-             const Object::Geometry&>())
+        .def(
+            init<
+                const String&,
+                const Celestial::Type&,
+                const Derived&,
+                const Length&,
+                const Real&,
+                const Real&,
+                const Real&,
+                const Shared<Ephemeris>&,
+                const Shared<GravitationalModel>&,
+                const Shared<MagneticModel>&,
+                const Shared<AtmosphericModel>&,
+                const Object::Geometry&>(),
+            arg("name"),
+            arg("type"),
+            arg("gravitational_parameter"),
+            arg("equatorial_radius"),
+            arg("flattening"),
+            arg("J2_parameter_value"),
+            arg("J4_parameter_value"),
+            arg("ephemeris"),
+            arg("gravitational_model"),
+            arg("magnetic_model"),
+            arg("atmospheric_model"),
+            arg("geometry")
+        )
 
         // Need to create corresponding operators in C++ source code for proper use of binding code below
         // .def(self == self)
@@ -75,17 +100,17 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Objects_Celestial(pybind11::mo
         .def("get_j2", &Celestial::getJ2)
         .def("get_j4", &Celestial::getJ4)
         // .def("access_frame", &Celestial::accessFrame)
-        .def("get_position_in", &Celestial::getPositionIn)
-        .def("get_transform_to", &Celestial::getTransformTo)
-        .def("get_axes_in", &Celestial::getAxesIn)
-        .def("get_gravitational_field_at", &Celestial::getGravitationalFieldAt)
-        .def("get_magnetic_field_at", &Celestial::getMagneticFieldAt)
-        .def("get_atmospheric_density_at", &Celestial::getAtmosphericDensityAt)
-        .def("get_frame_at", &Celestial::getFrameAt)
+        .def("get_position_in", &Celestial::getPositionIn, arg("frame"), arg("instant"))
+        .def("get_transform_to", &Celestial::getTransformTo, arg("frame"), arg("instant"))
+        .def("get_axes_in", &Celestial::getAxesIn, arg("frame"), arg("instant"))
+        .def("get_gravitational_field_at", &Celestial::getGravitationalFieldAt, arg("position"), arg("instant"))
+        .def("get_magnetic_field_at", &Celestial::getMagneticFieldAt, arg("position"), arg("instant"))
+        .def("get_atmospheric_density_at", &Celestial::getAtmosphericDensityAt, arg("position"), arg("instant"))
+        .def("get_frame_at", &Celestial::getFrameAt, arg("lla"), arg("frame_type"))
 
         .def_static("undefined", &Celestial::Undefined)
 
-        .def_static("string_from_frame_type", &Celestial::StringFromFrameType)
+        .def_static("string_from_frame_type", &Celestial::StringFromFrameType, arg("frame_type"))
 
         ;
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Objects/CelestialBodies/Earth.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Objects/CelestialBodies/Earth.cpp
@@ -33,8 +33,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Objects_CelestialBodies_Earth(
                     const Shared<Ephemeris>&,
                     const EarthGravitationalModel::Type&,
                     const EarthMagneticModel::Type&,
-                    const EarthAtmosphericModel::Type&,
-                    const Instant&>(),
+                    const EarthAtmosphericModel::Type&>(),
                 arg("gravitational_parameter"),
                 arg("equatorial_radius"),
                 arg("flattening"),
@@ -43,8 +42,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Objects_CelestialBodies_Earth(
                 arg("ephemeris"),
                 arg("gravitational_model_type"),
                 arg("magnetic_model_type"),
-                arg("atmospheric_model_type"),
-                arg("instant")
+                arg("atmospheric_model_type")
             )
 
             .def(
@@ -59,8 +57,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Objects_CelestialBodies_Earth(
                     const Integer&,
                     const Integer&,
                     const EarthMagneticModel::Type&,
-                    const EarthAtmosphericModel::Type&,
-                    const Instant&>(),
+                    const EarthAtmosphericModel::Type&>(),
                 arg("gravitational_parameter"),
                 arg("equatorial_radius"),
                 arg("flattening"),
@@ -71,8 +68,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Objects_CelestialBodies_Earth(
                 arg("gravitational_model_degree"),
                 arg("gravitational_model_order"),
                 arg("magnetic_model_type"),
-                arg("atmospheric_model_type"),
-                arg("instant")
+                arg("atmospheric_model_type")
             )
 
             .def_readonly_static("gravitational_parameter", &Earth::GravitationalParameter)

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Objects/CelestialBodies/Moon.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Objects/CelestialBodies/Moon.cpp
@@ -18,10 +18,9 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Objects_CelestialBodies_Moon(p
         class_<Moon, Shared<Moon>, Celestial>(aModule, "Moon")
 
             .def(
-                init<const Shared<Ephemeris>&, const MoonGravitationalModel::Type&, const Instant&>(),
+                init<const Shared<Ephemeris>&, const MoonGravitationalModel::Type&>(),
                 arg("ephemeris"),
-                arg("gravitational_model_type"),
-                arg("instant")
+                arg("gravitational_model_type")
             )
 
             .def_readonly_static("gravitational_parameter", &Moon::GravitationalParameter)

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Objects/CelestialBodies/Sun.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Objects/CelestialBodies/Sun.cpp
@@ -18,10 +18,9 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Objects_CelestialBodies_Sun(py
         class_<Sun, Shared<Sun>, Celestial>(aModule, "Sun")
 
             .def(
-                init<const Shared<Ephemeris>&, const SunGravitationalModel::Type&, const Instant&>(),
+                init<const Shared<Ephemeris>&, const SunGravitationalModel::Type&>(),
                 arg("ephemeris"),
-                arg("gravitational_model_type"),
-                arg("instant")
+                arg("gravitational_model_type")
             )
 
             .def_readonly_static("gravitational_parameter", &Sun::GravitationalParameter)

--- a/bindings/python/test/environment/atmospheric/test_earth.py
+++ b/bindings/python/test/environment/atmospheric/test_earth.py
@@ -39,13 +39,12 @@ class TestEarth:
 
     def test_get_type_success(self, earth_atmospheric_model: EarthAtmosphericModel):
         assert (
-            earth_atmospheric_model.get_type() == EarthAtmosphericModel.EarthAtmosphericType.Exponential
+            earth_atmospheric_model.get_type()
+            == EarthAtmosphericModel.EarthAtmosphericType.Exponential
         )
-    
+
     def test_is_defined_success(self, earth_atmospheric_model: EarthAtmosphericModel):
-        assert (
-            earth_atmospheric_model.is_defined() == True
-        )
+        assert earth_atmospheric_model.is_defined() == True
 
     def test_get_density_at_success(self, earth_atmospheric_model: EarthAtmosphericModel):
         latitude = Angle.degrees(30.0)

--- a/bindings/python/test/environment/magnetic/test_earth.py
+++ b/bindings/python/test/environment/magnetic/test_earth.py
@@ -33,11 +33,9 @@ class TestEarth:
 
     def test_get_type_success(self, earth_magnetic_model: EarthMagneticModel):
         assert (
-            earth_magnetic_model.get_type() == EarthMagneticModel.EarthMagneticType.EMM2010
-        )
-    
-    def test_is_defined_success(self, earth_magnetic_model: EarthMagneticModel):
-        assert (
-            earth_magnetic_model.is_defined() == True
+            earth_magnetic_model.get_type()
+            == EarthMagneticModel.EarthMagneticType.EMM2010
         )
 
+    def test_is_defined_success(self, earth_magnetic_model: EarthMagneticModel):
+        assert earth_magnetic_model.is_defined() == True

--- a/include/OpenSpaceToolkit/Physics/Environment.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment.hpp
@@ -167,8 +167,6 @@ class Environment
    private:
     Instant instant_;
     Array<Shared<Object>> objects_;
-
-    void updateObjects();
 };
 
 }  // namespace physics

--- a/include/OpenSpaceToolkit/Physics/Environment.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment.hpp
@@ -166,7 +166,7 @@ class Environment
 
    private:
     Instant instant_;
-    Array<Shared<Object>> objects_;
+    Array<Shared<const Object>> objects_;
 };
 
 }  // namespace physics

--- a/include/OpenSpaceToolkit/Physics/Environment/Object.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Object.hpp
@@ -40,9 +40,9 @@ class Object
    public:
     typedef object::Geometry Geometry;
 
-    Object(const String& aName, const Instant& anInstant);
+    Object(const String& aName);
 
-    Object(const String& aName, const Instant& anInstant, const Object::Geometry& aGeometry);
+    Object(const String& aName, const Object::Geometry& aGeometry);
 
     Object(const Object& anObject);
 
@@ -58,33 +58,26 @@ class Object
 
     const String& accessName() const;
 
-    const Instant& accessInstant() const;
-
     virtual Shared<const Frame> accessFrame() const = 0;
 
     const Object::Geometry& accessGeometry() const;
 
     String getName() const;
 
-    Instant getInstant() const;
-
     Object::Geometry getGeometry() const;
 
-    virtual Position getPositionIn(const Shared<const Frame>& aFrameSPtr) const = 0;
+    virtual Position getPositionIn(const Shared<const Frame>& aFrameSPtr, const Instant& anInstant) const = 0;
 
-    virtual Velocity getVelocityIn(const Shared<const Frame>& aFrameSPtr) const = 0;
+    virtual Velocity getVelocityIn(const Shared<const Frame>& aFrameSPtr, const Instant& anInstant) const = 0;
 
-    virtual Transform getTransformTo(const Shared<const Frame>& aFrameSPtr) const = 0;
+    virtual Transform getTransformTo(const Shared<const Frame>& aFrameSPtr, const Instant& anInstant) const = 0;
 
-    virtual Axes getAxesIn(const Shared<const Frame>& aFrameSPtr) const = 0;
+    virtual Axes getAxesIn(const Shared<const Frame>& aFrameSPtr, const Instant& anInstant) const = 0;
 
-    Object::Geometry getGeometryIn(const Shared<const Frame>& aFrameSPtr) const;
-
-    void setInstant(const Instant& anInstant);
+    Object::Geometry getGeometryIn(const Shared<const Frame>& aFrameSPtr, const Instant& anInstant) const;
 
    private:
     String name_;
-    Instant instant_;
 
     Object::Geometry geometry_;
 };

--- a/include/OpenSpaceToolkit/Physics/Environment/Objects/Celestial.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Objects/Celestial.hpp
@@ -104,8 +104,7 @@ class Celestial : public Object
         const Shared<Ephemeris>& anEphemeris,
         const Shared<GravitationalModel>& aGravitationalModel,
         const Shared<MagneticModel>& aMagneticModel,
-        const Shared<AtmosphericModel>& anAtmosphericModel,
-        const Instant& anInstant
+        const Shared<AtmosphericModel>& anAtmosphericModel
     );
 
     Celestial(
@@ -120,7 +119,6 @@ class Celestial : public Object
         const Shared<GravitationalModel>& aGravitationalModel,
         const Shared<MagneticModel>& aMagneticModel,
         const Shared<AtmosphericModel>& anAtmosphericModel,
-        const Instant& anInstant,
         const Object::Geometry& aGeometry
     );
 
@@ -152,19 +150,19 @@ class Celestial : public Object
 
     virtual Shared<const Frame> accessFrame() const override;
 
-    virtual Position getPositionIn(const Shared<const Frame>& aFrameSPtr) const override;
+    virtual Position getPositionIn(const Shared<const Frame>& aFrameSPtr, const Instant& anInstant) const override;
 
-    virtual Velocity getVelocityIn(const Shared<const Frame>& aFrameSPtr) const override;
+    virtual Velocity getVelocityIn(const Shared<const Frame>& aFrameSPtr, const Instant& anInstant) const override;
 
-    virtual Transform getTransformTo(const Shared<const Frame>& aFrameSPtr) const override;
+    virtual Transform getTransformTo(const Shared<const Frame>& aFrameSPtr, const Instant& anInstant) const override;
 
-    virtual Axes getAxesIn(const Shared<const Frame>& aFrameSPtr) const override;
+    virtual Axes getAxesIn(const Shared<const Frame>& aFrameSPtr, const Instant& anInstant) const override;
 
-    Vector getGravitationalFieldAt(const Position& aPosition) const;
+    Vector getGravitationalFieldAt(const Position& aPosition, const Instant& anInstant) const;
 
-    Vector getMagneticFieldAt(const Position& aPosition) const;
+    Vector getMagneticFieldAt(const Position& aPosition, const Instant& anInstant) const;
 
-    Scalar getAtmosphericDensityAt(const Position& aPosition) const;
+    Scalar getAtmosphericDensityAt(const Position& aPosition, const Instant& anInstant) const;
 
     Shared<const Frame> getFrameAt(const LLA& aLla, const Celestial::FrameType& aFrameType) const;
 

--- a/include/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Earth.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Earth.hpp
@@ -134,8 +134,7 @@ class Earth : public Celestial
         const Shared<Ephemeris>& anEphemeris,
         const EarthGravitationalModel::Type& aGravitationalModelType,
         const EarthMagneticModel::Type& aMagneticModelType,
-        const EarthAtmosphericModel::Type& aAtmosphericModelType,
-        const Instant& anInstant
+        const EarthAtmosphericModel::Type& aAtmosphericModelType
     );
 
     Earth(
@@ -149,8 +148,7 @@ class Earth : public Celestial
         const Integer& aGravityModelDegree,
         const Integer& aGravityModelOrder,
         const EarthMagneticModel::Type& aMagneticModelType,
-        const EarthAtmosphericModel::Type& aAtmosphericModelType,
-        const Instant& anInstant
+        const EarthAtmosphericModel::Type& aAtmosphericModelType
     );
 
     virtual ~Earth() override;

--- a/include/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Moon.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Moon.hpp
@@ -54,8 +54,7 @@ class Moon : public Celestial
 
     Moon(
         const Shared<Ephemeris>& anEphemeris,
-        const MoonGravitationalModel::Type& aGravitationalModelType,
-        const Instant& anInstant
+        const MoonGravitationalModel::Type& aGravitationalModelType
     );
 
     /// @brief              Destructor

--- a/include/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Moon.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Moon.hpp
@@ -52,10 +52,7 @@ class Moon : public Celestial
     /// (Spherical model only)
     /// @param              [in] anInstant An instant
 
-    Moon(
-        const Shared<Ephemeris>& anEphemeris,
-        const MoonGravitationalModel::Type& aGravitationalModelType
-    );
+    Moon(const Shared<Ephemeris>& anEphemeris, const MoonGravitationalModel::Type& aGravitationalModelType);
 
     /// @brief              Destructor
 

--- a/include/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Sun.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Sun.hpp
@@ -53,8 +53,7 @@ class Sun : public Celestial
     /// @param              [in] anInstant An instant
 
     Sun(const Shared<Ephemeris>& anEphemeris,
-        const SunGravitationalModel::Type& aGravitationalModelType,
-        const Instant& anInstant);
+        const SunGravitationalModel::Type& aGravitationalModelType);
 
     /// @brief              Destructor
 

--- a/include/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Sun.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Sun.hpp
@@ -52,8 +52,7 @@ class Sun : public Celestial
     /// (Spherical model only)
     /// @param              [in] anInstant An instant
 
-    Sun(const Shared<Ephemeris>& anEphemeris,
-        const SunGravitationalModel::Type& aGravitationalModelType);
+    Sun(const Shared<Ephemeris>& anEphemeris, const SunGravitationalModel::Type& aGravitationalModelType);
 
     /// @brief              Destructor
 

--- a/src/OpenSpaceToolkit/Physics/Environment.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment.cpp
@@ -16,25 +16,25 @@ namespace physics
 
 Environment::Environment(const Instant& anInstant, const Array<Shared<Object>>& anObjectArray)
     : instant_(anInstant),
-      objects_(Array<Shared<Object>>::Empty())
+      objects_(Array<Shared<const Object>>::Empty())
 {
     objects_.reserve(anObjectArray.getSize());
 
     for (const auto& objectSPtr : anObjectArray)
     {
-        objects_.add(Shared<Object>(objectSPtr->clone()));
+        objects_.add(Shared<const Object>(objectSPtr->clone()));
     }
 }
 
 Environment::Environment(const Environment& anEnvironment)
     : instant_(anEnvironment.instant_),
-      objects_(Array<Shared<Object>>::Empty())
+      objects_(Array<Shared<const Object>>::Empty())
 {
     objects_.reserve(anEnvironment.objects_.getSize());
 
     for (const auto& objectSPtr : anEnvironment.objects_)
     {
-        objects_.add(Shared<Object>(objectSPtr->clone()));
+        objects_.add(Shared<const Object>(objectSPtr->clone()));
     }
 }
 

--- a/src/OpenSpaceToolkit/Physics/Environment.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment.cpp
@@ -122,7 +122,7 @@ bool Environment::intersects(
     {
         if (!anObjectToIgnoreArray.contains(objectSPtr))
         {
-            if (objectSPtr->getGeometryIn(aGeometry.accessFrame()).intersects(aGeometry))
+            if (objectSPtr->getGeometryIn(aGeometry.accessFrame(), instant_).intersects(aGeometry))
             {
                 return true;
             }
@@ -233,8 +233,6 @@ void Environment::setInstant(const Instant& anInstant)
     }
 
     instant_ = anInstant;
-
-    this->updateObjects();
 }
 
 Environment Environment::Undefined()
@@ -256,14 +254,6 @@ Environment Environment::Default()
         std::make_shared<Moon>(Moon::Default())};
 
     return {instant, objects};
-}
-
-void Environment::updateObjects()
-{
-    for (auto& objectSPtr : objects_)
-    {
-        objectSPtr->setInstant(instant_);
-    }
 }
 
 }  // namespace physics

--- a/src/OpenSpaceToolkit/Physics/Environment/Object.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Object.cpp
@@ -12,23 +12,20 @@ namespace physics
 namespace env
 {
 
-Object::Object(const String& aName, const Instant& anInstant)
+Object::Object(const String& aName)
     : name_(aName),
-      instant_(anInstant),
       geometry_(Geometry::Undefined())
 {
 }
 
-Object::Object(const String& aName, const Instant& anInstant, const Object::Geometry& aGeometry)
+Object::Object(const String& aName, const Object::Geometry& aGeometry)
     : name_(aName),
-      instant_(anInstant),
       geometry_(aGeometry)
 {
 }
 
 Object::Object(const Object& anObject)
     : name_(anObject.name_),
-      instant_(anObject.instant_),
       geometry_(anObject.geometry_)
 {
 }
@@ -40,7 +37,6 @@ Object& Object::operator=(const Object& anObject)
     if (this != &anObject)
     {
         name_ = anObject.name_;
-        instant_ = anObject.instant_;
         geometry_ = anObject.geometry_;
     }
 
@@ -53,8 +49,6 @@ std::ostream& operator<<(std::ostream& anOutputStream, const Object& anObject)
 
     ostk::core::utils::Print::Line(anOutputStream)
         << "Name:" << (!anObject.name_.isEmpty() ? anObject.name_ : "Undefined");
-    ostk::core::utils::Print::Line(anOutputStream)
-        << "Instant:" << (anObject.instant_.isDefined() ? anObject.instant_.toString() : "Undefined");
 
     ostk::core::utils::Print::Footer(anOutputStream);
 
@@ -76,16 +70,6 @@ const String& Object::accessName() const
     return name_;
 }
 
-const Instant& Object::accessInstant() const
-{
-    if (!this->isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("Object");
-    }
-
-    return instant_;
-}
-
 const Object::Geometry& Object::accessGeometry() const
 {
     if (!this->isDefined())
@@ -101,34 +85,14 @@ String Object::getName() const
     return this->accessName();
 }
 
-Instant Object::getInstant() const
-{
-    return this->accessInstant();
-}
-
 Object::Geometry Object::getGeometry() const
 {
     return this->accessGeometry();
 }
 
-Object::Geometry Object::getGeometryIn(const Shared<const Frame>& aFrameSPtr) const
+Object::Geometry Object::getGeometryIn(const Shared<const Frame>& aFrameSPtr, const Instant& anInstant) const
 {
-    return this->accessGeometry().in(aFrameSPtr, instant_);
-}
-
-void Object::setInstant(const Instant& anInstant)
-{
-    if (!anInstant.isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("Instant");
-    }
-
-    if (!this->isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("Object");
-    }
-
-    instant_ = anInstant;
+    return this->accessGeometry().in(aFrameSPtr, anInstant);
 }
 
 }  // namespace env

--- a/src/OpenSpaceToolkit/Physics/Environment/Objects/Celestial.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Objects/Celestial.cpp
@@ -266,11 +266,9 @@ Vector Celestial::getGravitationalFieldAt(const Position& aPosition, const Insta
         throw ostk::core::error::runtime::Undefined("Gravitational model");
     }
 
-    const Vector3d positionInBodyFrame =
-        aPosition.inFrame(ephemeris_->accessFrame(), anInstant).getCoordinates();
+    const Vector3d positionInBodyFrame = aPosition.inFrame(ephemeris_->accessFrame(), anInstant).getCoordinates();
 
-    const Vector3d gravitationalFieldValue =
-        gravitationalModelSPtr_->getFieldValueAt(positionInBodyFrame, anInstant);
+    const Vector3d gravitationalFieldValue = gravitationalModelSPtr_->getFieldValueAt(positionInBodyFrame, anInstant);
 
     const static Unit gravitationalFieldUnit =
         Unit::Derived(Derived::Unit::Acceleration(Length::Unit::Meter, Time::Unit::Second));
@@ -298,8 +296,7 @@ Vector Celestial::getMagneticFieldAt(const Position& aPosition, const Instant& a
         throw ostk::core::error::runtime::Undefined("Magnetic model");
     }
 
-    const Vector3d positionInBodyFrame =
-        aPosition.inFrame(ephemeris_->accessFrame(), anInstant).getCoordinates();
+    const Vector3d positionInBodyFrame = aPosition.inFrame(ephemeris_->accessFrame(), anInstant).getCoordinates();
 
     const Vector3d magneticFieldValue = magneticModelSPtr_->getFieldValueAt(positionInBodyFrame, anInstant);
 

--- a/src/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Earth.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Earth.cpp
@@ -111,8 +111,7 @@ Earth::Earth(
     const Shared<Ephemeris>& anEphemeris,
     const EarthGravitationalModel::Type& aGravitationalModelType,
     const EarthMagneticModel::Type& aMagneticModelType,
-    const EarthAtmosphericModel::Type& anAtmosphericModelType,
-    const Instant& anInstant
+    const EarthAtmosphericModel::Type& anAtmosphericModelType
 )
     : Celestial(
           "Earth",
@@ -126,7 +125,6 @@ Earth::Earth(
           std::make_shared<EarthGravitationalModel>(aGravitationalModelType),
           std::make_shared<EarthMagneticModel>(aMagneticModelType),
           std::make_shared<EarthAtmosphericModel>(anAtmosphericModelType),
-          anInstant,
           Earth::Geometry(anEquatorialRadius, aFlattening, anEphemeris->accessFrame())
       )
 {
@@ -143,8 +141,7 @@ Earth::Earth(
     const Integer& aGravityModelDegree,
     const Integer& aGravityModelOrder,
     const EarthMagneticModel::Type& aMagneticModelType,
-    const EarthAtmosphericModel::Type& anAtmosphericModelType,
-    const Instant& anInstant
+    const EarthAtmosphericModel::Type& anAtmosphericModelType
 )
     : Celestial(
           "Earth",
@@ -160,7 +157,6 @@ Earth::Earth(
           ),
           std::make_shared<EarthMagneticModel>(aMagneticModelType),
           std::make_shared<EarthAtmosphericModel>(anAtmosphericModelType),
-          anInstant,
           Earth::Geometry(anEquatorialRadius, aFlattening, anEphemeris->accessFrame())
       )
 {
@@ -196,8 +192,7 @@ Earth Earth::EGM2008(const Integer& aGravityModelDegree, const Integer& aGravity
         aGravityModelDegree,
         aGravityModelOrder,
         EarthMagneticModel::Type::Undefined,
-        EarthAtmosphericModel::Type::Undefined,
-        Instant::J2000()};
+        EarthAtmosphericModel::Type::Undefined};
 }
 
 Earth Earth::WGS84_EGM96(const Integer& aGravityModelDegree, const Integer& aGravityModelOrder)
@@ -218,8 +213,7 @@ Earth Earth::WGS84_EGM96(const Integer& aGravityModelDegree, const Integer& aGra
         aGravityModelDegree,
         aGravityModelOrder,
         EarthMagneticModel::Type::Undefined,
-        EarthAtmosphericModel::Type::Undefined,
-        Instant::J2000()};
+        EarthAtmosphericModel::Type::Undefined};
 }
 
 Earth Earth::EGM96(const Integer& aGravityModelDegree, const Integer& aGravityModelOrder)
@@ -240,8 +234,7 @@ Earth Earth::EGM96(const Integer& aGravityModelDegree, const Integer& aGravityMo
         aGravityModelDegree,
         aGravityModelOrder,
         EarthMagneticModel::Type::Undefined,
-        EarthAtmosphericModel::Type::Undefined,
-        Instant::J2000()};
+        EarthAtmosphericModel::Type::Undefined};
 }
 
 Earth Earth::EGM84(const Integer& aGravityModelDegree, const Integer& aGravityModelOrder)
@@ -262,8 +255,7 @@ Earth Earth::EGM84(const Integer& aGravityModelDegree, const Integer& aGravityMo
         aGravityModelDegree,
         aGravityModelOrder,
         EarthMagneticModel::Type::Undefined,
-        EarthAtmosphericModel::Type::Undefined,
-        Instant::J2000()};
+        EarthAtmosphericModel::Type::Undefined};
 }
 
 Earth Earth::WGS84(const Integer& aGravityModelDegree, const Integer& aGravityModelOrder)
@@ -284,8 +276,7 @@ Earth Earth::WGS84(const Integer& aGravityModelDegree, const Integer& aGravityMo
         aGravityModelDegree,
         aGravityModelOrder,
         EarthMagneticModel::Type::Undefined,
-        EarthAtmosphericModel::Type::Undefined,
-        Instant::J2000()};
+        EarthAtmosphericModel::Type::Undefined};
 }
 
 Earth Earth::Spherical()
@@ -304,8 +295,7 @@ Earth Earth::Spherical()
         std::make_shared<Analytical>(earthFrameSPtr),
         EarthGravitationalModel::Type::Spherical,
         EarthMagneticModel::Type::Undefined,
-        EarthAtmosphericModel::Type::Undefined,
-        Instant::J2000()};
+        EarthAtmosphericModel::Type::Undefined};
 }
 
 Object::Geometry Earth::Geometry(

--- a/src/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Moon.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Moon.cpp
@@ -28,10 +28,7 @@ Derived Moon::GravitationalParameter = {
 Length Moon::EquatorialRadius = Length::Meters(1738.14e3);
 Real Moon::Flattening = 0.00125;
 
-Moon::Moon(
-    const Shared<Ephemeris>& anEphemeris,
-    const MoonGravitationalModel::Type& aGravitationalModelType
-)
+Moon::Moon(const Shared<Ephemeris>& anEphemeris, const MoonGravitationalModel::Type& aGravitationalModelType)
     : Celestial(
           "Moon",
           Celestial::Type::Moon,

--- a/src/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Moon.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Moon.cpp
@@ -30,8 +30,7 @@ Real Moon::Flattening = 0.00125;
 
 Moon::Moon(
     const Shared<Ephemeris>& anEphemeris,
-    const MoonGravitationalModel::Type& aGravitationalModelType,
-    const Instant& anInstant
+    const MoonGravitationalModel::Type& aGravitationalModelType
 )
     : Celestial(
           "Moon",
@@ -45,7 +44,6 @@ Moon::Moon(
           std::make_shared<MoonGravitationalModel>(aGravitationalModelType),
           nullptr,
           nullptr,
-          anInstant,
           Moon::Geometry(anEphemeris->accessFrame())
       )
 {
@@ -67,7 +65,7 @@ Moon Moon::Spherical()
 {
     using ostk::physics::env::ephem::SPICE;
 
-    return {std::make_shared<SPICE>(SPICE::Object::Moon), MoonGravitationalModel::Type::Spherical, Instant::J2000()};
+    return {std::make_shared<SPICE>(SPICE::Object::Moon), MoonGravitationalModel::Type::Spherical};
 }
 
 Object::Geometry Moon::Geometry(const Shared<const Frame>& aFrame)

--- a/src/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Sun.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Sun.cpp
@@ -30,8 +30,7 @@ Real Sun::Flattening = 0.0;
 
 Sun::Sun(
     const Shared<Ephemeris>& anEphemeris,
-    const SunGravitationalModel::Type& aGravitationalModelType,
-    const Instant& anInstant
+    const SunGravitationalModel::Type& aGravitationalModelType
 )
     : Celestial(
           "Sun",
@@ -45,7 +44,6 @@ Sun::Sun(
           std::make_shared<SunGravitationalModel>(aGravitationalModelType),
           nullptr,  // [TBI] Add Sun magnetic model
           nullptr,
-          anInstant,
           Sun::Geometry(anEphemeris->accessFrame())
       )
 {
@@ -67,7 +65,7 @@ Sun Sun::Spherical()
 {
     using ostk::physics::env::ephem::SPICE;
 
-    return {std::make_shared<SPICE>(SPICE::Object::Sun), SunGravitationalModel::Type::Spherical, Instant::J2000()};
+    return {std::make_shared<SPICE>(SPICE::Object::Sun), SunGravitationalModel::Type::Spherical};
 }
 
 Object::Geometry Sun::Geometry(const Shared<const Frame>& aFrame)

--- a/src/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Sun.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Objects/CelestialBodies/Sun.cpp
@@ -28,10 +28,7 @@ Derived Sun::GravitationalParameter = {
 Length Sun::EquatorialRadius = Length::Meters(6.955e8);
 Real Sun::Flattening = 0.0;
 
-Sun::Sun(
-    const Shared<Ephemeris>& anEphemeris,
-    const SunGravitationalModel::Type& aGravitationalModelType
-)
+Sun::Sun(const Shared<Ephemeris>& anEphemeris, const SunGravitationalModel::Type& aGravitationalModelType)
     : Celestial(
           "Sun",
           Celestial::Type::Sun,

--- a/src/OpenSpaceToolkit/Physics/Environment/Utilities/Eclipse.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Utilities/Eclipse.cpp
@@ -45,7 +45,7 @@ bool isPositionInEclipse(const Position& aPosition, const Environment& anEnviron
 
     const Segment sunToObjectSegment_GCRF = {
         Point::Vector(aPosition.getCoordinates()),
-        Point::Vector(sunSPtr->getPositionIn(Frame::GCRF()).getCoordinates())};
+        Point::Vector(sunSPtr->getPositionIn(Frame::GCRF(), anEnvironment.getInstant()).getCoordinates())};
 
     const Object::Geometry sunToObjectGeometry = {sunToObjectSegment_GCRF, Frame::GCRF()};
 

--- a/test/OpenSpaceToolkit/Physics/Environment.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment.test.cpp
@@ -289,41 +289,41 @@ TEST_F(OpenSpaceToolkit_Physics_Environment, Test_1)
 
         // Earth
 
-        const Transform earthFrameTransform = earthSPtr->getTransformTo(Frame::GCRF());
+        const Transform earthFrameTransform = earthSPtr->getTransformTo(Frame::GCRF(), instant);
 
         EXPECT_TRUE(earthFrameTransform.isDefined());
 
-        const Position earthPosition = earthSPtr->getPositionIn(Frame::GCRF());
-        const Velocity earthVelocity = earthSPtr->getVelocityIn(Frame::GCRF());
+        const Position earthPosition = earthSPtr->getPositionIn(Frame::GCRF(), instant);
+        const Velocity earthVelocity = earthSPtr->getVelocityIn(Frame::GCRF(), instant);
 
         EXPECT_TRUE(earthPosition.isDefined());
         EXPECT_TRUE(earthVelocity.isDefined());
 
-        const Quaternion earthOrientation = earthSPtr->getTransformTo(Frame::GCRF()).getOrientation();
+        const Quaternion earthOrientation = earthSPtr->getTransformTo(Frame::GCRF(), instant).getOrientation();
 
         EXPECT_TRUE(earthOrientation.isDefined());
 
-        const Axes earthAxes = earthSPtr->getAxesIn(Frame::GCRF());
+        const Axes earthAxes = earthSPtr->getAxesIn(Frame::GCRF(), instant);
 
         EXPECT_TRUE(earthAxes.isDefined());
 
         // Moon
 
-        const Transform moonFrameTransform = moonSPtr->getTransformTo(Frame::GCRF());
+        const Transform moonFrameTransform = moonSPtr->getTransformTo(Frame::GCRF(), instant);
 
         EXPECT_TRUE(moonFrameTransform.isDefined());
 
-        const Position moonPosition = moonSPtr->getPositionIn(Frame::GCRF());
-        const Velocity moonVelocity = moonSPtr->getVelocityIn(Frame::GCRF());
+        const Position moonPosition = moonSPtr->getPositionIn(Frame::GCRF(), instant);
+        const Velocity moonVelocity = moonSPtr->getVelocityIn(Frame::GCRF(), instant);
 
         EXPECT_TRUE(moonPosition.isDefined());
         EXPECT_TRUE(moonVelocity.isDefined());
 
-        const Quaternion moonOrientation = moonSPtr->getTransformTo(Frame::GCRF()).getOrientation();
+        const Quaternion moonOrientation = moonSPtr->getTransformTo(Frame::GCRF(), instant).getOrientation();
 
         EXPECT_TRUE(moonOrientation.isDefined());
 
-        const Axes moonAxes = moonSPtr->getAxesIn(Frame::GCRF());
+        const Axes moonAxes = moonSPtr->getAxesIn(Frame::GCRF(), instant);
 
         EXPECT_TRUE(moonAxes.isDefined());
     }
@@ -342,7 +342,7 @@ TEST_F(OpenSpaceToolkit_Physics_Environment, Test_2)
     const Shared<const Earth> earthSPtr =
         std::dynamic_pointer_cast<const Earth>(environment.accessObjectWithName("Earth"));
 
-    const Object::Geometry earthGeometry = earthSPtr->getGeometryIn(Frame::ITRF());
+    const Object::Geometry earthGeometry = earthSPtr->getGeometryIn(Frame::ITRF(), startInstant);
 
     const Ellipsoid& ellipsoid = earthGeometry.accessComposite().as<Ellipsoid>();
 

--- a/test/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth.test.cpp
@@ -169,12 +169,6 @@ TEST(OpenSpaceToolkit_Physics_Environment_Magnetic_Earth, GetType)
 
 TEST(OpenSpaceToolkit_Physics_Environment_Magnetic_Earth, IsDefined)
 {
-    using ostk::core::fs::Path;
-    using ostk::core::fs::Directory;
-
-    using EarthMagneticModel = ostk::physics::environment::magnetic::Earth;
-    using EarthMagneticModelManager = ostk::physics::environment::magnetic::earth::Manager;
-
     {
         EarthMagneticModelManager::Get().setLocalRepository(
             Directory::Path(Path::Parse("/app/test/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth"))

--- a/test/OpenSpaceToolkit/Physics/Environment/Object/Geometry.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Object/Geometry.test.cpp
@@ -364,7 +364,7 @@ TEST_F(OpenSpaceToolkit_Physics_Environment_Object_Geometry, IntersectionWith)
 
         const Geometry observerGeometry_ITRF = observerGeometry_NED.in(itrfFrameSPtr, instant);
 
-        const Geometry earthGeometry_ITRF = earthSPtr->getGeometryIn(itrfFrameSPtr);
+        const Geometry earthGeometry_ITRF = earthSPtr->getGeometryIn(itrfFrameSPtr, instant);
 
         const Geometry intersectionGeometry_ITRF = observerGeometry_ITRF.intersectionWith(earthGeometry_ITRF);
 

--- a/test/OpenSpaceToolkit/Physics/Environment/Objects/Celestial.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Objects/Celestial.test.cpp
@@ -89,7 +89,6 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, accessModel)
         const Real flattening = 0.0;
         const Real j2 = 0.0;
         const Real j4 = 0.0;
-        const Instant instant = Instant::J2000();
 
         const Celestial celestial = {
             name,
@@ -102,8 +101,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, accessModel)
             nullptr,
             nullptr,
             nullptr,
-            nullptr,
-            instant};
+            nullptr};
 
         EXPECT_ANY_THROW(celestial.accessGravitationalModel());
         EXPECT_ANY_THROW(celestial.accessMagneticModel());
@@ -124,7 +122,6 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, accessModel)
         const Shared<GravitationalModel> gravitationalModel = std::make_shared<Spherical>(gravitationalParameter);
         const Shared<MagneticModel> magneticModel = std::make_shared<Dipole>(Vector3d {0.0, 0.0, 1.0});
         const Shared<AtmosphericModel> atmosphericModel = std::make_shared<Exponential>();
-        const Instant instant = Instant::J2000();
 
         const Celestial celestial = {
             name,
@@ -137,8 +134,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, accessModel)
             ephemeris,
             nullptr,
             nullptr,
-            nullptr,
-            instant};
+            nullptr};
 
         EXPECT_EQ(celestial.accessGravitationalModel(), nullptr);
         EXPECT_EQ(celestial.accessMagneticModel(), nullptr);
@@ -159,7 +155,6 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, accessModel)
         const Shared<GravitationalModel> gravitationalModel = std::make_shared<Spherical>(gravitationalParameter);
         const Shared<MagneticModel> magneticModel = std::make_shared<Dipole>(Vector3d {0.0, 0.0, 1.0});
         const Shared<AtmosphericModel> atmosphericModel = std::make_shared<Exponential>();
-        const Instant instant = Instant::J2000();
 
         const Celestial celestial = {
             name,
@@ -172,8 +167,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, accessModel)
             ephemeris,
             gravitationalModel,
             magneticModel,
-            atmosphericModel,
-            instant};
+            atmosphericModel};
 
         EXPECT_NO_THROW(celestial.accessGravitationalModel());
         EXPECT_NO_THROW(celestial.accessMagneticModel());
@@ -207,13 +201,12 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, GetGravitationalFie
             ephemeris,
             gravitationalModel,
             nullptr,
-            nullptr,
-            instant};
+            nullptr};
 
         {
             const Position position = {{1.0, 0.0, 0.0}, Length::Unit::Meter, celestial.accessFrame()};
 
-            const Vector gravitationalFieldValue = celestial.getGravitationalFieldAt(position);
+            const Vector gravitationalFieldValue = celestial.getGravitationalFieldAt(position, instant);
 
             EXPECT_TRUE(gravitationalFieldValue.isDefined());
 
@@ -228,7 +221,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, GetGravitationalFie
         {
             const Position position = {{0.0, 0.0, 1.0}, Length::Unit::Meter, celestial.accessFrame()};
 
-            const Vector gravitationalFieldValue = celestial.getGravitationalFieldAt(position);
+            const Vector gravitationalFieldValue = celestial.getGravitationalFieldAt(position, instant);
 
             EXPECT_TRUE(gravitationalFieldValue.isDefined());
 
@@ -243,7 +236,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, GetGravitationalFie
         {
             const Position position = {{2.0, 0.0, 0.0}, Length::Unit::Meter, celestial.accessFrame()};
 
-            const Vector gravitationalFieldValue = celestial.getGravitationalFieldAt(position);
+            const Vector gravitationalFieldValue = celestial.getGravitationalFieldAt(position, instant);
 
             EXPECT_TRUE(gravitationalFieldValue.isDefined());
 
@@ -283,13 +276,12 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, GetMagneticFieldAt)
             ephemeris,
             nullptr,
             magneticModel,
-            nullptr,
-            instant};
+            nullptr};
 
         {
             const Position position = {{1.0, 0.0, 0.0}, Length::Unit::Meter, celestial.accessFrame()};
 
-            const Vector magneticFieldValue = celestial.getMagneticFieldAt(position);
+            const Vector magneticFieldValue = celestial.getMagneticFieldAt(position, instant);
 
             EXPECT_TRUE(magneticFieldValue.isDefined());
 
@@ -301,7 +293,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, GetMagneticFieldAt)
         {
             const Position position = {{0.0, 0.0, 1.0}, Length::Unit::Meter, celestial.accessFrame()};
 
-            const Vector magneticFieldValue = celestial.getMagneticFieldAt(position);
+            const Vector magneticFieldValue = celestial.getMagneticFieldAt(position, instant);
 
             EXPECT_TRUE(magneticFieldValue.isDefined());
 
@@ -313,7 +305,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, GetMagneticFieldAt)
         {
             const Position position = {{2.0, 0.0, 0.0}, Length::Unit::Meter, celestial.accessFrame()};
 
-            const Vector magneticFieldValue = celestial.getMagneticFieldAt(position);
+            const Vector magneticFieldValue = celestial.getMagneticFieldAt(position, instant);
 
             EXPECT_TRUE(magneticFieldValue.isDefined());
 
@@ -348,8 +340,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, GetAtmosphericDensi
             ephemeris,
             nullptr,
             nullptr,
-            atmosphericModel,
-            instant};
+            atmosphericModel};
 
         {
             const Position position = {
@@ -358,7 +349,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, GetAtmosphericDensi
                 Position::Unit::Meter,
                 Frame::ITRF()};
 
-            const Scalar atmosphericDensityValue = celestial.getAtmosphericDensityAt(position);
+            const Scalar atmosphericDensityValue = celestial.getAtmosphericDensityAt(position, instant);
 
             EXPECT_TRUE(atmosphericDensityValue.isDefined());
 
@@ -376,7 +367,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, GetAtmosphericDensi
                 Position::Unit::Meter,
                 Frame::ITRF()};
 
-            const Scalar atmosphericDensityValue = celestial.getAtmosphericDensityAt(position);
+            const Scalar atmosphericDensityValue = celestial.getAtmosphericDensityAt(position, instant);
 
             EXPECT_TRUE(atmosphericDensityValue.isDefined());
 
@@ -394,7 +385,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, GetAtmosphericDensi
                 Position::Unit::Meter,
                 Frame::ITRF()};
 
-            const Scalar atmosphericDensityValue = celestial.getAtmosphericDensityAt(position);
+            const Scalar atmosphericDensityValue = celestial.getAtmosphericDensityAt(position, instant);
 
             EXPECT_TRUE(atmosphericDensityValue.isDefined());
 
@@ -406,7 +397,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, GetAtmosphericDensi
         }
 
         {
-            EXPECT_ANY_THROW(celestial.getAtmosphericDensityAt(Position::Undefined()));
+            EXPECT_ANY_THROW(celestial.getAtmosphericDensityAt(Position::Undefined(), instant));
         }
 
         {
@@ -416,7 +407,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, GetAtmosphericDensi
                 Position::Unit::Meter,
                 Frame::ITRF()};
 
-            EXPECT_ANY_THROW(Celestial::Undefined().getAtmosphericDensityAt(position));
+            EXPECT_ANY_THROW(Celestial::Undefined().getAtmosphericDensityAt(position, instant));
         }
 
         {
@@ -437,18 +428,17 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, GetAtmosphericDensi
                 ephemeris,
                 nullptr,
                 nullptr,
-                nullptr,
-                instant};
+                nullptr};
 
-            EXPECT_ANY_THROW(celestialWithoutAtmospheric.getAtmosphericDensityAt(position));
+            EXPECT_ANY_THROW(celestialWithoutAtmospheric.getAtmosphericDensityAt(position, instant));
         }
 
         {
-            EXPECT_ANY_THROW(celestial.getAtmosphericDensityAt(Position::Undefined()));
+            EXPECT_ANY_THROW(celestial.getAtmosphericDensityAt(Position::Undefined(), instant));
         }
 
         {
-            EXPECT_ANY_THROW(Celestial::Undefined().getAtmosphericDensityAt(Position::Undefined()));
+            EXPECT_ANY_THROW(Celestial::Undefined().getAtmosphericDensityAt(Position::Undefined(), instant));
         }
     }
 }

--- a/test/OpenSpaceToolkit/Physics/Environment/Objects/Celestial.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Objects/Celestial.test.cpp
@@ -64,6 +64,9 @@ using ostk::physics::environment::gravitational::Spherical;
 using ostk::physics::environment::magnetic::Dipole;
 using ostk::physics::environment::atmospheric::earth::Exponential;
 using EarthCelestialBody = ostk::physics::env::obj::celest::Earth;
+using earthGravitationalModel = ostk::physics::environment::gravitational::Earth;
+using earthMagneticModel = ostk::physics::environment::magnetic::Earth;
+using earthAtmosphericModel = ostk::physics::environment::atmospheric::Earth;
 
 // TEST (OpenSpaceToolkit_Physics_Environment_Objects_Celestial, Constructor)
 // {
@@ -80,15 +83,17 @@ using EarthCelestialBody = ostk::physics::env::obj::celest::Earth;
 
 TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, accessModel)
 {
+    const String name = "Some Planet";
+    const Celestial::Type type = Celestial::Type::Earth;
+    const Derived gravitationalParameter = {
+        1.0, Derived::Unit::GravitationalParameter(Length::Unit::Meter, Time::Unit::Second)};
+    const Length equatorialRadius = Length::Kilometers(1000.0);
+    const Real flattening = 0.0;
+    const Real j2 = 0.0;
+    const Real j4 = 0.0;
+
+    const Shared<Ephemeris> ephemeris = std::make_shared<Analytical>(Frame::ITRF());
     {
-        const String name = "Some Planet";
-        const Celestial::Type type = Celestial::Type::Earth;
-        const Derived gravitationalParameter = {
-            1.0, Derived::Unit::GravitationalParameter(Length::Unit::Meter, Time::Unit::Second)};
-        const Length equatorialRadius = Length::Kilometers(1000.0);
-        const Real flattening = 0.0;
-        const Real j2 = 0.0;
-        const Real j4 = 0.0;
 
         const Celestial celestial = {
             name,
@@ -109,20 +114,6 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, accessModel)
     }
 
     {
-        const String name = "Some Planet";
-        const Celestial::Type type = Celestial::Type::Earth;
-        const Derived gravitationalParameter = {
-            1.0, Derived::Unit::GravitationalParameter(Length::Unit::Meter, Time::Unit::Second)};
-        const Length equatorialRadius = Length::Kilometers(1000.0);
-        const Real flattening = 0.0;
-        const Real j2 = 0.0;
-        const Real j4 = 0.0;
-
-        const Shared<Ephemeris> ephemeris = std::make_shared<Analytical>(Frame::ITRF());
-        const Shared<GravitationalModel> gravitationalModel = std::make_shared<Spherical>(gravitationalParameter);
-        const Shared<MagneticModel> magneticModel = std::make_shared<Dipole>(Vector3d {0.0, 0.0, 1.0});
-        const Shared<AtmosphericModel> atmosphericModel = std::make_shared<Exponential>();
-
         const Celestial celestial = {
             name,
             type,
@@ -142,16 +133,6 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, accessModel)
     }
 
     {
-        const String name = "Some Planet";
-        const Celestial::Type type = Celestial::Type::Earth;
-        const Derived gravitationalParameter = {
-            1.0, Derived::Unit::GravitationalParameter(Length::Unit::Meter, Time::Unit::Second)};
-        const Length equatorialRadius = Length::Kilometers(1000.0);
-        const Real flattening = 0.0;
-        const Real j2 = 0.0;
-        const Real j4 = 0.0;
-
-        const Shared<Ephemeris> ephemeris = std::make_shared<Analytical>(Frame::ITRF());
         const Shared<GravitationalModel> gravitationalModel = std::make_shared<Spherical>(gravitationalParameter);
         const Shared<MagneticModel> magneticModel = std::make_shared<Dipole>(Vector3d {0.0, 0.0, 1.0});
         const Shared<AtmosphericModel> atmosphericModel = std::make_shared<Exponential>();
@@ -177,48 +158,21 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, accessModel)
 
 TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, modelIsDefined)
 {
-    using ostk::core::types::Shared;
-    using ostk::core::types::Real;
-    using ostk::core::types::String;
+    const String name = "Some Planet";
+    const Celestial::Type type = Celestial::Type::Earth;
+    const Derived gravitationalParameter = {
+        1.0, Derived::Unit::GravitationalParameter(Length::Unit::Meter, Time::Unit::Second)};
+    const Length equatorialRadius = Length::Kilometers(1000.0);
+    const Real flattening = 0.0;
+    const Real j2 = 0.0;
+    const Real j4 = 0.0;
 
-    using ostk::math::obj::Vector3d;
-
-    using ostk::physics::Unit;
-    using ostk::physics::units::Length;
-    using ostk::physics::units::Time;
-    using ostk::physics::units::Derived;
-    using ostk::physics::data::Vector;
-    using ostk::physics::time::Instant;
-    using ostk::physics::coord::Frame;
-    using ostk::physics::coord::Position;
-    using ostk::physics::env::obj::Celestial;
-    using ostk::physics::env::Ephemeris;
-    using ostk::physics::env::ephem::Analytical;
-    using GravitationalModel = ostk::physics::environment::gravitational::Model;
-    using MagneticModel = ostk::physics::environment::magnetic::Model;
-    using AtmosphericModel = ostk::physics::environment::atmospheric::Model;
-    using ostk::physics::environment::gravitational::Spherical;
-    using ostk::physics::environment::magnetic::Dipole;
-    using earthGravitationalModel = ostk::physics::environment::gravitational::Earth;
-    using earthMagneticModel = ostk::physics::environment::magnetic::Earth;
-    using earthAtmosphericModel = ostk::physics::environment::atmospheric::Earth;
-    using ostk::physics::environment::atmospheric::earth::Exponential;
+    const Shared<Ephemeris> ephemeris = std::make_shared<Analytical>(Frame::ITRF());
 
     {
-        const String name = "Some Planet";
-        const Celestial::Type type = Celestial::Type::Earth;
-        const Derived gravitationalParameter = {
-            1.0, Derived::Unit::GravitationalParameter(Length::Unit::Meter, Time::Unit::Second)};
-        const Length equatorialRadius = Length::Kilometers(1000.0);
-        const Real flattening = 0.0;
-        const Real j2 = 0.0;
-        const Real j4 = 0.0;
-
-        const Shared<Ephemeris> ephemeris = std::make_shared<Analytical>(Frame::ITRF());
         const Shared<GravitationalModel> gravitationalModel = std::make_shared<Spherical>(gravitationalParameter);
         const Shared<MagneticModel> magneticModel = std::make_shared<Dipole>(Vector3d {0.0, 0.0, 1.0});
         const Shared<AtmosphericModel> atmosphericModel = std::make_shared<Exponential>();
-        const Instant instant = Instant::J2000();
 
         const Celestial celestial = {
             name,
@@ -231,8 +185,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, modelIsDefined)
             ephemeris,
             nullptr,
             nullptr,
-            nullptr,
-            instant};
+            nullptr};
 
         EXPECT_FALSE(celestial.gravitationalModelIsDefined());
         EXPECT_FALSE(celestial.magneticModelIsDefined());
@@ -240,20 +193,12 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, modelIsDefined)
     }
 
     {
-        const String name = "Some Planet";
-        const Celestial::Type type = Celestial::Type::Earth;
-        const Derived gravitationalParameter = {
-            1.0, Derived::Unit::GravitationalParameter(Length::Unit::Meter, Time::Unit::Second)};
-        const Length equatorialRadius = Length::Kilometers(1000.0);
-        const Real flattening = 0.0;
-        const Real j2 = 0.0;
-        const Real j4 = 0.0;
-
-        const Shared<Ephemeris> ephemeris = std::make_shared<Analytical>(Frame::ITRF());
-        const Shared<GravitationalModel> undefinedGravitationalModel = std::make_shared<earthGravitationalModel>(earthGravitationalModel::Type::Undefined);
-        const Shared<MagneticModel> undefinedMagneticModel = std::make_shared<earthMagneticModel>(earthMagneticModel::Type::Undefined);
-        const Shared<AtmosphericModel> undefinedAtmosphericModel = std::make_shared<earthAtmosphericModel>(earthAtmosphericModel::Type::Undefined);
-        const Instant instant = Instant::J2000();
+        const Shared<GravitationalModel> undefinedGravitationalModel =
+            std::make_shared<earthGravitationalModel>(earthGravitationalModel::Type::Undefined);
+        const Shared<MagneticModel> undefinedMagneticModel =
+            std::make_shared<earthMagneticModel>(earthMagneticModel::Type::Undefined);
+        const Shared<AtmosphericModel> undefinedAtmosphericModel =
+            std::make_shared<earthAtmosphericModel>(earthAtmosphericModel::Type::Undefined);
 
         const Celestial celestial = {
             name,
@@ -266,8 +211,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, modelIsDefined)
             ephemeris,
             undefinedGravitationalModel,
             undefinedMagneticModel,
-            undefinedAtmosphericModel,
-            instant};
+            undefinedAtmosphericModel};
 
         EXPECT_FALSE(celestial.gravitationalModelIsDefined());
         EXPECT_FALSE(celestial.magneticModelIsDefined());
@@ -275,20 +219,9 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, modelIsDefined)
     }
 
     {
-        const String name = "Some Planet";
-        const Celestial::Type type = Celestial::Type::Earth;
-        const Derived gravitationalParameter = {
-            1.0, Derived::Unit::GravitationalParameter(Length::Unit::Meter, Time::Unit::Second)};
-        const Length equatorialRadius = Length::Kilometers(1000.0);
-        const Real flattening = 0.0;
-        const Real j2 = 0.0;
-        const Real j4 = 0.0;
-
-        const Shared<Ephemeris> ephemeris = std::make_shared<Analytical>(Frame::ITRF());
         const Shared<GravitationalModel> gravitationalModel = std::make_shared<Spherical>(gravitationalParameter);
         const Shared<MagneticModel> magneticModel = std::make_shared<Dipole>(Vector3d {0.0, 0.0, 1.0});
         const Shared<AtmosphericModel> atmosphericModel = std::make_shared<Exponential>();
-        const Instant instant = Instant::J2000();
 
         const Celestial celestial = {
             name,
@@ -301,8 +234,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, modelIsDefined)
             ephemeris,
             gravitationalModel,
             magneticModel,
-            atmosphericModel,
-            instant};
+            atmosphericModel};
 
         EXPECT_TRUE(celestial.gravitationalModelIsDefined());
         EXPECT_TRUE(celestial.magneticModelIsDefined());
@@ -310,20 +242,9 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, modelIsDefined)
     }
 
     {
-        const String name = "Some Planet";
-        const Celestial::Type type = Celestial::Type::Earth;
-        const Derived gravitationalParameter = {
-            1.0, Derived::Unit::GravitationalParameter(Length::Unit::Meter, Time::Unit::Second)};
-        const Length equatorialRadius = Length::Kilometers(1000.0);
-        const Real flattening = 0.0;
-        const Real j2 = 0.0;
-        const Real j4 = 0.0;
-
-        const Shared<Ephemeris> ephemeris = std::make_shared<Analytical>(Frame::ITRF());
         const Shared<GravitationalModel> gravitationalModel = std::make_shared<Spherical>(gravitationalParameter);
         const Shared<MagneticModel> magneticModel = std::make_shared<Dipole>(Vector3d {0.0, 0.0, 1.0});
         const Shared<AtmosphericModel> atmosphericModel = std::make_shared<Exponential>();
-        const Instant instant = Instant::J2000();
 
         const Celestial celestial = {
             name,
@@ -336,8 +257,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Objects_Celestial, modelIsDefined)
             nullptr,
             gravitationalModel,
             magneticModel,
-            atmosphericModel,
-            instant};
+            atmosphericModel};
 
         EXPECT_ANY_THROW(celestial.gravitationalModelIsDefined());
         EXPECT_ANY_THROW(celestial.magneticModelIsDefined());


### PR DESCRIPTION
* remove instant_ as a member variable for the Object parent class
* pass the instant as an argument for relevant functions
This allows the celestial bodies to remain immutable in the environment after creating them, while still allowing the environment class to keep store and pass instants as appropriate.

This will make it possible to get a shared pointer to a const Celestial in OSTk astro while instantiating the propagator from the environment.
Also it prevents us from having to clone celestials since we technically never need to modify them for the sake of updating an instant.

IMO the instant is something that should be supplied at the function call as it is not a configuration parameter for the object/celestial classes.