### PR TITLE
build: make cspice archive build for arm

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -90,8 +90,11 @@ RUN mkdir -p /tmp/sofa \
 
 ## SPICE Toolkit
 
+ARG TARGETPLATFORM
+
 RUN cd /tmp \
- && wget --quiet http://naif.jpl.nasa.gov/pub/naif/toolkit/C/PC_Linux_GCC_64bit/packages/cspice.tar.Z \
+ && export PACKAGE_PLATFORM=$(if [ ${TARGETPLATFORM} = "linux/amd64" ]; then echo "PC_Linux_GCC_64bit"; elif [ ${TARGETPLATFORM} = "linux/arm64" ]; then echo "MacM1_OSX_clang_64bit"; else echo "Unknown platform" && exit 1; fi;) \
+ && wget --quiet http://naif.jpl.nasa.gov/pub/naif/toolkit/C/${PACKAGE_PLATFORM}/packages/cspice.tar.Z \
  && tar -xf cspice.tar.Z \
  && cd cspice \
  && apt-get update \


### PR DESCRIPTION
Uses the Mac M1 version of cspice.a file found on JPL's website to build the arm packages