### PR TITLE
refactor: remove pybound methods from `Celestial` that aren't usable in python 

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Object/Celestial.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Object/Celestial.cpp
@@ -107,9 +107,12 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Celestial(pybind11::mod
         .def("get_position_in", &Celestial::getPositionIn, arg("frame"), arg("instant"))
         .def("get_transform_to", &Celestial::getTransformTo, arg("frame"), arg("instant"))
         .def("get_axes_in", &Celestial::getAxesIn, arg("frame"), arg("instant"))
-        .def("get_gravitational_field_at", &Celestial::getGravitationalFieldAt, arg("position"), arg("instant"))
-        .def("get_magnetic_field_at", &Celestial::getMagneticFieldAt, arg("position"), arg("instant"))
-        .def("get_atmospheric_density_at", &Celestial::getAtmosphericDensityAt, arg("position"), arg("instant"))
+
+        // TBI: whenenver data::Vector and data::Scalar is supported in Python
+        // .def("get_gravitational_field_at", &Celestial::getGravitationalFieldAt, arg("position"), arg("instant"))
+        // .def("get_magnetic_field_at", &Celestial::getMagneticFieldAt, arg("position"), arg("instant"))
+        // .def("get_atmospheric_density_at", &Celestial::getAtmosphericDensityAt, arg("position"), arg("instant"))
+
         .def("gravitational_model_is_defined", &Celestial::gravitationalModelIsDefined)
         .def("magnetic_model_is_defined", &Celestial::magneticModelIsDefined)
         .def("atmospheric_model_is_defined", &Celestial::atmosphericModelIsDefined)
@@ -146,7 +149,6 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Celestial(pybind11::mod
 
     // Create "celestial" python submodule
     auto celestial = aModule.def_submodule("celestial");
-
 
     // Add objects to python "celestial" submodules
     OpenSpaceToolkitPhysicsPy_Environment_Object_Celestial_Earth(celestial);

--- a/test/OpenSpaceToolkit/Physics/Environment/Object/Celestial.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Object/Celestial.test.cpp
@@ -70,15 +70,7 @@ using EarthAtmosphericModel = ostk::physics::environment::atmospheric::Earth;
 
 // TEST (OpenSpaceToolkit_Physics_Environment_Object_Celestial, Constructor)
 // {
-
-//     using ostk::physics::environment::Object ;
-
-//     {
-
-//         FAIL() ;
-
-//     }
-
+// TBM: Constructor tested below, but should be refactored to this test case directly
 // }
 
 TEST(OpenSpaceToolkit_Physics_Environment_Object_Celestial, accessModel)


### PR DESCRIPTION
Due to the fact that `data::Scalar` and `data::Vector` aren't bound to python, the methods that return them in the `Celestial` bindings will compile but won't actually work at runtime, so I have commented them out. 