### PR TITLE
fix: gap in bulletinA intervals

### DIFF
--- a/bindings/python/test/coordinate/frame/providers/iers/test_bulletin_a.py
+++ b/bindings/python/test/coordinate/frame/providers/iers/test_bulletin_a.py
@@ -36,7 +36,7 @@ class TestBulletinA:
     def test_access_observation_interval_success(self, bulletin_a: BulletinA):
         assert (
             bulletin_a.access_observation_interval().to_string()
-            == "[2020-10-23 00:00:00 - 2020-10-29 00:00:00] [UTC]"
+            == "[2020-10-23 00:00:00 - 2020-10-30 00:00:00] [UTC]"
         )
 
     def test_access_prediction_interval_success(self, bulletin_a: BulletinA):
@@ -59,7 +59,7 @@ class TestBulletinA:
     def test_get_observation_interval_success(self, bulletin_a: BulletinA):
         assert (
             bulletin_a.get_observation_interval().to_string()
-            == "[2020-10-23 00:00:00 - 2020-10-29 00:00:00] [UTC]"
+            == "[2020-10-23 00:00:00 - 2020-10-30 00:00:00] [UTC]"
         )
 
     def test_get_observation_at_success(self, bulletin_a: BulletinA):

--- a/bindings/python/test/coordinate/frame/providers/iers/test_bulletin_a.py
+++ b/bindings/python/test/coordinate/frame/providers/iers/test_bulletin_a.py
@@ -36,7 +36,7 @@ class TestBulletinA:
     def test_access_observation_interval_success(self, bulletin_a: BulletinA):
         assert (
             bulletin_a.access_observation_interval().to_string()
-            == "[2020-10-23 00:00:00 - 2020-10-30 00:00:00] [UTC]"
+            == "[2020-10-23 00:00:00 - 2020-10-30 00:00:00[ [UTC]"
         )
 
     def test_access_prediction_interval_success(self, bulletin_a: BulletinA):
@@ -59,7 +59,7 @@ class TestBulletinA:
     def test_get_observation_interval_success(self, bulletin_a: BulletinA):
         assert (
             bulletin_a.get_observation_interval().to_string()
-            == "[2020-10-23 00:00:00 - 2020-10-30 00:00:00] [UTC]"
+            == "[2020-10-23 00:00:00 - 2020-10-30 00:00:00[ [UTC]"
         )
 
     def test_get_observation_at_success(self, bulletin_a: BulletinA):

--- a/src/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/IERS/BulletinA.cpp
+++ b/src/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/IERS/BulletinA.cpp
@@ -209,46 +209,53 @@ BulletinA::Observation BulletinA::getObservationAt(const Instant& anInstant) con
         else
         {
             const auto nextObservationIt = std::next(observationIt);
+            
+            auto observation1It = observations_.begin();
+            auto observation2It = observations_.begin();
 
             if (nextObservationIt != observations_.end())
             {
-                // [TBI] IERS gazette #13 for more precise interpolation and correction for tidal effects
-
-                const BulletinA::Observation& previousObservation = observationIt->second;
-                const BulletinA::Observation& nextObservation = nextObservationIt->second;
-
-                const Real ratio =
-                    (instantMjd - previousObservation.mjd) / (nextObservation.mjd - previousObservation.mjd);
-
-                const Integer year = previousObservation.year;
-                const Integer month = previousObservation.month;
-                const Integer day = previousObservation.day;
-
-                const Real mjd = previousObservation.mjd + ratio * (nextObservation.mjd - previousObservation.mjd);
-
-                const Real x = previousObservation.x + ratio * (nextObservation.x - previousObservation.x);
-                const Real xError =
-                    previousObservation.xError + ratio * (nextObservation.xError - previousObservation.xError);
-                const Real y = previousObservation.y + ratio * (nextObservation.y - previousObservation.y);
-                const Real yError =
-                    previousObservation.yError + ratio * (nextObservation.yError - previousObservation.yError);
-                const Real ut1MinusUtc = previousObservation.ut1MinusUtc +
-                                         ratio * (nextObservation.ut1MinusUtc - previousObservation.ut1MinusUtc);
-                const Real ut1MinusUtcError =
-                    previousObservation.ut1MinusUtcError +
-                    ratio * (nextObservation.ut1MinusUtcError - previousObservation.ut1MinusUtcError);
-
-                const BulletinA::Observation observation = {
-                    year, month, day, mjd, x, xError, y, yError, ut1MinusUtc, ut1MinusUtcError};
-
-                return observation;
+                // linearly interpolate between two observations
+                observation1It = observationIt;
+                observation2It = nextObservationIt;
             }
             else
             {
-                throw ostk::core::error::RuntimeError(
-                    "Cannot find observation at [{}].", anInstant.toString(Scale::UTC)
-                );
+                // linearly extrapolate from the last two observations to fill the gap before the first prediction
+                observation1It = std::prev(observationIt);
+                observation2It = observationIt;
             }
+
+            const Integer year = observationIt->second.year;
+            const Integer month = observationIt->second.month;
+            const Integer day = observationIt->second.day;
+
+             // [TBI] IERS gazette #13 for more precise interpolation and correction for tidal effects
+
+            const Observation observation1 = observation1It->second;
+            const Observation observation2 = observation2It->second;
+
+            const Real ratio =
+                (instantMjd - observation1.mjd) / (observation2.mjd - observation1.mjd);
+
+            const Real mjd = observation1.mjd + ratio * (observation2.mjd - observation1.mjd);
+
+            const Real x = observation1.x + ratio * (observation2.x - observation1.x);
+            const Real xError =
+                observation1.xError + ratio * (observation2.xError - observation1.xError);
+            const Real y = observation1.y + ratio * (observation2.y - observation1.y);
+            const Real yError =
+                observation1.yError + ratio * (observation2.yError - observation1.yError);
+            const Real ut1MinusUtc = observation1.ut1MinusUtc +
+                                        ratio * (observation2.ut1MinusUtc - observation1.ut1MinusUtc);
+            const Real ut1MinusUtcError =
+                observation1.ut1MinusUtcError +
+                ratio * (observation2.ut1MinusUtcError - observation1.ut1MinusUtcError);
+
+            const BulletinA::Observation observation = {
+                year, month, day, mjd, x, xError, y, yError, ut1MinusUtc, ut1MinusUtcError};
+
+            return observation;
         }
     }
     else
@@ -543,9 +550,10 @@ BulletinA BulletinA::Load(const fs::File& aFile)
         const Instant observationStartInstant =
             Instant::ModifiedJulianDate(Real::Integer(bulletin.observations_.begin()->first), Scale::UTC);
         const Instant observationEndInstant =
-            Instant::ModifiedJulianDate(Real::Integer(bulletin.observations_.rbegin()->first), Scale::UTC);
+            Instant::ModifiedJulianDate(Real::Integer(bulletin.observations_.rbegin()->first), Scale::UTC) +
+            Duration::Days(1);
 
-        bulletin.observationInterval_ = Interval::Closed(observationStartInstant, observationEndInstant);
+        bulletin.observationInterval_ = Interval(observationStartInstant, observationEndInstant, Interval::Type::HalfOpenRight);
     }
 
     if (!bulletin.predictions_.empty())

--- a/src/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/IERS/BulletinA.cpp
+++ b/src/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/IERS/BulletinA.cpp
@@ -209,7 +209,7 @@ BulletinA::Observation BulletinA::getObservationAt(const Instant& anInstant) con
         else
         {
             const auto nextObservationIt = std::next(observationIt);
-            
+
             auto observation1It = observations_.begin();
             auto observation2It = observations_.begin();
 
@@ -230,27 +230,23 @@ BulletinA::Observation BulletinA::getObservationAt(const Instant& anInstant) con
             const Integer month = observationIt->second.month;
             const Integer day = observationIt->second.day;
 
-             // [TBI] IERS gazette #13 for more precise interpolation and correction for tidal effects
+            // [TBI] IERS gazette #13 for more precise interpolation and correction for tidal effects
 
             const Observation observation1 = observation1It->second;
             const Observation observation2 = observation2It->second;
 
-            const Real ratio =
-                (instantMjd - observation1.mjd) / (observation2.mjd - observation1.mjd);
+            const Real ratio = (instantMjd - observation1.mjd) / (observation2.mjd - observation1.mjd);
 
             const Real mjd = observation1.mjd + ratio * (observation2.mjd - observation1.mjd);
 
             const Real x = observation1.x + ratio * (observation2.x - observation1.x);
-            const Real xError =
-                observation1.xError + ratio * (observation2.xError - observation1.xError);
+            const Real xError = observation1.xError + ratio * (observation2.xError - observation1.xError);
             const Real y = observation1.y + ratio * (observation2.y - observation1.y);
-            const Real yError =
-                observation1.yError + ratio * (observation2.yError - observation1.yError);
-            const Real ut1MinusUtc = observation1.ut1MinusUtc +
-                                        ratio * (observation2.ut1MinusUtc - observation1.ut1MinusUtc);
+            const Real yError = observation1.yError + ratio * (observation2.yError - observation1.yError);
+            const Real ut1MinusUtc =
+                observation1.ut1MinusUtc + ratio * (observation2.ut1MinusUtc - observation1.ut1MinusUtc);
             const Real ut1MinusUtcError =
-                observation1.ut1MinusUtcError +
-                ratio * (observation2.ut1MinusUtcError - observation1.ut1MinusUtcError);
+                observation1.ut1MinusUtcError + ratio * (observation2.ut1MinusUtcError - observation1.ut1MinusUtcError);
 
             const BulletinA::Observation observation = {
                 year, month, day, mjd, x, xError, y, yError, ut1MinusUtc, ut1MinusUtcError};
@@ -553,7 +549,8 @@ BulletinA BulletinA::Load(const fs::File& aFile)
             Instant::ModifiedJulianDate(Real::Integer(bulletin.observations_.rbegin()->first), Scale::UTC) +
             Duration::Days(1);
 
-        bulletin.observationInterval_ = Interval(observationStartInstant, observationEndInstant, Interval::Type::HalfOpenRight);
+        bulletin.observationInterval_ =
+            Interval(observationStartInstant, observationEndInstant, Interval::Type::HalfOpenRight);
     }
 
     if (!bulletin.predictions_.empty())

--- a/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/IERS/BulletinA.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/IERS/BulletinA.test.cpp
@@ -115,9 +115,10 @@ TEST_F(OpenSpaceToolkit_Physics_Coordinate_Frame_Providers_IERS_BulletinA, GetOb
 {
     {
         EXPECT_EQ(
-            Interval::Closed(
+            Interval(
                 Instant::DateTime(DateTime::Parse("2018-06-22 00:00:00"), Scale::UTC),
-                Instant::DateTime(DateTime::Parse("2018-06-28 00:00:00"), Scale::UTC)
+                Instant::DateTime(DateTime::Parse("2018-06-29 00:00:00"), Scale::UTC),
+                Interval::Type::HalfOpenRight
             ),
             bulletinA_.getObservationInterval()
         );
@@ -125,6 +126,31 @@ TEST_F(OpenSpaceToolkit_Physics_Coordinate_Frame_Providers_IERS_BulletinA, GetOb
 
     {
         EXPECT_ANY_THROW(BulletinA::Undefined().getObservationInterval());
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Physics_Coordinate_Frame_Providers_IERS_BulletinA, IntervalOverlap)
+{
+    const Interval observationInterval = bulletinA_.getObservationInterval();
+    const Interval predictionInterval = bulletinA_.getPredictionInterval();
+
+    {
+        EXPECT_EQ(
+            observationInterval.accessEnd(),
+            predictionInterval.accessStart()
+        );
+    }
+
+    {  
+        EXPECT_FALSE(
+            observationInterval.contains(predictionInterval.accessStart())
+        );
+    }
+
+    {
+        EXPECT_TRUE(
+            predictionInterval.contains(observationInterval.accessEnd())
+        );
     }
 }
 
@@ -211,9 +237,10 @@ TEST_F(OpenSpaceToolkit_Physics_Coordinate_Frame_Providers_IERS_BulletinA, Load)
         );
 
         EXPECT_EQ(
-            Interval::Closed(
+            Interval(
                 Instant::DateTime(DateTime::Parse("2018-06-22 00:00:00"), Scale::UTC),
-                Instant::DateTime(DateTime::Parse("2018-06-28 00:00:00"), Scale::UTC)
+                Instant::DateTime(DateTime::Parse("2018-06-29 00:00:00"), Scale::UTC),
+                Interval::Type::HalfOpenRight
             ),
             bulletinA_.getObservationInterval()
         );
@@ -264,6 +291,22 @@ TEST_F(OpenSpaceToolkit_Physics_Coordinate_Frame_Providers_IERS_BulletinA, Load)
             EXPECT_NEAR(0.00009 + (0.00009 - 0.00009) / 2.0, interpolatedObservation.yError, 1e-5);
             EXPECT_NEAR(0.067056 + (0.066865 - 0.067056) / 2.0, interpolatedObservation.ut1MinusUtc, 1e-6);
             EXPECT_NEAR(0.000031 + (0.000030 - 0.000031) / 2.0, interpolatedObservation.ut1MinusUtcError, 1e-6);
+        }
+
+        {
+            const BulletinA::Observation extrapolatedObservation =
+                bulletinA_.getObservationAt(Instant::DateTime(DateTime::Parse("2018-06-28 12:00:00"), Scale::UTC));
+
+            EXPECT_EQ(2018, extrapolatedObservation.year);
+            EXPECT_EQ(6, extrapolatedObservation.month);
+            EXPECT_EQ(28, extrapolatedObservation.day);
+            EXPECT_NEAR(58297.5, extrapolatedObservation.mjd, 1e-1);
+            EXPECT_NEAR(0.15407 + (0.15609 - 0.15407) * 1.5, extrapolatedObservation.x, 1e-5);
+            EXPECT_NEAR(0.00009 + (0.00009 - 0.00009) * 1.5, extrapolatedObservation.xError, 1e-5);
+            EXPECT_NEAR(0.43267 + (0.43164 - 0.43267) * 1.5, extrapolatedObservation.y, 1e-5);
+            EXPECT_NEAR(0.00009 + (0.00009 - 0.00009) * 1.5, extrapolatedObservation.yError, 1e-5);
+            EXPECT_NEAR(0.068107 + (0.068744 - 0.068107) * 1.5, extrapolatedObservation.ut1MinusUtc, 1e-6);
+            EXPECT_NEAR(0.000019 + (0.000018 - 0.000019) * 1.5, extrapolatedObservation.ut1MinusUtcError, 1e-6);
         }
 
         EXPECT_EQ(

--- a/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/IERS/BulletinA.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/IERS/BulletinA.test.cpp
@@ -135,22 +135,15 @@ TEST_F(OpenSpaceToolkit_Physics_Coordinate_Frame_Providers_IERS_BulletinA, Inter
     const Interval predictionInterval = bulletinA_.getPredictionInterval();
 
     {
-        EXPECT_EQ(
-            observationInterval.accessEnd(),
-            predictionInterval.accessStart()
-        );
-    }
-
-    {  
-        EXPECT_FALSE(
-            observationInterval.contains(predictionInterval.accessStart())
-        );
+        EXPECT_EQ(observationInterval.accessEnd(), predictionInterval.accessStart());
     }
 
     {
-        EXPECT_TRUE(
-            predictionInterval.contains(observationInterval.accessEnd())
-        );
+        EXPECT_FALSE(observationInterval.contains(predictionInterval.accessStart()));
+    }
+
+    {
+        EXPECT_TRUE(predictionInterval.contains(observationInterval.accessEnd()));
     }
 }
 
@@ -173,9 +166,9 @@ TEST_F(OpenSpaceToolkit_Physics_Coordinate_Frame_Providers_IERS_BulletinA, GetOb
     }
 
     {
-        EXPECT_NO_THROW(bulletinA_.getObservationAt(
-            Instant::DateTime(DateTime::Parse("2018-06-28 12:00:00"), Scale::UTC)
-        ));
+        EXPECT_NO_THROW(
+            bulletinA_.getObservationAt(Instant::DateTime(DateTime::Parse("2018-06-28 12:00:00"), Scale::UTC))
+        );
     }
 
     {

--- a/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/IERS/BulletinA.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/IERS/BulletinA.test.cpp
@@ -147,6 +147,12 @@ TEST_F(OpenSpaceToolkit_Physics_Coordinate_Frame_Providers_IERS_BulletinA, GetOb
     }
 
     {
+        EXPECT_NO_THROW(bulletinA_.getObservationAt(
+            Instant::DateTime(DateTime::Parse("2018-06-28 12:00:00"), Scale::UTC)
+        ));
+    }
+
+    {
         EXPECT_ANY_THROW(BulletinA::Undefined().getObservationAt(
             Instant::DateTime(DateTime::Parse("2018-06-29 00:00:00"), Scale::UTC)
         ));

--- a/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transform.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transform.test.cpp
@@ -251,10 +251,10 @@ INSTANTIATE_TEST_SUITE_P(
             "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_ITRF_orekit.csv",
             "ITRF",
             "",
-            0.0,   // Translation tolerance [m]
-            0.0,   // Relative velocity tolerance [m/s]
-            50.0,  // Orientation tolerance at Earth Surface [m]
-            1e-6   // Angular velocity tolerance [rad/s]
+            0.0,    // Translation tolerance [m]
+            0.0,    // Relative velocity tolerance [m/s]
+            100.0,  // Orientation tolerance at Earth Surface [m]
+            1e-6    // Angular velocity tolerance [rad/s]
         )
     )
 );

--- a/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transform.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transform.test.cpp
@@ -45,449 +45,459 @@ using ostk::physics::env::obj::celest::Earth;
 // This will test transformation translation, relative velocity, oreintation and
 // angular velocity against 3rd party generated files. The files can be found in
 // the folder 'Transforms', together with a README.md containing context.
-TEST(OpenSpaceToolkit_Physics_Coordinate_Frame_Providers_Transform, Validation)
+
+class OpenSpaceToolkit_Physics_Coordinate_Frame_Providers_Transform
+    : public ::testing::TestWithParam<Tuple<String, String, String, Real, Real, Real, Real>>
 {
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    Validation,
+    OpenSpaceToolkit_Physics_Coordinate_Frame_Providers_Transform,
+    ::testing::Values(
+        // GCRF <> TIRF (Orekit)
+        std::make_tuple(
+            "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_TIRF_orekit.csv",
+            "TIRF",
+            "",
+            0.0,    // Translation tolerance [m]
+            0.0,    // Relative velocity tolerance [m/s]
+            100.0,  // Orientation tolerance at Earth Surface [m]
+            1e-6    // Angular velocity tolerance [rad/s]
+        ),
+
+        // GCRF <> CIRF (Orekit)
+        std::make_tuple(
+            "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_CIRF_orekit.csv",
+            "CIRF",
+            "",
+            0.0,   // Translation tolerance [m]
+            0.0,   // Relative velocity tolerance [m/s]
+            1e-1,  // Orientation tolerance at Earth Surface [m]
+            1e-11  // Angular velocity tolerance [rad/s]
+        ),
+
+        // GCRF <> MOD (STK)
+        std::make_tuple(
+            "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_MOD_stk.csv",
+            "MOD",
+            "",
+            0.0,  // Translation tolerance [m]
+            0.0,  // Relative velocity tolerance [m/s]
+            2.0,  // Orientation tolerance at Earth Surface [m]
+            0.0   // Angular velocity tolerance [rad/s]
+        ),
+
+        // GCRF <> MOD (Orekit)
+        std::make_tuple(
+            "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_MOD_orekit.csv",
+            "MOD",
+            "",
+            0.0,  // Translation tolerance [m]
+            0.0,  // Relative velocity tolerance [m/s]
+            3.0,  // Orientation tolerance at Earth Surface [m]
+            0.0   // Angular velocity tolerance [rad/s]
+        ),
+
+        // GCRF <> J2000 IAU 2000A (STK)
+        std::make_tuple(
+
+            "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_J2000_stk.csv",
+            "J2000",
+            "IAU 2000A",
+            0.0,  // Translation tolerance [m]
+            0.0,  // Relative velocity tolerance [m/s]
+            1.5,  // Orientation tolerance at Earth Surface [m]
+            0.0   // Angular velocity tolerance [rad/s]
+        ),
+
+        // GCRF <> J2000 IAU 2000A (Orekit)
+        std::make_tuple(
+
+            "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_J2000_orekit.csv",
+            "J2000",
+            "IAU 2000A",
+            0.0,   // Translation tolerance [m]
+            0.0,   // Relative velocity tolerance [m/s]
+            1e-5,  // Orientation tolerance at Earth Surface [m]
+            0.0    // Angular velocity tolerance [rad/s]
+        ),
+
+        // GCRF <> J2000 IAU 2006 (STK)
+        std::make_tuple(
+
+            "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_J2000_stk.csv",
+            "J2000",
+            "IAU 2006",
+            0.0,  // Translation tolerance [m]
+            0.0,  // Relative velocity tolerance [m/s]
+            1.5,  // Orientation tolerance at Earth Surface [m]
+            0.0   // Angular velocity tolerance [rad/s]
+        ),
+
+        // GCRF <> J2000 IAU 2006 (Orekit)
+        std::make_tuple(
+
+            "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_J2000_orekit.csv",
+            "J2000",
+            "IAU 2006",
+            0.0,   // Translation tolerance [m]
+            0.0,   // Relative velocity tolerance [m/s]
+            1e-4,  // Orientation tolerance at Earth Surface [m]
+            0.0    // Angular velocity tolerance [rad/s]
+        ),
+
+        // GCRF <> TOD IAU 2000A (STK)
+        std::make_tuple(
+            "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_TOD_stk.csv",
+            "TOD",
+            "IAU 2000A",
+            0.0,  // Translation tolerance [m]
+            0.0,  // Relative velocity tolerance [m/s]
+            3.0,  // Orientation tolerance at Earth Surface [m]
+            0.0   // Angular velocity tolerance [rad/s]
+        ),
+
+        // GCRF <> TOD IAU 2000A (Orekit)
+        std::make_tuple(
+            "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_TOD_orekit.csv",
+            "TOD",
+            "IAU 2000A",
+            0.0,   // Translation tolerance [m]
+            0.0,   // Relative velocity tolerance [m/s]
+            3.0,   // Orientation tolerance at Earth Surface [m]
+            1e-10  // Angular velocity tolerance [rad/s]
+        ),
+
+        // GCRF <> TOD IAU 2000B (STK)
+        std::make_tuple(
+            "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_TOD_stk.csv",
+            "TOD",
+            "IAU 2000B",
+            0.0,  // Translation tolerance [m]
+            0.0,  // Relative velocity tolerance [m/s]
+            3.0,  // Orientation tolerance at Earth Surface [m]
+            0.0   // Angular velocity tolerance [rad/s]
+        ),
+
+        // GCRF <> TOD IAU 2000B (Orekit)
+        std::make_tuple(
+            "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_TOD_orekit.csv",
+            "TOD",
+            "IAU 2000B",
+            0.0,   // Translation tolerance [m]
+            0.0,   // Relative velocity tolerance [m/s]
+            3.0,   // Orientation tolerance at Earth Surface [m]
+            1e-10  // Angular velocity tolerance [rad/s]
+        ),
+
+        // GCRF <> TOD IAU 2006 (STK)
+        std::make_tuple(
+            "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_TOD_stk.csv",
+            "TOD",
+            "IAU 2006",
+            0.0,  // Translation tolerance [m]
+            0.0,  // Relative velocity tolerance [m/s]
+            3.0,  // Orientation tolerance at Earth Surface [m]
+            0.0   // Angular velocity tolerance [rad/s]
+        ),
+
+        // GCRF <> TOD IAU 2006 (Orekit)
+        std::make_tuple(
+            "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_TOD_orekit.csv",
+            "TOD",
+            "IAU 2006",
+            0.0,   // Translation tolerance [m]
+            0.0,   // Relative velocity tolerance [m/s]
+            3.0,   // Orientation tolerance at Earth Surface [m]
+            1e-10  // Angular velocity tolerance [rad/s]
+        ),
+
+        // GCRF <> TEME (STK)
+        std::make_tuple(
+            "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_TEME_stk.csv",
+            "TEME",
+            "",
+            0.0,   // Translation tolerance [m]
+            0.0,   // Relative velocity tolerance [m/s]
+            1.0,   // Orientation tolerance at Earth Surface [m]
+            1e-11  // Angular velocity tolerance [rad/s]
+        ),
+
+        // GCRF <> TEME (Orekit)
+        std::make_tuple(
+            "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_TEME_orekit.csv",
+            "TEME",
+            "",
+            0.0,   // Translation tolerance [m]
+            0.0,   // Relative velocity tolerance [m/s]
+            2.0,   // Orientation tolerance at Earth Surface [m]
+            1e-11  // Angular velocity tolerance [rad/s]
+        ),
+
+        // GCRF <> ITRF (STK)
+        std::make_tuple(
+            "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_ITRF_stk.csv",
+            "ITRF",
+            "",
+            0.0,    // Translation tolerance [m]
+            0.0,    // Relative velocity tolerance [m/s]
+            100.0,  // Orientation tolerance at Earth Surface [m]
+            1e-6    // Angular velocity tolerance [rad/s]
+        ),
+
+        // GCRF <> ITRF (Orekit)
+        std::make_tuple(
+            "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_ITRF_orekit.csv",
+            "ITRF",
+            "",
+            0.0,   // Translation tolerance [m]
+            0.0,   // Relative velocity tolerance [m/s]
+            50.0,  // Orientation tolerance at Earth Surface [m]
+            1e-6   // Angular velocity tolerance [rad/s]
+        )
+    )
+);
+
+TEST_P(OpenSpaceToolkit_Physics_Coordinate_Frame_Providers_Transform, Validation)
+{
+    const auto parameters = GetParam();
+    // Reference data setup
+
+    const File referenceDataFile = File::Path(Path::Parse(std::get<0>(parameters)));
+    const String frame2Str = std::get<1>(parameters);
+    const String otherStr = std::get<2>(parameters);
+    const Real translationTolerance = std::get<3>(parameters);
+    const Real velocityTolerance = std::get<4>(parameters);
+    const Real orientationToleranceAtEarthSurface = std::get<5>(parameters);
+    const Real angularVelocityTolerance = std::get<6>(parameters);
+
+    const double earthRadius = 6370000;
+    const Vector3d earthSurfaceX = earthRadius * Vector3d::X();
+    const Vector3d earthSurfaceY = earthRadius * Vector3d::Y();
+    const Vector3d earthSurfaceZ = earthRadius * Vector3d::Z();
+
+    const Table referenceData = Table::Load(referenceDataFile, Table::Format::CSV, true);
+
+    // Comparison test scenario
+    const String scenario =
+        String::Format("Frame: {} ({}) | File: {}\n", frame2Str, otherStr, referenceDataFile.toString());
+
+    for (const auto& referenceRow : referenceData)
     {
-        const Array<Tuple<File, String, String, Real, Real, Real, Real>> referenceScenarios = {
+        const Instant instant = Instant::DateTime(DateTime::Parse(referenceRow[0].accessString()), Scale::TAI);
 
-            // GCRF <> TIRF (Orekit)
-            {File::Path(Path::Parse(
-                 "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_TIRF_orekit.csv"
-             )),
-             "TIRF",
-             "",
-             0.0,    // Translation tolerance [m]
-             0.0,    // Relative velocity tolerance [m/s]
-             50.0,   // Orientation tolerance at Earth Surface [m]
-             1e-6},  // Angular velocity tolerance [rad/s]
+        Shared<const Frame> frame1 = Frame::GCRF();
+        Shared<const Frame> frame2 = Frame::GCRF();
 
-            // GCRF <> CIRF (Orekit)
-            {File::Path(Path::Parse(
-                 "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_CIRF_orekit.csv"
-             )),
-             "CIRF",
-             "",
-             0.0,     // Translation tolerance [m]
-             0.0,     // Relative velocity tolerance [m/s]
-             1e-1,    // Orientation tolerance at Earth Surface [m]
-             1e-11},  // Angular velocity tolerance [rad/s]
-
-            // GCRF <> MOD (STK)
-            {File::Path(Path::Parse(
-                 "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_MOD_stk.csv"
-             )),
-             "MOD",
-             "",
-             0.0,   // Translation tolerance [m]
-             0.0,   // Relative velocity tolerance [m/s]
-             2.0,   // Orientation tolerance at Earth Surface [m]
-             0.0},  // Angular velocity tolerance [rad/s]
-
-            // GCRF <> MOD (Orekit)
-            {File::Path(Path::Parse(
-                 "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_MOD_orekit.csv"
-             )),
-             "MOD",
-             "",
-             0.0,   // Translation tolerance [m]
-             0.0,   // Relative velocity tolerance [m/s]
-             3.0,   // Orientation tolerance at Earth Surface [m]
-             0.0},  // Angular velocity tolerance [rad/s]
-
-            // GCRF <> J2000 IAU 2000A (STK)
-            {File::Path(Path::Parse(
-                 "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_J2000_stk.csv"
-             )),
-             "J2000",
-             "IAU 2000A",
-             0.0,   // Translation tolerance [m]
-             0.0,   // Relative velocity tolerance [m/s]
-             1.5,   // Orientation tolerance at Earth Surface [m]
-             0.0},  // Angular velocity tolerance [rad/s]
-
-            // GCRF <> J2000 IAU 2000A (Orekit)
-            {File::Path(Path::Parse(
-                 "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_J2000_orekit.csv"
-             )),
-             "J2000",
-             "IAU 2000A",
-             0.0,   // Translation tolerance [m]
-             0.0,   // Relative velocity tolerance [m/s]
-             1e-5,  // Orientation tolerance at Earth Surface [m]
-             0.0},  // Angular velocity tolerance [rad/s]
-
-            // GCRF <> J2000 IAU 2006 (STK)
-            {File::Path(Path::Parse(
-                 "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_J2000_stk.csv"
-             )),
-             "J2000",
-             "IAU 2006",
-             0.0,   // Translation tolerance [m]
-             0.0,   // Relative velocity tolerance [m/s]
-             1.5,   // Orientation tolerance at Earth Surface [m]
-             0.0},  // Angular velocity tolerance [rad/s]
-
-            // GCRF <> J2000 IAU 2006 (Orekit)
-            {File::Path(Path::Parse(
-                 "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_J2000_orekit.csv"
-             )),
-             "J2000",
-             "IAU 2006",
-             0.0,   // Translation tolerance [m]
-             0.0,   // Relative velocity tolerance [m/s]
-             1e-4,  // Orientation tolerance at Earth Surface [m]
-             0.0},  // Angular velocity tolerance [rad/s]
-
-            // GCRF <> TOD IAU 2000A (STK)
-            {File::Path(Path::Parse(
-                 "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_TOD_stk.csv"
-             )),
-             "TOD",
-             "IAU 2000A",
-             0.0,   // Translation tolerance [m]
-             0.0,   // Relative velocity tolerance [m/s]
-             3.0,   // Orientation tolerance at Earth Surface [m]
-             0.0},  // Angular velocity tolerance [rad/s]
-
-            // GCRF <> TOD IAU 2000A (Orekit)
-            {File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/"
-                                    "GCRF_TOD_orekit.csv")),
-             "TOD",
-             "IAU 2000A",
-             0.0,     // Translation tolerance [m]
-             0.0,     // Relative velocity tolerance [m/s]
-             3.0,     // Orientation tolerance at Earth Surface [m]
-             1e-10},  // Angular velocity tolerance [rad/s]
-
-            // GCRF <> TOD IAU 2000B (STK)
-            {File::Path(Path::Parse(
-                 "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_TOD_stk.csv"
-             )),
-             "TOD",
-             "IAU 2000B",
-             0.0,   // Translation tolerance [m]
-             0.0,   // Relative velocity tolerance [m/s]
-             3.0,   // Orientation tolerance at Earth Surface [m]
-             0.0},  // Angular velocity tolerance [rad/s]
-
-            // GCRF <> TOD IAU 2000B (Orekit)
-            {File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/"
-                                    "GCRF_TOD_orekit.csv")),
-             "TOD",
-             "IAU 2000B",
-             0.0,     // Translation tolerance [m]
-             0.0,     // Relative velocity tolerance [m/s]
-             3.0,     // Orientation tolerance at Earth Surface [m]
-             1e-10},  // Angular velocity tolerance [rad/s]
-
-            // GCRF <> TOD IAU 2006 (STK)
-            {File::Path(Path::Parse(
-                 "/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/GCRF_TOD_stk.csv"
-             )),
-             "TOD",
-             "IAU 2006",
-             0.0,   // Translation tolerance [m]
-             0.0,   // Relative velocity tolerance [m/s]
-             3.0,   // Orientation tolerance at Earth Surface [m]
-             0.0},  // Angular velocity tolerance [rad/s]
-
-            // GCRF <> TOD IAU 2006 (Orekit)
-            {File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/"
-                                    "GCRF_TOD_orekit.csv")),
-             "TOD",
-             "IAU 2006",
-             0.0,     // Translation tolerance [m]
-             0.0,     // Relative velocity tolerance [m/s]
-             3.0,     // Orientation tolerance at Earth Surface [m]
-             1e-10},  // Angular velocity tolerance [rad/s]
-
-            // GCRF <> TEME (STK)
-            {File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/"
-                                    "GCRF_TEME_stk.csv")),
-             "TEME",
-             "",
-             0.0,     // Translation tolerance [m]
-             0.0,     // Relative velocity tolerance [m/s]
-             1.0,     // Orientation tolerance at Earth Surface [m]
-             1e-11},  // Angular velocity tolerance [rad/s]
-
-            // GCRF <> TEME (Orekit)
-            {File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/"
-                                    "GCRF_TEME_orekit.csv")),
-             "TEME",
-             "",
-             0.0,     // Translation tolerance [m]
-             0.0,     // Relative velocity tolerance [m/s]
-             2.0,     // Orientation tolerance at Earth Surface [m]
-             1e-11},  // Angular velocity tolerance [rad/s]
-
-            // GCRF <> ITRF (STK)
-            {File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/"
-                                    "GCRF_ITRF_stk.csv")),
-             "ITRF",
-             "",
-             0.0,    // Translation tolerance [m]
-             0.0,    // Relative velocity tolerance [m/s]
-             50.0,   // Orientation tolerance at Earth Surface [m]
-             1e-6},  // Angular velocity tolerance [rad/s]
-
-            // GCRF <> ITRF (Orekit)
-            {File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Physics/Coordinate/Frame/Providers/Transforms/"
-                                    "GCRF_ITRF_orekit.csv")),
-             "ITRF",
-             "",
-             0.0,    // Translation tolerance [m]
-             0.0,    // Relative velocity tolerance [m/s]
-             50.0,   // Orientation tolerance at Earth Surface [m]
-             1e-6},  // Angular velocity tolerance [rad/s]
-        };
-
-        for (const auto& referenceScenario : referenceScenarios)
+        if (frame2Str == "TOD")
         {
-            // Reference data setup
+            frame2 = Frame::TOD(instant, iau::TheoryFromString(otherStr));
+        }
+        else if (frame2Str == "TEME")
+        {
+            frame2 = Frame::TEME();
+        }
+        else if (frame2Str == "ITRF")
+        {
+            frame2 = Frame::ITRF();
+        }
+        else if (frame2Str == "J2000")
+        {
+            frame2 = Frame::J2000(iau::TheoryFromString(otherStr));
+        }
+        else if (frame2Str == "MOD")
+        {
+            frame2 = Frame::MOD(instant);
+        }
+        else if (frame2Str == "CIRF")
+        {
+            frame2 = Frame::CIRF();
+        }
+        else if (frame2Str == "TIRF")
+        {
+            frame2 = Frame::TIRF();
+        }
 
-            const File referenceDataFile = std::get<0>(referenceScenario);
-            const String frame2Str = std::get<1>(referenceScenario);
-            const String otherStr = std::get<2>(referenceScenario);
-            const Real translationTolerance = std::get<3>(referenceScenario);
-            const Real velocityTolerance = std::get<4>(referenceScenario);
-            const Real orientationToleranceAtEarthSurface = std::get<5>(referenceScenario);
-            const Real angularVelocityTolerance = std::get<6>(referenceScenario);
+        const Transform transformToFrame1 = frame2->getTransformTo(frame1, instant);
+        const Transform transformToFrame2 = frame1->getTransformTo(frame2, instant);
 
-            const double earthRadius = 6370000;
-            const Vector3d earthSurfaceX = earthRadius * Vector3d::X();
-            const Vector3d earthSurfaceY = earthRadius * Vector3d::Y();
-            const Vector3d earthSurfaceZ = earthRadius * Vector3d::Z();
+        // Instant
 
-            const Table referenceData = Table::Load(referenceDataFile, Table::Format::CSV, true);
+        {
+            EXPECT_EQ(instant, transformToFrame1.getInstant());
+            EXPECT_EQ(instant, transformToFrame2.getInstant());
+        }
 
-            // Comparison test scenario
-            const String scenario =
-                String::Format("Frame: {} ({}) | File: {}\n", frame2Str, otherStr, referenceDataFile.toString());
+        // Translation
 
-            for (const auto& referenceRow : referenceData)
-            {
-                const Instant instant = Instant::DateTime(DateTime::Parse(referenceRow[0].accessString()), Scale::TAI);
+        {
+            const Vector3d referenceToFrame2 = {
+                referenceRow[1].accessReal(), referenceRow[2].accessReal(), referenceRow[3].accessReal()};
+            const Vector3d referenceToFrame1 = -1 * referenceToFrame2;
 
-                Shared<const Frame> frame1 = Frame::GCRF();
-                Shared<const Frame> frame2 = Frame::GCRF();
+            const Vector3d toFrame2 = transformToFrame2.getTranslation();
+            const Vector3d toFrame1 = transformToFrame1.getTranslation();
 
-                if (frame2Str == "TOD")
-                {
-                    frame2 = Frame::TOD(instant, iau::TheoryFromString(otherStr));
-                }
-                else if (frame2Str == "TEME")
-                {
-                    frame2 = Frame::TEME();
-                }
-                else if (frame2Str == "ITRF")
-                {
-                    frame2 = Frame::ITRF();
-                }
-                else if (frame2Str == "J2000")
-                {
-                    frame2 = Frame::J2000(iau::TheoryFromString(otherStr));
-                }
-                else if (frame2Str == "MOD")
-                {
-                    frame2 = Frame::MOD(instant);
-                }
-                else if (frame2Str == "CIRF")
-                {
-                    frame2 = Frame::CIRF();
-                }
-                else if (frame2Str == "TIRF")
-                {
-                    frame2 = Frame::TIRF();
-                }
+            ASSERT_TRUE(referenceToFrame2.isNear(toFrame2, translationTolerance)) << String::Format(
+                "{} @ {} Translation: {} [m] vs. {} [m] above {} [m] tolerance",
+                scenario,
+                instant.toString(Scale::TAI),
+                referenceToFrame2.toString(),
+                toFrame2.toString(),
+                translationTolerance.toString()
+            );
 
-                const Transform transformToFrame1 = frame2->getTransformTo(frame1, instant);
-                const Transform transformToFrame2 = frame1->getTransformTo(frame2, instant);
+            ASSERT_TRUE(referenceToFrame1.isNear(toFrame1, translationTolerance)) << String::Format(
+                "{} @ {} Translation: {} [m] vs. {} [m] above {} [m] tolerance",
+                scenario,
+                instant.toString(Scale::TAI),
+                referenceToFrame1.toString(),
+                toFrame1.toString(),
+                translationTolerance.toString()
+            );
+        }
 
-                // Instant
+        // Relative velocity
 
-                {
-                    EXPECT_EQ(instant, transformToFrame1.getInstant());
-                    EXPECT_EQ(instant, transformToFrame2.getInstant());
-                }
+        {
+            const Vector3d referenceToFrame2 = {
+                referenceRow[4].accessReal(), referenceRow[5].accessReal(), referenceRow[6].accessReal()};
+            const Vector3d referenceToFrame1 = -1 * referenceToFrame2;
 
-                // Translation
+            const Vector3d toFrame2 = transformToFrame2.getVelocity();
+            const Vector3d toFrame1 = transformToFrame1.getVelocity();
 
-                {
-                    const Vector3d referenceToFrame2 = {
-                        referenceRow[1].accessReal(), referenceRow[2].accessReal(), referenceRow[3].accessReal()};
-                    const Vector3d referenceToFrame1 = -1 * referenceToFrame2;
+            ASSERT_TRUE(referenceToFrame2.isNear(toFrame2, velocityTolerance)) << String::Format(
+                "{} @ {} Velocity: {} [m/s] vs. {} [m/s] above {} [m/s] tolerance",
+                scenario,
+                instant.toString(Scale::TAI),
+                referenceToFrame2.toString(),
+                toFrame2.toString(),
+                velocityTolerance.toString()
+            );
 
-                    const Vector3d toFrame2 = transformToFrame2.getTranslation();
-                    const Vector3d toFrame1 = transformToFrame1.getTranslation();
+            ASSERT_TRUE(referenceToFrame1.isNear(toFrame1, velocityTolerance)) << String::Format(
+                "{} @ {} Velocity: {} [m/s] vs. {} [m/s] above {} [m/s] tolerance",
+                scenario,
+                instant.toString(Scale::TAI),
+                referenceToFrame1.toString(),
+                toFrame1.toString(),
+                velocityTolerance.toString()
+            );
+        }
 
-                    ASSERT_TRUE(referenceToFrame2.isNear(toFrame2, translationTolerance)) << String::Format(
-                        "{} @ {} Translation: {} [m] vs. {} [m] above {} [m] tolerance",
-                        scenario,
-                        instant.toString(Scale::TAI),
-                        referenceToFrame2.toString(),
-                        toFrame2.toString(),
-                        translationTolerance.toString()
-                    );
+        // Relative orientation
 
-                    ASSERT_TRUE(referenceToFrame1.isNear(toFrame1, translationTolerance)) << String::Format(
-                        "{} @ {} Translation: {} [m] vs. {} [m] above {} [m] tolerance",
-                        scenario,
-                        instant.toString(Scale::TAI),
-                        referenceToFrame1.toString(),
-                        toFrame1.toString(),
-                        translationTolerance.toString()
-                    );
-                }
+        {
+            const Quaternion referenceOrientationToFrame2 = Quaternion::XYZS(
+                                                                referenceRow[7].accessReal(),
+                                                                referenceRow[8].accessReal(),
+                                                                referenceRow[9].accessReal(),
+                                                                referenceRow[10].accessReal()
+            )
+                                                                .normalize();
 
-                // Relative velocity
+            // Orientation to Frame 2
+            const Vector3d referenceToFrame2X = referenceOrientationToFrame2 * earthSurfaceX;
+            const Vector3d toFrame2X = transformToFrame2.applyToVector(earthSurfaceX);
+            const Vector3d referenceToFrame2Y = referenceOrientationToFrame2 * earthSurfaceY;
+            const Vector3d toFrame2Y = transformToFrame2.applyToVector(earthSurfaceY);
+            const Vector3d referenceToFrame2Z = referenceOrientationToFrame2 * earthSurfaceZ;
+            const Vector3d toFrame2Z = transformToFrame2.applyToVector(earthSurfaceZ);
 
-                {
-                    const Vector3d referenceToFrame2 = {
-                        referenceRow[4].accessReal(), referenceRow[5].accessReal(), referenceRow[6].accessReal()};
-                    const Vector3d referenceToFrame1 = -1 * referenceToFrame2;
+            ASSERT_TRUE(referenceToFrame2X.isNear(toFrame2X, orientationToleranceAtEarthSurface)) << String::Format(
+                "{} @ {} Orientation at Earth Surface +X: {} [m] vs. {} [m] above {} [m] tolerance",
+                scenario,
+                instant.toString(Scale::TAI),
+                referenceToFrame2X.toString(),
+                toFrame2X.toString(),
+                orientationToleranceAtEarthSurface.toString()
+            );
 
-                    const Vector3d toFrame2 = transformToFrame2.getVelocity();
-                    const Vector3d toFrame1 = transformToFrame1.getVelocity();
+            ASSERT_TRUE(referenceToFrame2Y.isNear(toFrame2Y, orientationToleranceAtEarthSurface)) << String::Format(
+                "{} @ {} Orientation at Earth Surface +Y: {} [m] vs. {} [m] above {} [m] tolerance",
+                scenario,
+                instant.toString(Scale::TAI),
+                referenceToFrame2Y.toString(),
+                toFrame2Y.toString(),
+                orientationToleranceAtEarthSurface.toString()
+            );
 
-                    ASSERT_TRUE(referenceToFrame2.isNear(toFrame2, velocityTolerance)) << String::Format(
-                        "{} @ {} Velocity: {} [m/s] vs. {} [m/s] above {} [m/s] tolerance",
-                        scenario,
-                        instant.toString(Scale::TAI),
-                        referenceToFrame2.toString(),
-                        toFrame2.toString(),
-                        velocityTolerance.toString()
-                    );
+            ASSERT_TRUE(referenceToFrame2Z.isNear(toFrame2Z, orientationToleranceAtEarthSurface)) << String::Format(
+                "{} @ {} Orientation at Earth Surface +Z: {} [m] vs. {} [m] above {} [m] tolerance",
+                scenario,
+                instant.toString(Scale::TAI),
+                referenceToFrame2Z.toString(),
+                toFrame2Z.toString(),
+                orientationToleranceAtEarthSurface.toString()
+            );
 
-                    ASSERT_TRUE(referenceToFrame1.isNear(toFrame1, velocityTolerance)) << String::Format(
-                        "{} @ {} Velocity: {} [m/s] vs. {} [m/s] above {} [m/s] tolerance",
-                        scenario,
-                        instant.toString(Scale::TAI),
-                        referenceToFrame1.toString(),
-                        toFrame1.toString(),
-                        velocityTolerance.toString()
-                    );
-                }
+            // Orientation to Frame 1
+            const Quaternion referenceOrientationToFrame1 = referenceOrientationToFrame2.toConjugate();
 
-                // Relative orientation
+            const Vector3d referenceToFrame1X = referenceOrientationToFrame1 * earthSurfaceX;
+            const Vector3d toFrame1X = transformToFrame1.applyToVector(earthSurfaceX);
+            const Vector3d referenceToFrame1Y = referenceOrientationToFrame1 * earthSurfaceY;
+            const Vector3d toFrame1Y = transformToFrame1.applyToVector(earthSurfaceY);
+            const Vector3d referenceToFrame1Z = referenceOrientationToFrame1 * earthSurfaceZ;
+            const Vector3d toFrame1Z = transformToFrame1.applyToVector(earthSurfaceZ);
 
-                {
-                    const Quaternion referenceOrientationToFrame2 = Quaternion::XYZS(
-                                                                        referenceRow[7].accessReal(),
-                                                                        referenceRow[8].accessReal(),
-                                                                        referenceRow[9].accessReal(),
-                                                                        referenceRow[10].accessReal()
-                    )
-                                                                        .normalize();
+            ASSERT_TRUE(referenceToFrame1X.isNear(toFrame1X, orientationToleranceAtEarthSurface)) << String::Format(
+                "{} @ {} Orientation at Earth Surface +X: {} [m] vs. {} [m] above {} [m] tolerance",
+                scenario,
+                instant.toString(Scale::TAI),
+                referenceToFrame1X.toString(),
+                toFrame1X.toString(),
+                orientationToleranceAtEarthSurface.toString()
+            );
 
-                    // Orientation to Frame 2
-                    const Vector3d referenceToFrame2X = referenceOrientationToFrame2 * earthSurfaceX;
-                    const Vector3d toFrame2X = transformToFrame2.applyToVector(earthSurfaceX);
-                    const Vector3d referenceToFrame2Y = referenceOrientationToFrame2 * earthSurfaceY;
-                    const Vector3d toFrame2Y = transformToFrame2.applyToVector(earthSurfaceY);
-                    const Vector3d referenceToFrame2Z = referenceOrientationToFrame2 * earthSurfaceZ;
-                    const Vector3d toFrame2Z = transformToFrame2.applyToVector(earthSurfaceZ);
+            ASSERT_TRUE(referenceToFrame1Y.isNear(toFrame1Y, orientationToleranceAtEarthSurface)) << String::Format(
+                "{} @ {} Orientation at Earth Surface +Y: {} [m] vs. {} [m] above {} [m] tolerance",
+                scenario,
+                instant.toString(Scale::TAI),
+                referenceToFrame1Y.toString(),
+                toFrame1Y.toString(),
+                orientationToleranceAtEarthSurface.toString()
+            );
 
-                    ASSERT_TRUE(referenceToFrame2X.isNear(toFrame2X, orientationToleranceAtEarthSurface))
-                        << String::Format(
-                               "{} @ {} Orientation at Earth Surface +X: {} [m] vs. {} [m] above {} [m] tolerance",
-                               scenario,
-                               instant.toString(Scale::TAI),
-                               referenceToFrame2X.toString(),
-                               toFrame2X.toString(),
-                               orientationToleranceAtEarthSurface.toString()
-                           );
+            ASSERT_TRUE(referenceToFrame1Z.isNear(toFrame1Z, orientationToleranceAtEarthSurface)) << String::Format(
+                "{} @ {} Orientation at Earth Surface +Z: {} [m] vs. {} [m] above {} [m] tolerance",
+                scenario,
+                instant.toString(Scale::TAI),
+                referenceToFrame1Z.toString(),
+                toFrame1Z.toString(),
+                orientationToleranceAtEarthSurface.toString()
+            );
+        }
 
-                    ASSERT_TRUE(referenceToFrame2Y.isNear(toFrame2Y, orientationToleranceAtEarthSurface))
-                        << String::Format(
-                               "{} @ {} Orientation at Earth Surface +Y: {} [m] vs. {} [m] above {} [m] tolerance",
-                               scenario,
-                               instant.toString(Scale::TAI),
-                               referenceToFrame2Y.toString(),
-                               toFrame2Y.toString(),
-                               orientationToleranceAtEarthSurface.toString()
-                           );
+        // Relative angular velocity
 
-                    ASSERT_TRUE(referenceToFrame2Z.isNear(toFrame2Z, orientationToleranceAtEarthSurface))
-                        << String::Format(
-                               "{} @ {} Orientation at Earth Surface +Z: {} [m] vs. {} [m] above {} [m] tolerance",
-                               scenario,
-                               instant.toString(Scale::TAI),
-                               referenceToFrame2Z.toString(),
-                               toFrame2Z.toString(),
-                               orientationToleranceAtEarthSurface.toString()
-                           );
+        {
+            const Vector3d referenceToFrame2 = {
+                referenceRow[11].accessReal(), referenceRow[12].accessReal(), referenceRow[13].accessReal()};
+            const Vector3d referenceToFrame1 = -1 * referenceToFrame2;
 
-                    // Orientation to Frame 1
-                    const Quaternion referenceOrientationToFrame1 = referenceOrientationToFrame2.toConjugate();
+            const Vector3d toFrame2 = transformToFrame2.getAngularVelocity();
+            const Vector3d toFrame1 = transformToFrame1.getAngularVelocity();
 
-                    const Vector3d referenceToFrame1X = referenceOrientationToFrame1 * earthSurfaceX;
-                    const Vector3d toFrame1X = transformToFrame1.applyToVector(earthSurfaceX);
-                    const Vector3d referenceToFrame1Y = referenceOrientationToFrame1 * earthSurfaceY;
-                    const Vector3d toFrame1Y = transformToFrame1.applyToVector(earthSurfaceY);
-                    const Vector3d referenceToFrame1Z = referenceOrientationToFrame1 * earthSurfaceZ;
-                    const Vector3d toFrame1Z = transformToFrame1.applyToVector(earthSurfaceZ);
+            ASSERT_TRUE(referenceToFrame2.isNear(toFrame2, angularVelocityTolerance)) << String::Format(
+                "{} @ {} Angular Velocity: {} [rad/s] vs. {} [rad/s] above {} [rad/s] tolerance",
+                scenario,
+                instant.toString(Scale::TAI),
+                referenceToFrame2.toString(),
+                toFrame2.toString(),
+                angularVelocityTolerance.toString()
+            );
 
-                    ASSERT_TRUE(referenceToFrame1X.isNear(toFrame1X, orientationToleranceAtEarthSurface))
-                        << String::Format(
-                               "{} @ {} Orientation at Earth Surface +X: {} [m] vs. {} [m] above {} [m] tolerance",
-                               scenario,
-                               instant.toString(Scale::TAI),
-                               referenceToFrame1X.toString(),
-                               toFrame1X.toString(),
-                               orientationToleranceAtEarthSurface.toString()
-                           );
-
-                    ASSERT_TRUE(referenceToFrame1Y.isNear(toFrame1Y, orientationToleranceAtEarthSurface))
-                        << String::Format(
-                               "{} @ {} Orientation at Earth Surface +Y: {} [m] vs. {} [m] above {} [m] tolerance",
-                               scenario,
-                               instant.toString(Scale::TAI),
-                               referenceToFrame1Y.toString(),
-                               toFrame1Y.toString(),
-                               orientationToleranceAtEarthSurface.toString()
-                           );
-
-                    ASSERT_TRUE(referenceToFrame1Z.isNear(toFrame1Z, orientationToleranceAtEarthSurface))
-                        << String::Format(
-                               "{} @ {} Orientation at Earth Surface +Z: {} [m] vs. {} [m] above {} [m] tolerance",
-                               scenario,
-                               instant.toString(Scale::TAI),
-                               referenceToFrame1Z.toString(),
-                               toFrame1Z.toString(),
-                               orientationToleranceAtEarthSurface.toString()
-                           );
-                }
-
-                // Relative angular velocity
-
-                {
-                    const Vector3d referenceToFrame2 = {
-                        referenceRow[11].accessReal(), referenceRow[12].accessReal(), referenceRow[13].accessReal()};
-                    const Vector3d referenceToFrame1 = -1 * referenceToFrame2;
-
-                    const Vector3d toFrame2 = transformToFrame2.getAngularVelocity();
-                    const Vector3d toFrame1 = transformToFrame1.getAngularVelocity();
-
-                    ASSERT_TRUE(referenceToFrame2.isNear(toFrame2, angularVelocityTolerance)) << String::Format(
-                        "{} @ {} Angular Velocity: {} [rad/s] vs. {} [rad/s] above {} [rad/s] tolerance",
-                        scenario,
-                        instant.toString(Scale::TAI),
-                        referenceToFrame2.toString(),
-                        toFrame2.toString(),
-                        angularVelocityTolerance.toString()
-                    );
-
-                    ASSERT_TRUE(referenceToFrame1.isNear(toFrame1, angularVelocityTolerance)) << String::Format(
-                        "{} @ {} Angular Velocity: {} [rad/s] vs. {} [rad/s] above {} [rad/s] tolerance",
-                        scenario,
-                        instant.toString(Scale::TAI),
-                        referenceToFrame1.toString(),
-                        toFrame1.toString(),
-                        angularVelocityTolerance.toString()
-                    );
-                }
-            }
+            ASSERT_TRUE(referenceToFrame1.isNear(toFrame1, angularVelocityTolerance)) << String::Format(
+                "{} @ {} Angular Velocity: {} [rad/s] vs. {} [rad/s] above {} [rad/s] tolerance",
+                scenario,
+                instant.toString(Scale::TAI),
+                referenceToFrame1.toString(),
+                toFrame1.toString(),
+                angularVelocityTolerance.toString()
+            );
         }
     }
 }


### PR DESCRIPTION
The bulletin A file defines about a week's worth of observations for reference frame data. It then defines months of predictive data. So we have:
```
   23  7 21  60146 0.23587 .00009 0.49114 .00009 -0.020431 0.000012          
   [other observations]...       
   23  7 27  60152 0.24985 .00009 0.48239 .00009 -0.018731 0.000014 
  ---------
   2023  7 28  60153       0.2522      0.4808     -0.01819         
   2023  7 29  60154       0.2545      0.4792     -0.01744
   [other predictions]...
   2024  7 26  60517       0.1872      0.4533      0.00902
```

When we load the Bulletin A files, we record the interval associated with each. Which is:
```
[2023-07-21 00:00:00 - 2023-07-27 00:00:00]
[2023-07-28 00:00:00 - 2024-07-26 00:00:00]
```

This causes a 1-day gap in Bulletin A data. A point at `2023-07-27 12:00:00` is neither in the observation nor prediction interval.

I believe this is why the test in Physics that tries to grab data from 8 days ago can periodically fail. It does so whenever we are 8 days past that gap but IERS has not yet released a new bulletin.

This MR fixes the gap by:
- Changing the observation Interval to be open on the right side, and extending it by 1 day such that it capture all points in the last day.
- Using linear extrapolation for points that land in the gap between observation and predictions.