### PR TITLE
chore: suggestions to propagate the ephemerides->ephemeris change

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The library exhibits the following structure:
     ├── Constants
     ├── Object
     │   └── Celestial
-    ├── Ephemerides
+    ├── Ephemeris
     │   ├── Analytical
     │   ├── Tabulated
     │   └── SPICE (JPL)
@@ -186,8 +186,8 @@ The following table shows the availabe data source settings:
 | `OSTK_PHYSICS_COORDINATE_FRAME_PROVIDERS_IERS_MANAGER_MODE`                          | `Automatic`                                                              |
 | `OSTK_PHYSICS_COORDINATE_FRAME_PROVIDERS_IERS_MANAGER_LOCAL_REPOSITORY`              | `./.open-space-toolkit/physics/data/coordinate/frame/providers/iers`          |
 | `OSTK_PHYSICS_COORDINATE_FRAME_PROVIDERS_IERS_MANAGER_LOCAL_REPOSITORY_LOCK_TIMEOUT` | `60`                                                                     |
-| `OSTK_PHYSICS_ENVIRONMENT_EPHEMERIDES_SPICE_ENGINE_MODE`                             | `Automatic`                                                              |
-| `OSTK_PHYSICS_ENVIRONMENT_EPHEMERIDES_SPICE_MANAGER_LOCAL_REPOSITORY`                | `./.open-space-toolkit/physics/data/environment/ephemerides/spice`            |
+| `OSTK_PHYSICS_ENVIRONMENT_EPHEMERIS_SPICE_ENGINE_MODE`                             | `Automatic`                                                              |
+| `OSTK_PHYSICS_ENVIRONMENT_EPHEMERIS_SPICE_MANAGER_LOCAL_REPOSITORY`                | `./.open-space-toolkit/physics/data/environment/ephemeris/spice`            |
 | `OSTK_PHYSICS_ENVIRONMENT_GRAVITATIONAL_EARTH_MANAGER_MODE`                          | `Automatic`                                                                  |
 | `OSTK_PHYSICS_ENVIRONMENT_GRAVITATIONAL_EARTH_MANAGER_LOCAL_REPOSITORY`              | `./.open-space-toolkit/physics/data/environment/gravitational/earth`          |
 | `OSTK_PHYSICS_ENVIRONMENT_GRAVITATIONAL_EARTH_MANAGER_LOCAL_REPOSITORY_LOCK_TIMEOUT` | `60`                                                                        |

--- a/include/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Engine.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Engine.hpp
@@ -22,7 +22,7 @@
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Interval.hpp>
 
-#define OSTK_PHYSICS_ENVIRONMENT_EPHEMERIDES_SPICE_ENGINE_MODE Engine::Mode::Automatic
+#define OSTK_PHYSICS_ENVIRONMENT_EPHEMERIS_SPICE_ENGINE_MODE Engine::Mode::Automatic
 
 namespace ostk
 {
@@ -55,7 +55,7 @@ using ostk::physics::environment::ephemeris::spice::Kernel;
 ///
 ///                             The following environment variables can be defined:
 ///
-///                             - "OSTK_PHYSICS_ENVIRONMENT_EPHEMERIDES_SPICE_ENGINE_MODE" will override "DefaultMode"
+///                             - "OSTK_PHYSICS_ENVIRONMENT_EPHEMERIS_SPICE_ENGINE_MODE" will override "DefaultMode"
 
 class Engine
 {
@@ -113,7 +113,7 @@ class Engine
 
     /// @brief              Get default engine mode
     ///
-    ///                     Overriden by: OSTK_PHYSICS_ENVIRONMENT_EPHEMERIDES_SPICE_ENGINE_MODE
+    ///                     Overriden by: OSTK_PHYSICS_ENVIRONMENT_EPHEMERIS_SPICE_ENGINE_MODE
     ///
     /// @return             Default engine mode
 

--- a/include/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Manager.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Manager.hpp
@@ -21,8 +21,8 @@
 #include <OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Kernel.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 
-#define OSTK_PHYSICS_ENVIRONMENT_EPHEMERIDES_SPICE_MANAGER_LOCAL_REPOSITORY \
-    "./.open-space-toolkit/physics/data/environment/ephemerides/spice"
+#define OSTK_PHYSICS_ENVIRONMENT_EPHEMERIS_SPICE_MANAGER_LOCAL_REPOSITORY \
+    "./.open-space-toolkit/physics/data/environment/ephemeris/spice"
 
 namespace ostk
 {
@@ -55,7 +55,7 @@ using ManifestManager = ostk::physics::data::Manager;
 ///
 ///                             The following environment variables can be defined:
 ///
-///                             - "OSTK_PHYSICS_ENVIRONMENT_EPHEMERIDES_SPICE_MANAGER_LOCAL_REPOSITORY" will override
+///                             - "OSTK_PHYSICS_ENVIRONMENT_EPHEMERIS_SPICE_MANAGER_LOCAL_REPOSITORY" will override
 ///                             "DefaultLocalRepository"
 
 class Manager
@@ -89,7 +89,7 @@ class Manager
 
     /// @brief              Get default local repository
     ///
-    ///                     Overriden by: OSTK_PHYSICS_ENVIRONMENT_EPHEMERIDES_SPICE_MANAGER_LOCAL_REPOSITORY
+    ///                     Overriden by: OSTK_PHYSICS_ENVIRONMENT_EPHEMERIS_SPICE_MANAGER_LOCAL_REPOSITORY
     ///
     /// @return             Default local repository
 

--- a/src/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Engine.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Engine.cpp
@@ -203,9 +203,9 @@ Engine& Engine::Get()
 
 Engine::Mode Engine::DefaultMode()
 {
-    static const Engine::Mode defaultMode = OSTK_PHYSICS_ENVIRONMENT_EPHEMERIDES_SPICE_ENGINE_MODE;
+    static const Engine::Mode defaultMode = OSTK_PHYSICS_ENVIRONMENT_EPHEMERIS_SPICE_ENGINE_MODE;
 
-    if (const char* modeString = std::getenv("OSTK_PHYSICS_ENVIRONMENT_EPHEMERIDES_SPICE_ENGINE_MODE"))
+    if (const char* modeString = std::getenv("OSTK_PHYSICS_ENVIRONMENT_EPHEMERIS_SPICE_ENGINE_MODE"))
     {
         if (strcmp(modeString, "Manual") == 0)
         {

--- a/src/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Manager.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Manager.cpp
@@ -69,16 +69,16 @@ void Manager::setLocalRepository(const Directory& aDirectory)
 Directory Manager::DefaultLocalRepository()
 {
     static const Directory defaultLocalRepository =
-        Directory::Path(Path::Parse(OSTK_PHYSICS_ENVIRONMENT_EPHEMERIDES_SPICE_MANAGER_LOCAL_REPOSITORY));
+        Directory::Path(Path::Parse(OSTK_PHYSICS_ENVIRONMENT_EPHEMERIS_SPICE_MANAGER_LOCAL_REPOSITORY));
 
     if (const char* localRepositoryPath =
-            std::getenv("OSTK_PHYSICS_ENVIRONMENT_EPHEMERIDES_SPICE_MANAGER_LOCAL_REPOSITORY"))
+            std::getenv("OSTK_PHYSICS_ENVIRONMENT_EPHEMERIS_SPICE_MANAGER_LOCAL_REPOSITORY"))
     {
         return Directory::Path(Path::Parse(localRepositoryPath));
     }
     else if (const char* dataPath = std::getenv("OSTK_PHYSICS_DATA_LOCAL_REPOSITORY"))
     {
-        return Directory::Path(Path::Parse(dataPath) + Path::Parse("environment/ephemerides/spice"));
+        return Directory::Path(Path::Parse(dataPath) + Path::Parse("environment/ephemeris/spice"));
     }
 
     return defaultLocalRepository;

--- a/test/OpenSpaceToolkit/Physics/Environment/Ephemerides/SPICE/AccessFrame/Scenario_1/Scenario_1 STK ScenarioWB.wsp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Ephemerides/SPICE/AccessFrame/Scenario_1/Scenario_1 STK ScenarioWB.wsp
@@ -24,7 +24,7 @@ ptn_Child7=Document-6
 [WorkState_v1_2.Frames.ChildFrames.Document-0]
 ptn_Child1=ViewFrame-0
 [WorkState_v1_2.Frames.ChildFrames.Document-0.ViewFrame-0]
-DocPathName=Z:\Projects\Engineering\open-space-collective\open-space-toolkit-physics\test\OpenSpaceToolkit\Physics\Environment\Ephemerides\SPICE\AccessFrame\AgUi3DGfxView11.AgUiPi3DGfxView.1
+DocPathName=Z:\Projects\Engineering\open-space-collective\open-space-toolkit-physics\test\OpenSpaceToolkit\Physics\Environment\Ephemeris\SPICE\AccessFrame\AgUi3DGfxView11.AgUiPi3DGfxView.1
 DocumentString=AgUi3DGfxView.AgUiPi3DGfxView.1
 DocTemplateIndex=0
 WindowPlacement=MCAAAAAAAAAAAAAABAAAAAAAPPPPPPPPPPPPPPPPGPPPPPPPPNPPPPPPBAAAAAAABAAAAAAAMCCAAAAALMBAAAAA
@@ -37,7 +37,7 @@ SceneType=1
 [WorkState_v1_2.Frames.ChildFrames.Document-1]
 ptn_Child1=ViewFrame-0
 [WorkState_v1_2.Frames.ChildFrames.Document-1.ViewFrame-0]
-DocPathName=Z:\Projects\Engineering\open-space-collective\open-space-toolkit-physics\test\OpenSpaceToolkit\Physics\Environment\Ephemerides\SPICE\AccessFrame\AgUi2DGfxView11.AgUiPi2DGfxView.1
+DocPathName=Z:\Projects\Engineering\open-space-collective\open-space-toolkit-physics\test\OpenSpaceToolkit\Physics\Environment\Ephemeris\SPICE\AccessFrame\AgUi2DGfxView11.AgUiPi2DGfxView.1
 DocumentString=AgUi2DGfxView.AgUiPi2DGfxView.1
 DocTemplateIndex=0
 WindowPlacement=MCAAAAAAAAAAAAAABAAAAAAAPPPPPPPPPPPPPPPPIPPPPPPPBOPPPPPPOCCAAAAABAAAAAAAEFEAAAAAOEBAAAAA
@@ -49,7 +49,7 @@ MapID=1
 [WorkState_v1_2.Frames.ChildFrames.Document-2]
 ptn_Child1=ViewFrame-0
 [WorkState_v1_2.Frames.ChildFrames.Document-2.ViewFrame-0]
-DocPathName=Z:\Projects\Engineering\open-space-collective\open-space-toolkit-physics\test\OpenSpaceToolkit\Physics\Environment\Ephemerides\SPICE\AccessFrame\AgUiAttrBrowser11.AgUiPiAttrBrowser.1
+DocPathName=Z:\Projects\Engineering\open-space-collective\open-space-toolkit-physics\test\OpenSpaceToolkit\Physics\Environment\Ephemeris\SPICE\AccessFrame\AgUiAttrBrowser11.AgUiPiAttrBrowser.1
 DocumentString=AgUiAttrBrowser.AgUiPiAttrBrowser.1
 DocTemplateIndex=0
 WindowPlacement=MCAAAAAAAAAAAAAABAAAAAAAPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPAAAAAAAAAAAAAAAALNAAAAAAABEAAAAA
@@ -60,7 +60,7 @@ ptn_Child1=AGI Custom Node Data
 [WorkState_v1_2.Frames.ChildFrames.Document-5]
 ptn_Child1=ViewFrame-0
 [WorkState_v1_2.Frames.ChildFrames.Document-5.ViewFrame-0]
-DocPathName=Z:\Projects\Engineering\open-space-collective\open-space-toolkit-physics\test\OpenSpaceToolkit\Physics\Environment\Ephemerides\SPICE\AccessFrame\AgUiTimelineView11.AgUiPiTimelineView.1
+DocPathName=Z:\Projects\Engineering\open-space-collective\open-space-toolkit-physics\test\OpenSpaceToolkit\Physics\Environment\Ephemeris\SPICE\AccessFrame\AgUiTimelineView11.AgUiPiTimelineView.1
 DocumentString=AgUiTimelineView.AgUiPiTimelineView.1
 DocTemplateIndex=0
 WindowPlacement=MCAAAAAAAAAAAAAABAAAAAAAPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPAAAAAAAAAAAAAAAAAAKAAAAAOJAAAAAA

--- a/test/OpenSpaceToolkit/Physics/Environment/Ephemerides/SPICE/Manager.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Ephemerides/SPICE/Manager.test.cpp
@@ -70,7 +70,7 @@ class OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Manager : public ::te
 
     Manager& manager_ = Manager::Get();
 
-    const char* localRepositoryVarName_ = "OSTK_PHYSICS_ENVIRONMENT_EPHEMERIDES_SPICE_MANAGER_LOCAL_REPOSITORY";
+    const char* localRepositoryVarName_ = "OSTK_PHYSICS_ENVIRONMENT_EPHEMERIS_SPICE_MANAGER_LOCAL_REPOSITORY";
     const char* fullDataVarName_ = "OSTK_PHYSICS_DATA_LOCAL_REPOSITORY";
 
     char* localRepositoryPath;
@@ -94,7 +94,7 @@ TEST_F(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Manager, SetLocalRep
         EXPECT_EQ("tmp", manager_.getLocalRepository().getName());
 
         manager_.setLocalRepository(
-            Directory::Path(Path::Parse("./.open-space-toolkit/physics/environment/ephemerides/spice"))
+            Directory::Path(Path::Parse("./.open-space-toolkit/physics/environment/ephemeris/spice"))
         );
 
         EXPECT_EQ("spice", manager_.getLocalRepository().getName());
@@ -111,7 +111,7 @@ TEST_F(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Manager, DefaultLoca
 
         EXPECT_EQ(
             Manager::DefaultLocalRepository(),
-            Directory::Path(Path::Parse("./.open-space-toolkit/physics/data/environment/ephemerides/spice"))
+            Directory::Path(Path::Parse("./.open-space-toolkit/physics/data/environment/ephemeris/spice"))
         );
     }
 
@@ -122,7 +122,7 @@ TEST_F(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Manager, DefaultLoca
         setenv(fullDataVarName_, "/tmp", true);
 
         EXPECT_EQ(
-            Manager::DefaultLocalRepository(), Directory::Path(Path::Parse("/tmp/environment/ephemerides/spice"))
+            Manager::DefaultLocalRepository(), Directory::Path(Path::Parse("/tmp/environment/ephemeris/spice"))
         );
     }
 
@@ -141,7 +141,7 @@ TEST_F(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Manager, FetchKernel
 {
     // make subdir for test
     manager_.setLocalRepository(Directory::Path(
-        Path::Parse("/app/.open-space-toolkit/physics/environment/ephemerides/spice/") + Path::Parse("FetchKernelTest/")
+        Path::Parse("/app/.open-space-toolkit/physics/environment/ephemeris/spice/") + Path::Parse("FetchKernelTest/")
     ));
     manager_.getLocalRepository().create();
 
@@ -167,7 +167,7 @@ TEST_F(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Manager, FetchMatchi
 {
     // make subdir for test
     manager_.setLocalRepository(Directory::Path(
-        Path::Parse("/app/.open-space-toolkit/physics/environment/ephemerides/spice/") +
+        Path::Parse("/app/.open-space-toolkit/physics/environment/ephemeris/spice/") +
         Path::Parse("FetchMatchingKernelsTest/")
     ));
     if (manager_.getLocalRepository().exists())
@@ -194,7 +194,7 @@ TEST_F(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Manager, FindKernel)
 {
     // make subdir for test
     manager_.setLocalRepository(Directory::Path(
-        Path::Parse("/app/.open-space-toolkit/physics/environment/ephemerides/spice/") + Path::Parse("FindKernelTest/")
+        Path::Parse("/app/.open-space-toolkit/physics/environment/ephemeris/spice/") + Path::Parse("FindKernelTest/")
     ));
     if (manager_.getLocalRepository().exists())
     {


### PR DESCRIPTION
This changes the name of the Data environment variables (which I would be surprised if anyone used) and the _local_ storage place for files.

It does not change the place on the remote where it looks for data. That change does not break the interface, so I'll do it in a separate MR.