### PR TITLE
build: fix ostk-core incompatible release

### DIFF
--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -3,5 +3,6 @@
 numpy>=1.17.4
 
 open-space-toolkit-core~=2.1.0
+open-space-toolkit-core~=2.1.0
 open-space-toolkit-io~=2.0.0
 open-space-toolkit-mathematics~=2.0.0

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -2,5 +2,5 @@
 
 numpy>=1.17.4
 
-open-space-toolkit-io~=2.0
-open-space-toolkit-mathematics~=2.0
+open-space-toolkit-io~=2.0.0
+open-space-toolkit-mathematics~=2.0.0

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -3,6 +3,5 @@
 numpy>=1.17.4
 
 open-space-toolkit-core~=2.1.0
-open-space-toolkit-core~=2.1.0
 open-space-toolkit-io~=2.0.0
 open-space-toolkit-mathematics~=2.0.0

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -2,5 +2,6 @@
 
 numpy>=1.17.4
 
+open-space-toolkit-core~=2.1.0
 open-space-toolkit-io~=2.0.0
 open-space-toolkit-mathematics~=2.0.0

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -2,6 +2,5 @@
 
 numpy>=1.17.4
 
-open-space-toolkit-core~=2.1
 open-space-toolkit-io~=2.0
 open-space-toolkit-mathematics~=2.0


### PR DESCRIPTION
This should resolve the incompatible versions of ostk-core issue

ostk-physics was letting core go up to 2.2, while io and math were not letting it go past 2.1, that was causing the issue