### PR TITLE
refactor: move eclipse method from utils to environment

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment.cpp
@@ -49,6 +49,8 @@ inline void OpenSpaceToolkitPhysicsPy_Environment(pybind11::module& aModule)
 
         .def("set_instant", &Environment::setInstant, arg("instant"))
 
+        .def("is_position_in_eclipse", &Environment::isPositionInEclipse, arg("position"))
+
         .def_static("undefined", &Environment::Undefined)
         .def_static("default", &Environment::Default)
 

--- a/bindings/python/test/test_environment.py
+++ b/bindings/python/test/test_environment.py
@@ -6,6 +6,7 @@ from ostk.physics.time import Instant, DateTime, Scale
 from ostk.physics.coordinate import Frame, Position
 from ostk.physics import Environment
 
+
 @pytest.fixture
 def environment() -> Environment:
     return Environment.default()
@@ -70,7 +71,13 @@ def test_environment_getObjectNames(environment: Environment):
 def test_environment_setInstant(environment: Environment):
     environment.set_instant(Instant.date_time(DateTime(2019, 1, 1, 0, 0, 0), Scale.UTC))
 
-def test_environment_isPositionInEclipse(environment: Environment):
-    environment.set_instant(Instant.date_time(DateTime(2018,1,1,0,0,0), Scale.UTC))
 
-    assert environment.is_position_in_eclipse(Position.meters([7000e3, 0.0, 0.0], Frame.ITRF()))
+def test_environment_isPositionInEclipse(environment: Environment):
+    environment.set_instant(Instant.date_time(DateTime(2018, 1, 1, 0, 0, 0), Scale.UTC))
+
+    assert environment.is_position_in_eclipse(
+        Position.meters(
+            [7000e3, 0.0, 0.0],
+            Frame.ITRF(),
+        )
+    )

--- a/bindings/python/test/test_environment.py
+++ b/bindings/python/test/test_environment.py
@@ -2,10 +2,13 @@
 
 import pytest
 
-from ostk.physics.time import Scale
-from ostk.physics.time import Instant
-from ostk.physics.time import DateTime
+from ostk.physics.time import Instant, DateTime, Scale
+from ostk.physics.coordinate import Frame, Position
 from ostk.physics import Environment
+
+@pytest.fixture
+def environment() -> Environment:
+    return Environment.default()
 
 
 def test_environment_constructors():
@@ -27,60 +30,47 @@ def test_environment_default():
     assert Environment.default() is not None
 
 
-def test_environment_isDefined():
-    environment = Environment.default()
-
+def test_environment_isDefined(environment: Environment):
     assert environment.is_defined() is not None
 
 
-def test_environment_hasObjectWithName():
-    environment = Environment.default()
-
+def test_environment_hasObjectWithName(environment: Environment):
     assert environment.has_object_with_name("Earth") is not None
 
 
 @pytest.mark.skip
-def test_environment_intersects():
-    environment = Environment.default()
-
+def test_environment_intersects(environment: Environment):
     assert environment.intersects() is not None
 
 
 @pytest.mark.skip
-def test_environment_accessObjects():
-    environment = Environment.default()
-
+def test_environment_accessObjects(environment: Environment):
     assert environment.access_objects() is not None
 
 
 @pytest.mark.skip
-def test_environment_accessObjectWithName():
-    environment = Environment.default()
-
+def test_environment_accessObjectWithName(environment: Environment):
     assert environment.access_object_with_name("Earth") is not None
 
 
 @pytest.mark.skip
-def test_environment_accessCelestialObjectWithName():
-    environment = Environment.default()
-
+def test_environment_accessCelestialObjectWithName(environment: Environment):
     assert environment.access_celestial_object_with_name("Earth") is not None
 
 
-def test_environment_getInstant():
-    environment = Environment.default()
-
+def test_environment_getInstant(environment: Environment):
     assert environment.get_instant() is not None
 
 
 @pytest.mark.skip
-def test_environment_getObjectNames():
-    environment = Environment.default()
-
+def test_environment_getObjectNames(environment: Environment):
     assert environment.get_object_names() is not None
 
 
-def test_environment_setInstant():
-    environment = Environment.default()
-
+def test_environment_setInstant(environment: Environment):
     environment.set_instant(Instant.date_time(DateTime(2019, 1, 1, 0, 0, 0), Scale.UTC))
+
+def test_environment_isPositionInEclipse(environment: Environment):
+    environment.set_instant(Instant.date_time(DateTime(2018,1,1,0,0,0), Scale.UTC))
+
+    assert environment.is_position_in_eclipse(Position.meters([7000e3, 0.0, 0.0], Frame.ITRF()))

--- a/include/OpenSpaceToolkit/Physics/Environment.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment.hpp
@@ -23,6 +23,7 @@ using ostk::core::types::String;
 using ostk::core::ctnr::Array;
 
 using ostk::physics::time::Instant;
+using ostk::physics::coord::Position;
 using ostk::physics::env::Object;
 using ostk::physics::env::obj::Celestial;
 
@@ -120,6 +121,12 @@ class Environment
     /// @param              [in] anInstant An instant
 
     void setInstant(const Instant& anInstant);
+
+    /// @brief              Return true if the position is in eclipse
+    ///
+    /// @return             True if the position is in eclipse
+
+    bool isPositionInEclipse(const Position& aPosition) const;
 
     /// @brief              Get gravitational field at position
     ///

--- a/include/OpenSpaceToolkit/Physics/Environment.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment.hpp
@@ -122,8 +122,9 @@ class Environment
 
     void setInstant(const Instant& anInstant);
 
-    /// @brief              Return true if the position is in eclipse
+    /// @brief              Is position in eclipse
     ///
+    /// @param              [in] aPosition A position
     /// @return             True if the position is in eclipse
 
     bool isPositionInEclipse(const Position& aPosition) const;

--- a/include/OpenSpaceToolkit/Physics/Environment/Utilities/Eclipse.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Utilities/Eclipse.hpp
@@ -24,14 +24,6 @@ using ostk::physics::coord::Position;
 using ostk::physics::time::Interval;
 using ostk::physics::Environment;
 
-/// @brief                      Is position in eclipse
-///
-/// @param                      [in] aPosition A position (in GCRF)
-/// @param                      [in] anEnvironment An environment
-/// @return                     True if position is in eclipse
-
-bool isPositionInEclipse(const Position& aPosition, const Environment& anEnvironment);
-
 /// @brief                      Calculate eclipse intervals for a given position
 ///
 /// @param                      [in] anAnalysisInterval An analysis interval

--- a/src/OpenSpaceToolkit/Physics/Environment/Utilities/Eclipse.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Utilities/Eclipse.cpp
@@ -17,41 +17,6 @@ namespace env
 namespace utilities
 {
 
-bool isPositionInEclipse(const Position& aPosition, const Environment& anEnvironment)
-{
-    using ostk::core::types::Shared;
-
-    using ostk::math::geom::d3::objects::Point;
-    using ostk::math::geom::d3::objects::Segment;
-
-    using ostk::physics::env::Object;
-
-    if (!aPosition.isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("Position");
-    }
-
-    if (aPosition.accessFrame() != Frame::GCRF())
-    {
-        throw ostk::core::error::RuntimeError("Position has to be expressed in GCRF.");
-    }
-
-    if (!anEnvironment.isDefined())
-    {
-        throw ostk::core::error::runtime::Undefined("Environment");
-    }
-
-    const Shared<const Object> sunSPtr = anEnvironment.accessObjectWithName("Sun");
-
-    const Segment sunToObjectSegment_GCRF = {
-        Point::Vector(aPosition.getCoordinates()),
-        Point::Vector(sunSPtr->getPositionIn(Frame::GCRF(), anEnvironment.getInstant()).getCoordinates())};
-
-    const Object::Geometry sunToObjectGeometry = {sunToObjectSegment_GCRF, Frame::GCRF()};
-
-    return anEnvironment.intersects(sunToObjectGeometry, {sunSPtr});
-}
-
 Array<Interval> eclipseIntervalsAtPosition(
     const Interval& anAnalysisInterval, const Position& aPosition, const Environment& anEnvironment
 )
@@ -92,9 +57,7 @@ Array<Interval> eclipseIntervalsAtPosition(
     {
         environment.setInstant(instant);
 
-        const Position position_GCRF = aPosition.inFrame(Frame::GCRF(), instant);
-
-        const bool inEclipse = isPositionInEclipse(position_GCRF, environment);
+        const bool inEclipse = environment.isPositionInEclipse(aPosition);
 
         if (inEclipse && (!eclipseStartInstant.isDefined()))
         {

--- a/test/OpenSpaceToolkit/Physics/Environment.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment.test.cpp
@@ -248,6 +248,39 @@ TEST_F(OpenSpaceToolkit_Physics_Environment, SetInstant)
     }
 }
 
+TEST_F(OpenSpaceToolkit_Physics_Environment, IsPositionInEclipse)
+{
+    {
+        const Position position = Position::Meters({7000e3, 0.0, 0.0}, Frame::ITRF());
+
+        Environment environment = Environment::Default();
+
+        {
+            const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
+
+            environment.setInstant(instant);
+
+            EXPECT_TRUE(environment.isPositionInEclipse(position));
+        }
+
+        {
+            const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 12, 0, 0), Scale::UTC);
+
+            environment.setInstant(instant);
+
+            EXPECT_FALSE(environment.isPositionInEclipse(position));
+        }
+
+        {
+            const Instant instant = Instant::DateTime(DateTime(2018, 1, 2, 0, 0, 0), Scale::UTC);
+
+            environment.setInstant(instant);
+
+            EXPECT_TRUE(environment.isPositionInEclipse(position));
+        }
+    }
+}
+
 TEST_F(OpenSpaceToolkit_Physics_Environment, Undefined)
 {
     {

--- a/test/OpenSpaceToolkit/Physics/Environment/Utilities/Eclipse.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Utilities/Eclipse.test.cpp
@@ -40,47 +40,7 @@ using ostk::physics::coord::spherical::LLA;
 using ostk::physics::Environment;
 using ostk::physics::env::obj::celest::Earth;
 using ostk::physics::env::utilities::eclipseIntervalsAtPosition;
-using ostk::physics::env::utilities::isPositionInEclipse;
 using EarthGravitationalModel = ostk::physics::environment::gravitational::Earth;
-
-TEST(OpenSpaceToolkit_Physics_Environment_Utilities_Eclipse, IsPositionInEclipse)
-{
-    {
-        const Position position_ITRF = Position::Meters({7000e3, 0.0, 0.0}, Frame::ITRF());
-
-        Environment environment = Environment::Default();
-
-        {
-            const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::UTC);
-
-            environment.setInstant(instant);
-
-            const Position position_GCRF = position_ITRF.inFrame(Frame::GCRF(), instant);
-
-            EXPECT_TRUE(isPositionInEclipse(position_GCRF, environment));
-        }
-
-        {
-            const Instant instant = Instant::DateTime(DateTime(2018, 1, 1, 12, 0, 0), Scale::UTC);
-
-            environment.setInstant(instant);
-
-            const Position position_GCRF = position_ITRF.inFrame(Frame::GCRF(), instant);
-
-            EXPECT_FALSE(isPositionInEclipse(position_GCRF, environment));
-        }
-
-        {
-            const Instant instant = Instant::DateTime(DateTime(2018, 1, 2, 0, 0, 0), Scale::UTC);
-
-            environment.setInstant(instant);
-
-            const Position position_GCRF = position_ITRF.inFrame(Frame::GCRF(), instant);
-
-            EXPECT_TRUE(isPositionInEclipse(position_GCRF, environment));
-        }
-    }
-}
 
 TEST(OpenSpaceToolkit_Physics_Environment_Utilities_Eclipse, EclipseIntervalsAtPosition)
 {


### PR DESCRIPTION
I believe it's better suited there, and thus also easily exposed via python bindings.