### PR TITLE
feat: Update version compatibility with Boost and OSTk packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,7 +218,21 @@ SET (Boost_USE_MULTITHREADED ON)
 
 FIND_PACKAGE ("Boost" "1.82" REQUIRED COMPONENTS "date_time" "regex" "filesystem")
 
-ADD_DEFINITIONS(-DBOOST_STACKTRACE_USE_BACKTRACE -DBOOST_STACKTRACE_BACKTRACE_INCLUDE_FILE=</usr/lib/gcc/x86_64-linux-gnu/9/include/backtrace.h>)
+## Stacktrace definitions
+# Detect system architecture
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+    # Architecture-specific include for x86_64
+    set(BACKTRACE_INCLUDE "/usr/lib/gcc/x86_64-linux-gnu/9/include/backtrace.h")
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    # Example path adjustment for aarch64, adjust the path as needed
+    set(BACKTRACE_INCLUDE "/usr/lib/gcc/aarch64-linux-gnu/9/include/backtrace.h")
+else()
+    message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+
+# Add definitions with architecture-specific path
+ADD_DEFINITIONS(-DBOOST_STACKTRACE_USE_BACKTRACE)
+ADD_DEFINITIONS(-DBOOST_STACKTRACE_BACKTRACE_INCLUDE_FILE=<${BACKTRACE_INCLUDE}>)
 
 IF (NOT Boost_FOUND)
     MESSAGE (SEND_ERROR "[Boost] not found.")
@@ -288,7 +302,7 @@ ENDIF ()
 
 ### Open Space Toolkit ▸ Core
 
-FIND_PACKAGE ("OpenSpaceToolkitCore" "2.0" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitCore" "2.2" REQUIRED)
 
 IF (NOT OpenSpaceToolkitCore_FOUND)
 
@@ -298,7 +312,7 @@ ENDIF ()
 
 ### Open Space Toolkit ▸ I/O
 
-FIND_PACKAGE ("OpenSpaceToolkitIO" "2.0" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitIO" "2.1" REQUIRED)
 
 IF (NOT OpenSpaceToolkitIO_FOUND)
 
@@ -308,7 +322,7 @@ ENDIF ()
 
 ### Open Space Toolkit ▸ Mathematics
 
-FIND_PACKAGE ("OpenSpaceToolkitMathematics" "2.0" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitMathematics" "2.1" REQUIRED)
 
 IF (NOT OpenSpaceToolkitMathematics_FOUND)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,9 +300,9 @@ ELSE ()
     MESSAGE (SEND_ERROR "[GeographicLib] not found.")
 ENDIF ()
 
-### Open Space Toolkit ▸ Core
+### Open Space Toolkit ▸ Core [3.0.x]
 
-FIND_PACKAGE ("OpenSpaceToolkitCore" "2.2" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitCore" "3.0" REQUIRED)
 
 IF (NOT OpenSpaceToolkitCore_FOUND)
 
@@ -310,9 +310,9 @@ IF (NOT OpenSpaceToolkitCore_FOUND)
 
 ENDIF ()
 
-### Open Space Toolkit ▸ I/O
+### Open Space Toolkit ▸ I/O [3.0.x]
 
-FIND_PACKAGE ("OpenSpaceToolkitIO" "2.1" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitIO" "3.0" REQUIRED)
 
 IF (NOT OpenSpaceToolkitIO_FOUND)
 
@@ -320,9 +320,9 @@ IF (NOT OpenSpaceToolkitIO_FOUND)
 
 ENDIF ()
 
-### Open Space Toolkit ▸ Mathematics
+### Open Space Toolkit ▸ Mathematics [3.0.x]
 
-FIND_PACKAGE ("OpenSpaceToolkitMathematics" "2.1" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitMathematics" "3.0" REQUIRED)
 
 IF (NOT OpenSpaceToolkitMathematics_FOUND)
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,18 @@ extract_python_package_version := $(shell echo $(project_version) | sed 's/-/./'
 
 dev_username := developer
 
+
+ifeq ($(PLATFORM),amd64)
+platform := x86_64
+endif
+
+ifeq ($(PLATFORM),arm64)
+platform := aarch64
+endif
+
+platform ?= x86_64
+$(info Platform value is $(platform))
+
 pull: ## Pull all images
 
 	@ echo "Pulling images..."
@@ -213,6 +225,7 @@ build-packages-cpp-standalone: ## Build C++ packages (standalone)
 	@ echo "Building C++ packages..."
 
 	docker run \
+		--platform ${platform} \
 		--rm \
 		--volume="$(CURDIR):/app:delegated" \
 		--volume="/app/build" \
@@ -236,6 +249,7 @@ build-packages-python-standalone: ## Build Python packages (standalone)
 	@ echo "Building Python packages..."
 
 	docker run \
+		--platform ${platform} \
 		--rm \
 		--volume="$(CURDIR):/app:delegated" \
 		--volume="/app/build" \

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ endif
 platform ?= x86_64
 $(info Platform value is $(platform))
 
+
 pull: ## Pull all images
 
 	@ echo "Pulling images..."

--- a/Makefile
+++ b/Makefile
@@ -22,16 +22,9 @@ extract_python_package_version := $(shell echo $(project_version) | sed 's/-/./'
 dev_username := developer
 
 
-ifeq ($(PLATFORM),amd64)
-platform := x86_64
-endif
-
-ifeq ($(PLATFORM),arm64)
-platform := aarch64
-endif
-
-platform ?= x86_64
-$(info Platform value is $(platform))
+# Handle multi-platform builds locally (CI sets these env vars, but need defaults here)
+TARGETPLATFORM ?= linux/amd64
+$(info Target platform is $(TARGETPLATFORM))
 
 
 pull: ## Pull all images
@@ -226,7 +219,7 @@ build-packages-cpp-standalone: ## Build C++ packages (standalone)
 	@ echo "Building C++ packages..."
 
 	docker run \
-		--platform ${platform} \
+		--platform $(TARGETPLATFORM) \
 		--rm \
 		--volume="$(CURDIR):/app:delegated" \
 		--volume="/app/build" \
@@ -250,7 +243,7 @@ build-packages-python-standalone: ## Build Python packages (standalone)
 	@ echo "Building Python packages..."
 
 	docker run \
-		--platform ${platform} \
+		--platform $(TARGETPLATFORM) \
 		--rm \
 		--volume="$(CURDIR):/app:delegated" \
 		--volume="/app/build" \

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -127,6 +127,15 @@ FUNCTION (PY_ADD_PACKAGE_DIRECTORY NAME)
     # Package directory name
     SET (PACKAGE_DIRECTORY_NAME ${NAME})
 
+    # Set platforme name for wheel
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+        SET (PLATFORM "manylinux2014_x86_64")
+    ELSEIF(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+        SET (PLATFORM "manylinux2014_aarch64")
+    ELSE()
+        MESSAGE (FATAL_ERROR "Unsupported platform")
+    ENDIF()
+
     # Get python extension for relevant shared library spotting
     STRING (REPLACE "." "" EXTENSION "${PYTHON_VERSION}")
 

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -2,6 +2,6 @@
 
 numpy>=1.17.4
 
-open-space-toolkit-core~=2.2.0
-open-space-toolkit-io~=2.1.0
-open-space-toolkit-mathematics~=2.1.0
+open-space-toolkit-core~=3.0.0
+open-space-toolkit-io~=3.0.0
+open-space-toolkit-mathematics~=3.0.0

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -2,6 +2,6 @@
 
 numpy>=1.17.4
 
-open-space-toolkit-core~=2.1.0
-open-space-toolkit-io~=2.0.0
-open-space-toolkit-mathematics~=2.0.0
+open-space-toolkit-core~=2.2.0
+open-space-toolkit-io~=2.1.0
+open-space-toolkit-mathematics~=2.1.0

--- a/bindings/python/tools/python/setup.cfg.in
+++ b/bindings/python/tools/python/setup.cfg.in
@@ -3,6 +3,7 @@
 [bdist_wheel]
 python-tag=py${EXTENSION}
 bdist-dir=./dist${EXTENSION}
+plat-name=${PLATFORM}
 
 [metadata]
 name = open-space-toolkit-physics

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -13,61 +13,61 @@ LABEL maintainer="lucas@loftorbital.com"
 ## Zip, jq, and git-lfs
 
 RUN apt-get update \
-    && apt-get install -y unzip jq git-lfs \
-    && rm -rf /var/lib/apt/lists/*
+ && apt-get install -y unzip jq git-lfs \
+ && rm -rf /var/lib/apt/lists/*
 
 ## {fmt}
 
 ARG FMT_VERSION="5.2.0"
 
 RUN git clone --branch ${FMT_VERSION} --depth 1 https://github.com/fmtlib/fmt.git /tmp/fmt \
-    && cd /tmp/fmt \
-    && mkdir build \
-    && cd build \
-    && cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE .. \
-    && make --silent -j $(nproc) \
-    && make install \
-    && rm -rf /tmp/fmt
+ && cd /tmp/fmt \
+ && mkdir build \
+ && cd build \
+ && cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE .. \
+ && make --silent -j $(nproc) \
+ && make install \
+ && rm -rf /tmp/fmt
 
 ## ordered-map
 
 ARG ORDERED_MAP_VERSION="0.6.0"
 
 RUN git clone --branch v${ORDERED_MAP_VERSION} --depth 1 https://github.com/Tessil/ordered-map.git /tmp/ordered-map \
-    && cd /tmp/ordered-map \
-    && cp -r ./include/tsl /usr/local/include \
-    && rm -rf /tmp/ordered-map
+ && cd /tmp/ordered-map \
+ && cp -r ./include/tsl /usr/local/include \
+ && rm -rf /tmp/ordered-map
 
 # NRLMSISE00 Model
 
 ARG NRLMSISE00_MODEL_COMMIT="a5f81be"
 
 RUN git clone https://github.com/magnific0/nrlmsise-00.git /tmp/nrlmsise \
-    && cd /tmp/nrlmsise \
-    && git checkout ${NRLMSISE00_MODEL_COMMIT} \
-    && mkdir build \
-    && cd build \
-    && cmake -DNRLMSISE00_WITH_TESTS="OFF" -DCMAKE_C_FLAGS="-fPIC" .. \
-    && make -j $(nproc) \
-    && mkdir /usr/local/include/NRLMSISE-00 \
-    && cp ../nrlmsise-00.h /usr/local/include/NRLMSISE-00 \
-    && cp ../lib/libnrlmsise00.a /usr/local/lib \
-    && rm -rf /tmp/nrlmsise
+ && cd /tmp/nrlmsise \
+ && git checkout ${NRLMSISE00_MODEL_COMMIT} \
+ && mkdir build \
+ && cd build \
+ && cmake -DNRLMSISE00_WITH_TESTS="OFF" -DCMAKE_C_FLAGS="-fPIC" .. \
+ && make -j $(nproc) \
+ && mkdir /usr/local/include/NRLMSISE-00 \
+ && cp ../nrlmsise-00.h /usr/local/include/NRLMSISE-00 \
+ && cp ../lib/libnrlmsise00.a /usr/local/lib \
+ && rm -rf /tmp/nrlmsise
 
 ## Eigen
 
 ARG EIGEN_VERSION="3.4.0"
 
 RUN mkdir /tmp/eigen \
-    && cd /tmp/eigen \
-    && wget --quiet https://gitlab.com/libeigen/eigen/-/archive/${EIGEN_VERSION}/eigen-${EIGEN_VERSION}.tar.gz \
-    && tar -xvf eigen-${EIGEN_VERSION}.tar.gz \
-    && cd eigen-${EIGEN_VERSION} \
-    && mkdir build \
-    && cd build \
-    && cmake .. \
-    && make install \
-    && rm -rf /tmp/eigen
+ && cd /tmp/eigen \
+ && wget --quiet https://gitlab.com/libeigen/eigen/-/archive/${EIGEN_VERSION}/eigen-${EIGEN_VERSION}.tar.gz \
+ && tar -xvf eigen-${EIGEN_VERSION}.tar.gz \
+ && cd eigen-${EIGEN_VERSION} \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make install \
+ && rm -rf /tmp/eigen
 
 ## IAU SOFA
 
@@ -75,52 +75,52 @@ ARG IAU_SOFA_RELEASE="2018_0130_C"
 ARG IAU_SOFA_VERSION="20180130"
 
 RUN mkdir -p /tmp/sofa \
-    && cd /tmp/sofa \
-    && wget --quiet http://www.iausofa.org/${IAU_SOFA_RELEASE}/sofa_c-${IAU_SOFA_VERSION}.tar.gz \
-    && tar -zxf sofa_c-${IAU_SOFA_VERSION}.tar.gz \
-    && cd sofa/${IAU_SOFA_VERSION}/c/src/ \
-    && pattern="CFLAGF = -c -pedantic -Wall -W -O" \
-    && target="CFLAGF = -c -pedantic -Wall -W -O -fpic" \
-    && sed -i -e 's,'"$pattern"','"$target"',g' makefile \
-    && make -j $(nproc) \
-    && mkdir /usr/local/include/sofa \
-    && cp -r *.h /usr/local/include/sofa \
-    && cp -r *.a /usr/local/lib \
-    && rm -rf /tmp/sofa
+ && cd /tmp/sofa \
+ && wget --quiet http://www.iausofa.org/${IAU_SOFA_RELEASE}/sofa_c-${IAU_SOFA_VERSION}.tar.gz \
+ && tar -zxf sofa_c-${IAU_SOFA_VERSION}.tar.gz \
+ && cd sofa/${IAU_SOFA_VERSION}/c/src/ \
+ && pattern="CFLAGF = -c -pedantic -Wall -W -O" \
+ && target="CFLAGF = -c -pedantic -Wall -W -O -fpic" \
+ && sed -i -e 's,'"$pattern"','"$target"',g' makefile \
+ && make -j $(nproc) \
+ && mkdir /usr/local/include/sofa \
+ && cp -r *.h /usr/local/include/sofa \
+ && cp -r *.a /usr/local/lib \
+ && rm -rf /tmp/sofa
 
 ## SPICE Toolkit
 
 RUN cd /tmp \
-    && wget --quiet http://naif.jpl.nasa.gov/pub/naif/toolkit/C/PC_Linux_GCC_64bit/packages/cspice.tar.Z \
-    && tar -xf cspice.tar.Z \
-    && cd cspice \
-    && apt-get update \
-    && apt-get install -y csh \
-    && ./makeall.csh > /dev/null \
-    && mkdir -p /usr/local/include/cspice \
-    && cp -r include/* /usr/local/include/cspice/ \
-    && cp -r lib/* /usr/local/lib/ \
-    && ln -s /usr/local/lib/cspice.a /usr/local/lib/libcspice.a \
-    && rm -rf /tmp/cspice \
-    && apt-get remove -y csh \
-    && rm -rf /var/lib/apt/lists/*
+ && wget --quiet http://naif.jpl.nasa.gov/pub/naif/toolkit/C/PC_Linux_GCC_64bit/packages/cspice.tar.Z \
+ && tar -xf cspice.tar.Z \
+ && cd cspice \
+ && apt-get update \
+ && apt-get install -y csh \
+ && ./makeall.csh > /dev/null \
+ && mkdir -p /usr/local/include/cspice \
+ && cp -r include/* /usr/local/include/cspice/ \
+ && cp -r lib/* /usr/local/lib/ \
+ && ln -s /usr/local/lib/cspice.a /usr/local/lib/libcspice.a \
+ && rm -rf /tmp/cspice \
+ && apt-get remove -y csh \
+ && rm -rf /var/lib/apt/lists/*
 
 # GeographicLib
 
 ARG GEOGRAPHIC_LIB="1.52"
 
 RUN git clone https://github.com/geographiclib/geographiclib /tmp/geographiclib \
-    && cd /tmp/geographiclib \
-    && git checkout tags/r${GEOGRAPHIC_LIB} \
-    && mkdir build \
-    && cd build \
-    && apt-get update \
-    && apt-get install -y libproj-dev \
-    && cmake -DGEOGRAPHICLIB_LIB_TYPE=STATIC -DCMAKE_CXX_FLAGS="-fPIC" .. \
-    && make -j $(nproc) \
-    && make install \
-    && rm -rf /tmp/geographiclib \
-    && rm -rf /var/lib/apt/lists/*
+ && cd /tmp/geographiclib \
+ && git checkout tags/r${GEOGRAPHIC_LIB} \
+ && mkdir build \
+ && cd build \
+ && apt-get update \
+ && apt-get install -y libproj-dev \
+ && cmake -DGEOGRAPHICLIB_LIB_TYPE=STATIC -DCMAKE_CXX_FLAGS="-fPIC" .. \
+ && make -j $(nproc) \
+ && make install \
+ && rm -rf /tmp/geographiclib \
+ && rm -rf /var/lib/apt/lists/*
 
 ## Open Space Toolkit ▸ Core
 
@@ -132,13 +132,13 @@ ARG OSTK_CORE_MINOR="0"
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-core/git/matching-refs/tags/${OSTK_CORE_MAJOR}.${OSTK_CORE_MINOR} /tmp/open-space-toolkit-core/versions.json
 
 RUN mkdir -p /tmp/open-space-toolkit-core \
-    && cd /tmp/open-space-toolkit-core \
-    && export LATEST_PATCH_OF_MINOR=$(jq -r .[-1].ref versions.json | cut -d "/" -f3) \
-    && export PACKAGE_PLATFORM=$(if [ ${TARGETPLATFORM} = "linux/amd64" ]; then echo "x86_64"; elif [ ${TARGETPLATFORM} = "linux/arm64" ]; then echo "aarch64"; else echo "Unknown platform" && exit 1; fi;) \
-    && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-core-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-runtime.deb \
-    && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-core-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-devel.deb \
-    && apt-get install -y ./*.deb \
-    && rm -rf /tmp/open-space-toolkit-core
+ && cd /tmp/open-space-toolkit-core \
+ && export LATEST_PATCH_OF_MINOR=$(jq -r .[-1].ref versions.json | cut -d "/" -f3) \
+ && export PACKAGE_PLATFORM=$(if [ ${TARGETPLATFORM} = "linux/amd64" ]; then echo "x86_64"; elif [ ${TARGETPLATFORM} = "linux/arm64" ]; then echo "aarch64"; else echo "Unknown platform" && exit 1; fi;) \
+ && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-core-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-runtime.deb \
+ && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-core-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-devel.deb \
+ && apt-get install -y ./*.deb \
+ && rm -rf /tmp/open-space-toolkit-core
 
 ## Open Space Toolkit ▸ I/O
 
@@ -150,13 +150,13 @@ ARG OSTK_IO_MINOR="0"
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-io/git/matching-refs/tags/${OSTK_IO_MAJOR}.${OSTK_IO_MINOR} /tmp/open-space-toolkit-io/versions.json
 
 RUN mkdir -p /tmp/open-space-toolkit-io \
-    && cd /tmp/open-space-toolkit-io \
-    && export LATEST_PATCH_OF_MINOR=$(jq -r .[-1].ref versions.json | cut -d "/" -f3) \
-    && export PACKAGE_PLATFORM=$(if [ ${TARGETPLATFORM} = "linux/amd64" ]; then echo "x86_64"; elif [ ${TARGETPLATFORM} = "linux/arm64" ]; then echo "aarch64"; else echo "Unknown platform" && exit 1; fi;) \
-    && wget --quiet https://github.com/open-space-collective/open-space-toolkit-io/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-io-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-runtime.deb \
-    && wget --quiet https://github.com/open-space-collective/open-space-toolkit-io/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-io-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-devel.deb \
-    && apt-get install -y ./*.deb \
-    && rm -rf /tmp/open-space-toolkit-io
+ && cd /tmp/open-space-toolkit-io \
+ && export LATEST_PATCH_OF_MINOR=$(jq -r .[-1].ref versions.json | cut -d "/" -f3) \
+ && export PACKAGE_PLATFORM=$(if [ ${TARGETPLATFORM} = "linux/amd64" ]; then echo "x86_64"; elif [ ${TARGETPLATFORM} = "linux/arm64" ]; then echo "aarch64"; else echo "Unknown platform" && exit 1; fi;) \
+ && wget --quiet https://github.com/open-space-collective/open-space-toolkit-io/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-io-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-runtime.deb \
+ && wget --quiet https://github.com/open-space-collective/open-space-toolkit-io/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-io-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-devel.deb \
+ && apt-get install -y ./*.deb \
+ && rm -rf /tmp/open-space-toolkit-io
 
 ## Open Space Toolkit ▸ Mathematics
 
@@ -168,13 +168,13 @@ ARG OSTK_MATHEMATICS_MINOR="0"
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-mathematics/git/matching-refs/tags/${OSTK_MATHEMATICS_MAJOR}.${OSTK_MATHEMATICS_MINOR} /tmp/open-space-toolkit-mathematics/versions.json
 
 RUN mkdir -p /tmp/open-space-toolkit-mathematics \
-    && cd /tmp/open-space-toolkit-mathematics \
-    && export LATEST_PATCH_OF_MINOR=$(jq -r .[-1].ref versions.json | cut -d "/" -f3) \
-    && export PACKAGE_PLATFORM=$(if [ ${TARGETPLATFORM} = "linux/amd64" ]; then echo "x86_64"; elif [ ${TARGETPLATFORM} = "linux/arm64" ]; then echo "aarch64"; else echo "Unknown platform" && exit 1; fi;) \
-    && wget --quiet https://github.com/open-space-collective/open-space-toolkit-mathematics/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-mathematics-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-runtime.deb \
-    && wget --quiet https://github.com/open-space-collective/open-space-toolkit-mathematics/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-mathematics-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-devel.deb \
-    && apt-get install -y ./*.deb \
-    && rm -rf /tmp/open-space-toolkit-mathematics
+ && cd /tmp/open-space-toolkit-mathematics \
+ && export LATEST_PATCH_OF_MINOR=$(jq -r .[-1].ref versions.json | cut -d "/" -f3) \
+ && export PACKAGE_PLATFORM=$(if [ ${TARGETPLATFORM} = "linux/amd64" ]; then echo "x86_64"; elif [ ${TARGETPLATFORM} = "linux/arm64" ]; then echo "aarch64"; else echo "Unknown platform" && exit 1; fi;) \
+ && wget --quiet https://github.com/open-space-collective/open-space-toolkit-mathematics/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-mathematics-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-runtime.deb \
+ && wget --quiet https://github.com/open-space-collective/open-space-toolkit-mathematics/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-mathematics-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-devel.deb \
+ && apt-get install -y ./*.deb \
+ && rm -rf /tmp/open-space-toolkit-mathematics
 
 # Install seed data
 
@@ -195,8 +195,8 @@ FROM root-user as non-root-user
 # Install dev utilities
 
 RUN apt-get update \
-    && apt-get install -y zsh sudo \
-    && rm -rf /var/lib/apt/lists/*
+ && apt-get install -y zsh sudo \
+ && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user and group
 
@@ -204,8 +204,8 @@ ARG USERNAME="developer"
 ARG USER_UID="1000"
 ARG USER_GID=${USER_UID}
 RUN groupadd --gid ${USER_GID} ${USERNAME} || true \
-    && adduser --uid ${USER_UID} --gid ${USER_GID} ${USERNAME} \
-    && echo "${USERNAME} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/${USERNAME}
+ && adduser --uid ${USER_UID} --gid ${USER_GID} ${USERNAME} \
+ && echo "${USERNAME} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/${USERNAME}
 
 # Change ownership of OSTK_PHYSICS_DATA_LOCAL_REPOSITORY
 
@@ -218,10 +218,10 @@ USER ${USERNAME}
 # Install shell utilities
 
 RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" \
-    && git clone https://github.com/bhilburn/powerlevel9k.git /home/${USERNAME}/.oh-my-zsh/custom/themes/powerlevel9k \
-    && git clone https://github.com/zsh-users/zsh-autosuggestions /home/${USERNAME}/.oh-my-zsh/custom/plugins/zsh-autosuggestions \
-    && git clone https://github.com/zsh-users/zsh-syntax-highlighting.git /home/${USERNAME}/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting \
-    && mkdir -p /home/${USERNAME}/.vscode-server/extensions /home/${USERNAME}/.vscode-server-insiders/extensions
+ && git clone https://github.com/bhilburn/powerlevel9k.git /home/${USERNAME}/.oh-my-zsh/custom/themes/powerlevel9k \
+ && git clone https://github.com/zsh-users/zsh-autosuggestions /home/${USERNAME}/.oh-my-zsh/custom/plugins/zsh-autosuggestions \
+ && git clone https://github.com/zsh-users/zsh-syntax-highlighting.git /home/${USERNAME}/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting \
+ && mkdir -p /home/${USERNAME}/.vscode-server/extensions /home/${USERNAME}/.vscode-server-insiders/extensions
 
 ## Configure environment
 

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE_VERSION="latest"
 
 # General purpose development image (root user)
 
-FROM openspacecollective/open-space-toolkit-base:${BASE_IMAGE_VERSION} as root-user
+FROM openspacecollective/open-space-toolkit-base-dvelopment:${BASE_IMAGE_VERSION} as root-user
 
 LABEL maintainer="lucas@loftorbital.com"
 
@@ -125,7 +125,7 @@ RUN git clone https://github.com/geographiclib/geographiclib /tmp/geographiclib 
 ## Open Space Toolkit ▸ Core
 
 ARG OSTK_CORE_MAJOR="2"
-ARG OSTK_CORE_MINOR="1"
+ARG OSTK_CORE_MINOR="2"
 
 ## Force an image rebuild when new Core patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-core/git/matching-refs/tags/${OSTK_CORE_MAJOR}.${OSTK_CORE_MINOR} /tmp/open-space-toolkit-core/versions.json
@@ -141,7 +141,7 @@ RUN mkdir -p /tmp/open-space-toolkit-core \
 ## Open Space Toolkit ▸ I/O
 
 ARG OSTK_IO_MAJOR="2"
-ARG OSTK_IO_MINOR="0"
+ARG OSTK_IO_MINOR="1"
 
 ## Force an image rebuild when new IO patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-io/git/matching-refs/tags/${OSTK_IO_MAJOR}.${OSTK_IO_MINOR} /tmp/open-space-toolkit-io/versions.json
@@ -157,7 +157,7 @@ RUN mkdir -p /tmp/open-space-toolkit-io \
 ## Open Space Toolkit ▸ Mathematics
 
 ARG OSTK_MATHEMATICS_MAJOR="2"
-ARG OSTK_MATHEMATICS_MINOR="0"
+ARG OSTK_MATHEMATICS_MINOR="1"
 
 ## Force an image rebuild when new Math patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-mathematics/git/matching-refs/tags/${OSTK_MATHEMATICS_MAJOR}.${OSTK_MATHEMATICS_MINOR} /tmp/open-space-toolkit-mathematics/versions.json

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -124,8 +124,9 @@ RUN git clone https://github.com/geographiclib/geographiclib /tmp/geographiclib 
 
 ## Open Space Toolkit ▸ Core
 
-ARG OSTK_CORE_MAJOR="2"
-ARG OSTK_CORE_MINOR="2"
+ARG TARGETPLATFORM
+ARG OSTK_CORE_MAJOR="3"
+ARG OSTK_CORE_MINOR="0"
 
 ## Force an image rebuild when new Core patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-core/git/matching-refs/tags/${OSTK_CORE_MAJOR}.${OSTK_CORE_MINOR} /tmp/open-space-toolkit-core/versions.json
@@ -133,15 +134,17 @@ ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-core/g
 RUN mkdir -p /tmp/open-space-toolkit-core \
     && cd /tmp/open-space-toolkit-core \
     && export LATEST_PATCH_OF_MINOR=$(jq -r .[-1].ref versions.json | cut -d "/" -f3) \
-    && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-core-${LATEST_PATCH_OF_MINOR}-1.x86_64-runtime.deb \
-    && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-core-${LATEST_PATCH_OF_MINOR}-1.x86_64-devel.deb \
+    && export PACKAGE_PLATFORM=$(if [ ${TARGETPLATFORM} = "linux/amd64" ]; then echo "x86_64"; elif [ ${TARGETPLATFORM} = "linux/arm64" ]; then echo "aarch64"; else echo "Unknown platform" && exit 1; fi;) \
+    && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-core-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-runtime.deb \
+    && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-core-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-devel.deb \
     && apt-get install -y ./*.deb \
     && rm -rf /tmp/open-space-toolkit-core
 
 ## Open Space Toolkit ▸ I/O
 
-ARG OSTK_IO_MAJOR="2"
-ARG OSTK_IO_MINOR="1"
+ARG TARGETPLATFORM
+ARG OSTK_IO_MAJOR="3"
+ARG OSTK_IO_MINOR="0"
 
 ## Force an image rebuild when new IO patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-io/git/matching-refs/tags/${OSTK_IO_MAJOR}.${OSTK_IO_MINOR} /tmp/open-space-toolkit-io/versions.json
@@ -149,15 +152,17 @@ ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-io/git
 RUN mkdir -p /tmp/open-space-toolkit-io \
     && cd /tmp/open-space-toolkit-io \
     && export LATEST_PATCH_OF_MINOR=$(jq -r .[-1].ref versions.json | cut -d "/" -f3) \
-    && wget --quiet https://github.com/open-space-collective/open-space-toolkit-io/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-io-${LATEST_PATCH_OF_MINOR}-1.x86_64-runtime.deb \
-    && wget --quiet https://github.com/open-space-collective/open-space-toolkit-io/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-io-${LATEST_PATCH_OF_MINOR}-1.x86_64-devel.deb \
+    && export PACKAGE_PLATFORM=$(if [ ${TARGETPLATFORM} = "linux/amd64" ]; then echo "x86_64"; elif [ ${TARGETPLATFORM} = "linux/arm64" ]; then echo "aarch64"; else echo "Unknown platform" && exit 1; fi;) \
+    && wget --quiet https://github.com/open-space-collective/open-space-toolkit-io/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-io-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-runtime.deb \
+    && wget --quiet https://github.com/open-space-collective/open-space-toolkit-io/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-io-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-devel.deb \
     && apt-get install -y ./*.deb \
     && rm -rf /tmp/open-space-toolkit-io
 
 ## Open Space Toolkit ▸ Mathematics
 
-ARG OSTK_MATHEMATICS_MAJOR="2"
-ARG OSTK_MATHEMATICS_MINOR="1"
+ARG TARGETPLATFORM
+ARG OSTK_MATHEMATICS_MAJOR="3"
+ARG OSTK_MATHEMATICS_MINOR="0"
 
 ## Force an image rebuild when new Math patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-mathematics/git/matching-refs/tags/${OSTK_MATHEMATICS_MAJOR}.${OSTK_MATHEMATICS_MINOR} /tmp/open-space-toolkit-mathematics/versions.json
@@ -165,8 +170,9 @@ ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-mathem
 RUN mkdir -p /tmp/open-space-toolkit-mathematics \
     && cd /tmp/open-space-toolkit-mathematics \
     && export LATEST_PATCH_OF_MINOR=$(jq -r .[-1].ref versions.json | cut -d "/" -f3) \
-    && wget --quiet https://github.com/open-space-collective/open-space-toolkit-mathematics/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-mathematics-${LATEST_PATCH_OF_MINOR}-1.x86_64-runtime.deb \
-    && wget --quiet https://github.com/open-space-collective/open-space-toolkit-mathematics/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-mathematics-${LATEST_PATCH_OF_MINOR}-1.x86_64-devel.deb \
+    && export PACKAGE_PLATFORM=$(if [ ${TARGETPLATFORM} = "linux/amd64" ]; then echo "x86_64"; elif [ ${TARGETPLATFORM} = "linux/arm64" ]; then echo "aarch64"; else echo "Unknown platform" && exit 1; fi;) \
+    && wget --quiet https://github.com/open-space-collective/open-space-toolkit-mathematics/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-mathematics-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-runtime.deb \
+    && wget --quiet https://github.com/open-space-collective/open-space-toolkit-mathematics/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-mathematics-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-devel.deb \
     && apt-get install -y ./*.deb \
     && rm -rf /tmp/open-space-toolkit-mathematics
 

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE_VERSION="latest"
 
 # General purpose development image (root user)
 
-FROM openspacecollective/open-space-toolkit-base-dvelopment:${BASE_IMAGE_VERSION} as root-user
+FROM openspacecollective/open-space-toolkit-base-development:${BASE_IMAGE_VERSION} as root-user
 
 LABEL maintainer="lucas@loftorbital.com"
 


### PR DESCRIPTION
Update version compatibility with Boost and OSTk packages, define architecture-specific path for Boost stacktrace backtrace include file, adjust platform naming for Python bindings, and update version compatibility with OpenSpaceToolkit Core, IO, and Mathematics packages.

- Requires merge of https://github.com/open-space-collective/open-space-toolkit-core/pull/153 and ostk-core 3.0.0 release before passing
- Requires merge of https://github.com/open-space-collective/open-space-toolkit-io/pull/82 and ostk-io 3.0.0 release before passing
- Requires merge of https://github.com/open-space-collective/open-space-toolkit-mathematics/pull/121 and ostk-math 3.0.0 release before passing

Needs to be released as ostk-physics 6.0.0