### PR TITLE
feat: use OSTk Data V1 API to align file locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,9 @@ The library exhibits the following structure:
 </details>
 
 ## Data Management
+
 OSTk Physics uses input data from various sources to determine the state of the space environment at any given time. The following input data is used:
+
 - IERS Reference Frame Data
 - CSSI Solar Flux/Space Weather Data
 - Gravitational Survey Data
@@ -180,27 +182,27 @@ OSTk Physics uses input data from various sources to determine the state of the 
 None of these files are shipped with the source code of this library. OSTk Physics has the capability to fetch the required files at runtime if they are not present or if they are outdated. This is done using file Manager classes (see any file named `Manager.hpp`). Data for any use-case is queried through the Manager class rather than directly, which allows the Manager to handle file loading and fetching.
 
 The following table shows the availabe data source settings:
-| Environment Variable                                                                 | Default Value                                                            |
-| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
-| `OSTK_PHYSICS_DATA_LOCAL_REPOSITORY`                                                 | `./.open-space-toolkit/physics/data` [Bulk setting. Overridden by specific repository settings below.] |
-| `OSTK_PHYSICS_COORDINATE_FRAME_PROVIDER_IERS_MANAGER_MODE`                          | `Automatic`                                                              |
-| `OSTK_PHYSICS_COORDINATE_FRAME_PROVIDER_IERS_MANAGER_LOCAL_REPOSITORY`              | `./.open-space-toolkit/physics/data/coordinate/frame/provider/iers`          |
-| `OSTK_PHYSICS_COORDINATE_FRAME_PROVIDER_IERS_MANAGER_LOCAL_REPOSITORY_LOCK_TIMEOUT` | `60`                                                                     |
-| `OSTK_PHYSICS_ENVIRONMENT_EPHEMERIS_SPICE_ENGINE_MODE`                             | `Automatic`                                                              |
-| `OSTK_PHYSICS_ENVIRONMENT_EPHEMERIS_SPICE_MANAGER_LOCAL_REPOSITORY`                | `./.open-space-toolkit/physics/data/environment/ephemeris/spice`            |
-| `OSTK_PHYSICS_ENVIRONMENT_GRAVITATIONAL_EARTH_MANAGER_MODE`                          | `Automatic`                                                                  |
-| `OSTK_PHYSICS_ENVIRONMENT_GRAVITATIONAL_EARTH_MANAGER_LOCAL_REPOSITORY`              | `./.open-space-toolkit/physics/data/environment/gravitational/earth`          |
-| `OSTK_PHYSICS_ENVIRONMENT_GRAVITATIONAL_EARTH_MANAGER_LOCAL_REPOSITORY_LOCK_TIMEOUT` | `60`                                                                        |
-| `OSTK_PHYSICS_ENVIRONMENT_MAGNETIC_EARTH_MANAGER_MODE`                               | `Automatic`                                                                  |
-| `OSTK_PHYSICS_ENVIRONMENT_MAGNETIC_EARTH_MANAGER_LOCAL_REPOSITORY`                   | `./.open-space-toolkit/physics/data/environment/magnetic/earth`               |
-| `OSTK_PHYSICS_ENVIRONMENT_MAGNETIC_EARTH_MANAGER_LOCAL_REPOSITORY_LOCK_TIMEOUT`      | `60`                                                                        |
-| `OSTK_PHYSICS_ENVIRONMENT_ATMOSPHERIC_EARTH_MANAGER_MODE`                            | `Automatic`                                                              |
-| `OSTK_PHYSICS_ENVIRONMENT_ATMOSPHERIC_EARTH_MANAGER_LOCAL_REPOSITORY`                | `./.open-space-toolkit/physics/data/environment/atmospheric/earth`            |
-| `OSTK_PHYSICS_ENVIRONMENT_ATMOSPHERIC_EARTH_MANAGER_LOCAL_REPOSITORY_LOCK_TIMEOUT`   | `60`                                                                        |
-| `OSTK_PHYSICS_DATA_REMOTE_URL`                                                       | `https://github.com/open-space-collective/open-space-toolkit-data/raw/main/data/` |
-| `OSTK_PHYSICS_DATA_MANIFEST_LOCAL_REPOSITORY`                                        | `./.open-space-toolkit/physics/data/`                                       |
-| `OSTK_PHYSICS_DATA_MANIFEST_LOCAL_REPOSITORY_LOCK_TIMEOUT`                           | `60`                                                                        |
 
+| Environment Variable                                                                   | Default Value                                                                                            |
+| -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `OSTK_PHYSICS_DATA_LOCAL_REPOSITORY`                                                 | `./.open-space-toolkit/physics/data` [Bulk setting. Overridden by specific repository settings below.] |
+| `OSTK_PHYSICS_COORDINATE_FRAME_PROVIDER_IERS_MANAGER_MODE`                           | `Automatic`                                                                                            |
+| `OSTK_PHYSICS_COORDINATE_FRAME_PROVIDER_IERS_MANAGER_LOCAL_REPOSITORY`               | `./.open-space-toolkit/physics/data/coordinate/frame/provider/iers`                                    |
+| `OSTK_PHYSICS_COORDINATE_FRAME_PROVIDER_IERS_MANAGER_LOCAL_REPOSITORY_LOCK_TIMEOUT`  | `60`                                                                                                   |
+| `OSTK_PHYSICS_ENVIRONMENT_EPHEMERIS_SPICE_ENGINE_MODE`                               | `Automatic`                                                                                            |
+| `OSTK_PHYSICS_ENVIRONMENT_EPHEMERIS_SPICE_MANAGER_LOCAL_REPOSITORY`                  | `./.open-space-toolkit/physics/data/environment/ephemeris/spice`                                       |
+| `OSTK_PHYSICS_ENVIRONMENT_GRAVITATIONAL_EARTH_MANAGER_MODE`                          | `Automatic`                                                                                            |
+| `OSTK_PHYSICS_ENVIRONMENT_GRAVITATIONAL_EARTH_MANAGER_LOCAL_REPOSITORY`              | `./.open-space-toolkit/physics/data/environment/gravitational/earth`                                   |
+| `OSTK_PHYSICS_ENVIRONMENT_GRAVITATIONAL_EARTH_MANAGER_LOCAL_REPOSITORY_LOCK_TIMEOUT` | `60`                                                                                                   |
+| `OSTK_PHYSICS_ENVIRONMENT_MAGNETIC_EARTH_MANAGER_MODE`                               | `Automatic`                                                                                            |
+| `OSTK_PHYSICS_ENVIRONMENT_MAGNETIC_EARTH_MANAGER_LOCAL_REPOSITORY`                   | `./.open-space-toolkit/physics/data/environment/magnetic/earth`                                        |
+| `OSTK_PHYSICS_ENVIRONMENT_MAGNETIC_EARTH_MANAGER_LOCAL_REPOSITORY_LOCK_TIMEOUT`      | `60`                                                                                                   |
+| `OSTK_PHYSICS_ENVIRONMENT_ATMOSPHERIC_EARTH_MANAGER_MODE`                            | `Automatic`                                                                                            |
+| `OSTK_PHYSICS_ENVIRONMENT_ATMOSPHERIC_EARTH_MANAGER_LOCAL_REPOSITORY`                | `./.open-space-toolkit/physics/data/environment/atmospheric/earth`                                     |
+| `OSTK_PHYSICS_ENVIRONMENT_ATMOSPHERIC_EARTH_MANAGER_LOCAL_REPOSITORY_LOCK_TIMEOUT`   | `60`                                                                                                   |
+| `OSTK_PHYSICS_DATA_REMOTE_URL`                                                       | `https://github.com/open-space-collective/open-space-toolkit-data/raw/v1/data/`                        |
+| `OSTK_PHYSICS_DATA_MANIFEST_LOCAL_REPOSITORY`                                        | `./.open-space-toolkit/physics/data/`                                                                  |
+| `OSTK_PHYSICS_DATA_MANIFEST_LOCAL_REPOSITORY_LOCK_TIMEOUT`                           | `60`                                                                                                   |
 
 ## Tutorials
 
@@ -260,18 +262,18 @@ Or to run them manually:
 
 ## Dependencies
 
-| Name          | Version      | License                                                    | Link                                                                                                                                       |
-| ------------- | ------------ | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| Pybind11      | `2.10.1`     | BSD-3-Clause                                               | [github.com/pybind/pybind11](https://github.com/pybind/pybind11)                                                                           |
-| {fmt}         | `5.2.0`      | BSD-2-Clause                                               | [github.com/fmtlib/fmt](https://github.com/fmtlib/fmt)                                                                                     |
-| ordered-map   | `0.6.0`      | MIT                                                        | [github.com/Tessil/ordered-map](https://github.com/Tessil/ordered-map)                                                                     |
-| Eigen         | `3.3.7`      | MPL2                                                       | [eigen.tuxfamily.org](http://eigen.tuxfamily.org/index.php)                                                                                |
+| Name          | Version        | License                                                 | Link                                                                                                                                    |
+| ------------- | -------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Pybind11      | `2.10.1`     | BSD-3-Clause                                            | [github.com/pybind/pybind11](https://github.com/pybind/pybind11)                                                                           |
+| {fmt}         | `5.2.0`      | BSD-2-Clause                                            | [github.com/fmtlib/fmt](https://github.com/fmtlib/fmt)                                                                                     |
+| ordered-map   | `0.6.0`      | MIT                                                     | [github.com/Tessil/ordered-map](https://github.com/Tessil/ordered-map)                                                                     |
+| Eigen         | `3.3.7`      | MPL2                                                    | [eigen.tuxfamily.org](http://eigen.tuxfamily.org/index.php)                                                                                |
 | IAU SOFA      | `2018-01-30` | [SOFA Software License](http://www.iausofa.org/tandc.html) | [www.iausofa.org](http://www.iausofa.org)                                                                                                  |
 | SPICE Toolkit | `N0067`      | [NAIF](https://naif.jpl.nasa.gov/naif/rules.html)          | [naif.jpl.nasa.gov/naif/toolkit.html](https://naif.jpl.nasa.gov/naif/toolkit.html)                                                         |
-| GeographicLib | `1.52`       | MIT                                                        | [geographiclib.sourceforge.io](https://geographiclib.sourceforge.io)                                                                       |
-| Core          | `main`       | Apache License 2.0                                        | [github.com/open-space-collective/open-space-toolkit-core](https://github.com/open-space-collective/open-space-toolkit-core)               |
-| I/O           | `main`       | Apache License 2.0                                        | [github.com/open-space-collective/open-space-toolkit-io](https://github.com/open-space-collective/open-space-toolkit-io)                   |
-| Mathematics   | `main`       | Apache License 2.0                                        | [github.com/open-space-collective/open-space-toolkit-mathematics](https://github.com/open-space-collective/open-space-toolkit-mathematics) |
+| GeographicLib | `1.52`       | MIT                                                     | [geographiclib.sourceforge.io](https://geographiclib.sourceforge.io)                                                                       |
+| Core          | `main`       | Apache License 2.0                                      | [github.com/open-space-collective/open-space-toolkit-core](https://github.com/open-space-collective/open-space-toolkit-core)               |
+| I/O           | `main`       | Apache License 2.0                                      | [github.com/open-space-collective/open-space-toolkit-io](https://github.com/open-space-collective/open-space-toolkit-io)                   |
+| Mathematics   | `main`       | Apache License 2.0                                      | [github.com/open-space-collective/open-space-toolkit-mathematics](https://github.com/open-space-collective/open-space-toolkit-mathematics) |
 
 ## Contribution
 

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -172,7 +172,7 @@ RUN mkdir -p /tmp/open-space-toolkit-mathematics \
 
 # Install seed data
 
-RUN git clone --branch main --single-branch --depth=1 https://github.com/open-space-collective/open-space-toolkit-data.git /var/cache/open-space-toolkit-data
+RUN git clone --branch v1 --single-branch --depth=1 https://github.com/open-space-collective/open-space-toolkit-data.git /var/cache/open-space-toolkit-data
 
 ENV OSTK_PHYSICS_DATA_LOCAL_REPOSITORY="/var/cache/open-space-toolkit-data/data"
 

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -29,7 +29,7 @@ RUN chown -R ${NB_UID}:${NB_GID} /home/jovyan
 
 # Install seed data
 
-RUN git clone --branch main --single-branch --depth=1 https://github.com/open-space-collective/open-space-toolkit-data.git /var/cache/open-space-toolkit-data
+RUN git clone --branch v1 --single-branch --depth=1 https://github.com/open-space-collective/open-space-toolkit-data.git /var/cache/open-space-toolkit-data
 
 ENV OSTK_PHYSICS_DATA_LOCAL_REPOSITORY="/var/cache/open-space-toolkit-data/data"
 

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -29,7 +29,7 @@ FROM debian:buster as cpp-release
 
 ENV LD_LIBRARY_PATH="/usr/local/lib"
 
-RUN git clone --branch main --single-branch --depth=1 https://github.com/open-space-collective/open-space-toolkit-data.git /var/cache/open-space-toolkit-data
+RUN git clone --branch v1 --single-branch --depth=1 https://github.com/open-space-collective/open-space-toolkit-data.git /var/cache/open-space-toolkit-data
 
 ENV OSTK_PHYSICS_DATA_LOCAL_REPOSITORY="/var/cache/open-space-toolkit-data/data"
 
@@ -58,7 +58,7 @@ RUN pip install ipython numpy
 
 # Install seed data
 
-RUN git clone --branch main --single-branch --depth=1 https://github.com/open-space-collective/open-space-toolkit-data.git /var/cache/open-space-toolkit-data
+RUN git clone --branch v1 --single-branch --depth=1 https://github.com/open-space-collective/open-space-toolkit-data.git /var/cache/open-space-toolkit-data
 
 ENV OSTK_PHYSICS_DATA_LOCAL_REPOSITORY="/var/cache/open-space-toolkit-data/data"
 

--- a/include/OpenSpaceToolkit/Physics/Data/Manager.hpp
+++ b/include/OpenSpaceToolkit/Physics/Data/Manager.hpp
@@ -14,7 +14,7 @@
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 
 // Base remote URL for OSTk data files
-#define OSTK_PHYSICS_DATA_REMOTE_URL "https://github.com/open-space-collective/open-space-toolkit-data/raw/main/data/"
+#define OSTK_PHYSICS_DATA_REMOTE_URL "https://github.com/open-space-collective/open-space-toolkit-data/raw/v1/data/"
 
 #define OSTK_PHYSICS_DATA_MANIFEST_LOCAL_REPOSITORY "./.open-space-toolkit/physics/data/"
 

--- a/src/OpenSpaceToolkit/Physics/Coordinate/Frame/Provider/IERS/Manager.cpp
+++ b/src/OpenSpaceToolkit/Physics/Coordinate/Frame/Provider/IERS/Manager.cpp
@@ -52,10 +52,6 @@ const String finals2000AFileName = "finals2000A.data";
 const String bulletinAManifestName = "bulletin-A";
 const String finals2000AManifestName = "finals-2000A";
 
-// TBI: this path can be obtained from the manifest
-const String bulletinARemotePath = "coordinate/frame/providers/iers/bulletin-A/";
-const String finals2000ARemotePath = "coordinate/frame/providers/iers/finals-2000A/";
-
 const String temporaryDirectoryName = "tmp";
 
 Manager::Mode Manager::getMode() const
@@ -591,7 +587,10 @@ File Manager::fetchLatestBulletinA_() const
 
     this->lockLocalRepository_(localRepositoryLockTimeout_);
 
-    const URL latestBulletinAUrl = manifestManager.getRemoteUrl() + bulletinARemotePath + bulletinAFileName;
+    const Array<URL> bulletinAUrls = manifestManager.getRemoteDataUrls(bulletinAManifestName);
+
+    // Only one remote file for Bulletin A
+    const URL bulletinAUrl = bulletinAUrls.accessFirst(); 
 
     File latestBulletinAFile = File::Undefined();
     Directory destinationDirectory = Directory::Undefined();
@@ -614,13 +613,13 @@ File Manager::fetchLatestBulletinA_() const
 
         // Download latest Bulletin A File into temporary Directory
 
-        std::cout << String::Format("Fetching Bulletin A from [{}]...", latestBulletinAUrl.toString()) << std::endl;
+        std::cout << String::Format("Fetching Bulletin A from [{}]...", bulletinAUrl.toString()) << std::endl;
 
-        latestBulletinAFile = Client::Fetch(latestBulletinAUrl, temporaryDirectory, 2);
+        latestBulletinAFile = Client::Fetch(bulletinAUrl, temporaryDirectory, 2);
 
         if (!latestBulletinAFile.exists())
         {
-            throw ostk::core::error::RuntimeError("Cannot fetch Bulletin A from [{}].", latestBulletinAUrl.toString());
+            throw ostk::core::error::RuntimeError("Cannot fetch Bulletin A from [{}].", bulletinAUrl.toString());
         }
 
         // Check that Bulletin A File size is not zero
@@ -631,7 +630,7 @@ File Manager::fetchLatestBulletinA_() const
         if (latestBulletinAFileSize == 0)
         {
             throw ostk::core::error::RuntimeError(
-                "Cannot fetch Bulletin A from [{}]: file is empty.", latestBulletinAUrl.toString()
+                "Cannot fetch Bulletin A from [{}]: file is empty.", bulletinAUrl.toString()
             );
         }
 
@@ -649,7 +648,7 @@ File Manager::fetchLatestBulletinA_() const
         std::cout << String::Format(
                          "Bulletin A [{}] has been successfully fetched from [{}].",
                          latestBulletinAFile.toString(),
-                         latestBulletinAUrl.toString()
+                         bulletinAUrl.toString()
                      )
                   << std::endl;
     }
@@ -657,7 +656,7 @@ File Manager::fetchLatestBulletinA_() const
     {
         std::cerr << String::Format(
                          "Error caught while fetching latest Bulletin A from [{}]: [{}].",
-                         latestBulletinAUrl.toString(),
+                         bulletinAUrl.toString(),
                          anException.what()
                      )
                   << std::endl;
@@ -692,7 +691,10 @@ File Manager::fetchLatestFinals2000A_() const
 
     this->lockLocalRepository_(localRepositoryLockTimeout_);
 
-    const URL latestFinals2000AUrl = manifestManager.getRemoteUrl() + finals2000ARemotePath + finals2000AFileName;
+    const Array<URL> finals2000AUrls = manifestManager.getRemoteDataUrls(finals2000AManifestName);
+
+    // Only one remote file for Finals 2000 A
+    const URL finals2000AUrl = finals2000AUrls.accessFirst(); 
 
     File latestFinals2000AFile = File::Undefined();
     Directory destinationDirectory = Directory::Undefined();
@@ -715,9 +717,9 @@ File Manager::fetchLatestFinals2000A_() const
 
         temporaryDirectory.create();
 
-        std::cout << String::Format("Fetching Finals 2000A from [{}]...", latestFinals2000AUrl.toString()) << std::endl;
+        std::cout << String::Format("Fetching Finals 2000A from [{}]...", finals2000AUrl.toString()) << std::endl;
 
-        latestFinals2000AFile = Client::Fetch(latestFinals2000AUrl, temporaryDirectory, 2);
+        latestFinals2000AFile = Client::Fetch(finals2000AUrl, temporaryDirectory, 2);
 
         const Finals2000A latestFinals2000A = Finals2000A::Load(latestFinals2000AFile);
 
@@ -726,7 +728,7 @@ File Manager::fetchLatestFinals2000A_() const
             throw ostk::core::error::RuntimeError(
                 "Cannot fetch Finals 2000A [{}] from [{}].",
                 latestFinals2000AFile.toString(),
-                latestFinals2000AUrl.toString()
+                finals2000AUrl.toString()
             );
         }
         else
@@ -739,7 +741,7 @@ File Manager::fetchLatestFinals2000A_() const
             if (latestFinals2000AFileSize == 0)
             {
                 throw ostk::core::error::RuntimeError(
-                    "Cannot fetch Finals 2000A from [{}]: file is empty.", latestFinals2000AUrl.toString()
+                    "Cannot fetch Finals 2000A from [{}]: file is empty.", finals2000AUrl.toString()
                 );
             }
         }
@@ -753,7 +755,7 @@ File Manager::fetchLatestFinals2000A_() const
         std::cout << String::Format(
                          "Finals 2000A [{}] has been successfully fetched from [{}].",
                          latestFinals2000AFile.toString(),
-                         latestFinals2000AUrl.toString()
+                         finals2000AUrl.toString()
                      )
                   << std::endl;
     }
@@ -761,7 +763,7 @@ File Manager::fetchLatestFinals2000A_() const
     {
         std::cerr << String::Format(
                          "Error caught while fetching latest Finals 2000A from [{}]: [{}].",
-                         latestFinals2000AUrl.toString(),
+                         finals2000AUrl.toString(),
                          anException.what()
                      )
                   << std::endl;

--- a/src/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/Manager.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/Manager.cpp
@@ -56,9 +56,6 @@ using ManifestManager = ostk::physics::data::Manager;
 const String CSSICSSISpaceWeatherFileName = "SW-Last5Years.csv";
 const String CSSISpaceWeatherManifestName = "space-weather-CSSI";
 
-// [TBI]: this path can be obtained from the manifest
-const String CSSISpaceWeatherRemotePath = "environment/atmospheric/earth/CSSISpaceWeather/";
-
 const String temporaryDirectoryName = "tmp";
 
 Manager::Mode Manager::getMode() const
@@ -574,8 +571,10 @@ File Manager::fetchLatestCSSISpaceWeather_()
 
     this->lockLocalRepository(localRepositoryLockTimeout_);
 
-    const URL latestCSSISpaceWeatherUrl =
-        manifestManager.getRemoteUrl() + CSSISpaceWeatherRemotePath + CSSICSSISpaceWeatherFileName;
+    const Array<URL> CSSISpaceWeatherUrls = manifestManager.getRemoteDataUrls(CSSISpaceWeatherManifestName);
+
+    // Only one remote file for CSSI Space Weather
+    const URL CSSISpaceWeatherUrl = CSSISpaceWeatherUrls.accessFirst();
 
     File latestCSSICSSISpaceWeatherFile = File::Undefined();
     Directory destinationDirectory = Directory::Undefined();
@@ -598,15 +597,15 @@ File Manager::fetchLatestCSSISpaceWeather_()
 
         // Download latest CSSI Space Weather File into temporary Directory
 
-        std::cout << String::Format("Fetching CSSI Space Weather from [{}]...", latestCSSISpaceWeatherUrl.toString())
+        std::cout << String::Format("Fetching CSSI Space Weather from [{}]...", CSSISpaceWeatherUrl.toString())
                   << std::endl;
 
-        latestCSSICSSISpaceWeatherFile = Client::Fetch(latestCSSISpaceWeatherUrl, temporaryDirectory, 2);
+        latestCSSICSSISpaceWeatherFile = Client::Fetch(CSSISpaceWeatherUrl, temporaryDirectory, 2);
 
         if (!latestCSSICSSISpaceWeatherFile.exists())
         {
             throw ostk::core::error::RuntimeError(
-                "Cannot fetch CSSI Space Weather from [{}].", latestCSSISpaceWeatherUrl.toString()
+                "Cannot fetch CSSI Space Weather from [{}].", CSSISpaceWeatherUrl.toString()
             );
         }
 
@@ -618,7 +617,7 @@ File Manager::fetchLatestCSSISpaceWeather_()
         if (latestCSSICSSISpaceWeatherFileSize == 0)
         {
             throw ostk::core::error::RuntimeError(
-                "Cannot fetch CSSI Space Weather from [{}]: file is empty.", latestCSSISpaceWeatherUrl.toString()
+                "Cannot fetch CSSI Space Weather from [{}]: file is empty.", CSSISpaceWeatherUrl.toString()
             );
         }
 
@@ -640,7 +639,7 @@ File Manager::fetchLatestCSSISpaceWeather_()
         std::cout << String::Format(
                          "CSSI Space Weather [{}] has been successfully fetched from [{}].",
                          latestCSSICSSISpaceWeatherFile.toString(),
-                         latestCSSISpaceWeatherUrl.toString()
+                         CSSISpaceWeatherUrl.toString()
                      )
                   << std::endl;
     }
@@ -648,7 +647,7 @@ File Manager::fetchLatestCSSISpaceWeather_()
     {
         std::cerr << String::Format(
                          "Error caught while fetching latest CSSI Space Weather from [{}]: [{}].",
-                         latestCSSISpaceWeatherUrl.toString(),
+                         CSSISpaceWeatherUrl.toString(),
                          anException.what()
                      )
                   << std::endl;

--- a/src/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Manager.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Manager.cpp
@@ -37,9 +37,6 @@ using ostk::io::ip::tcp::http::Client;
 
 const String temporaryDirectoryName = "tmp";
 
-// [TBI]: this path can be obtained from the manifest
-const String spiceFilesRemotePath = "environment/ephemerides/spice/";
-
 Manager& Manager::Get()
 {
     static Manager manager;
@@ -101,7 +98,11 @@ void Manager::fetchKernel(const Kernel& aKernel) const
     }
 
     ManifestManager& manifestManager = ManifestManager::Get();
-    const URL kernelFileUrl = manifestManager.getRemoteUrl() + spiceFilesRemotePath + aKernel.getName();
+
+    const Array<URL> kernelFileUrls = manifestManager.getRemoteDataUrls(aKernel.getName());
+
+    // Only one remote file for each kernel
+    const URL kernelFileUrl = kernelFileUrls.accessFirst();
 
     std::cout << String::Format(
                      "Fetching SPICE Kernel [{}] from [{}]...", kernelFile.toString(), kernelFileUrl.toString()

--- a/test/OpenSpaceToolkit/Physics/Data/Manager.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Data/Manager.test.cpp
@@ -37,7 +37,7 @@ class OpenSpaceToolkit_Physics_Data_Manager : public ::testing::Test
         managerNoIO_.loadManifest(manifest_);
 
         manager_.setRemoteUrl(
-            URL::Parse("https://github.com/open-space-collective/open-space-toolkit-data/raw/main/data")
+            URL::Parse("https://github.com/open-space-collective/open-space-toolkit-data/raw/v1/data")
         );
 
         // cache current directory environment variables
@@ -110,7 +110,7 @@ TEST_F(OpenSpaceToolkit_Physics_Data_Manager, GetRemoteUrl)
 {
     {
         EXPECT_EQ(
-            "https://github.com/open-space-collective/open-space-toolkit-data/raw/main/data",
+            "https://github.com/open-space-collective/open-space-toolkit-data/raw/v1/data",
             manager_.getRemoteUrl().toString()
         );
     }
@@ -120,7 +120,7 @@ TEST_F(OpenSpaceToolkit_Physics_Data_Manager, SetRemoteUrl)
 {
     {
         EXPECT_EQ(
-            "https://github.com/open-space-collective/open-space-toolkit-data/raw/main/data",
+            "https://github.com/open-space-collective/open-space-toolkit-data/raw/v1/data",
             manager_.getRemoteUrl().toString()
         );
 
@@ -136,7 +136,7 @@ TEST_F(OpenSpaceToolkit_Physics_Data_Manager, DefaultRemoteUrl)
 {
     {
         EXPECT_EQ(
-            "https://github.com/open-space-collective/open-space-toolkit-data/raw/main/data/",
+            "https://github.com/open-space-collective/open-space-toolkit-data/raw/v1/data/",
             Manager::DefaultRemoteUrl().toString()
         );
     }
@@ -149,12 +149,12 @@ TEST_F(OpenSpaceToolkit_Physics_Data_Manager, FindRemoteDataUrls)
 
         EXPECT_EQ(
             urls[0],
-            URL::Parse("https://github.com/open-space-collective/open-space-toolkit-data/raw/main/data/environment/"
+            URL::Parse("https://github.com/open-space-collective/open-space-toolkit-data/raw/v1/data/environment/"
                        "gravitational/earth/egm2008.egm")
         );
         EXPECT_EQ(
             urls[1],
-            URL::Parse("https://github.com/open-space-collective/open-space-toolkit-data/raw/main/data/environment/"
+            URL::Parse("https://github.com/open-space-collective/open-space-toolkit-data/raw/v1/data/environment/"
                        "gravitational/earth/egm2008.egm.cof")
         );
     }


### PR DESCRIPTION
After changing the namespace and filenames in OSTk, the structure of data in OSTk Physics no longer mirrored OSTk Data. It was not safe to simply update OSTk Data to use the new structure, as it would break any OSTk that was not updated to at least Physics V5. 

To solve this, we introduced versioning into the OSTk Data "API". The versioning is present in the URL that is used to fetch data:

this: https://github.com/open-space-collective/open-space-toolkit-data/blob/main/data/manifest.json
vs. this: https://github.com/open-space-collective/open-space-toolkit-data/blob/v1/data/manifest.json

Which is implemented by just created a new synced branch on the OSTk Data remote, called `v1`.

This MR does 2 things:
1.) change hard-coded remote paths to use the manifest as a reference (should've been done a long time ago)
2.) update OSTk Data URL to the new V1 API, so that the local file structure matches the remote.