### PR TITLE
fix: double free in Earth models

### DIFF
--- a/src/OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.cpp
@@ -182,9 +182,7 @@ class Earth::ExternalImpl : public Earth::Impl
         const Integer& aGravityModelOrder
     );
 
-    ExternalImpl(
-        const ExternalImpl& anExternalImpl
-    );
+    ExternalImpl(const ExternalImpl& anExternalImpl);
 
     ~ExternalImpl();
 
@@ -235,13 +233,16 @@ Earth::ExternalImpl::ExternalImpl(const Earth::ExternalImpl& anExternalImpl)
       gravityModelDegree_(anExternalImpl.getDegree()),
       gravityModelOrder_(anExternalImpl.getOrder()),
       dataDirectory_(anExternalImpl.getDataDirectory()),
-      gravityModelUPtr_(
-        Earth::ExternalImpl::GravityModelFromType(anExternalImpl.getType(), anExternalImpl.getDataDirectory(), anExternalImpl.getDegree(), anExternalImpl.getOrder())
-      )
+      gravityModelUPtr_(Earth::ExternalImpl::GravityModelFromType(
+          anExternalImpl.getType(),
+          anExternalImpl.getDataDirectory(),
+          anExternalImpl.getDegree(),
+          anExternalImpl.getOrder()
+      ))
 {
 }
 
-Earth::ExternalImpl::~ExternalImpl(){}
+Earth::ExternalImpl::~ExternalImpl() {}
 
 Earth::ExternalImpl* Earth::ExternalImpl::clone() const
 {
@@ -333,7 +334,9 @@ Unique<GravityModel> Earth::ExternalImpl::GravityModelFromType(
                 throw ostk::core::error::runtime::Wrong("Gravity Model Order", gravityModelOrder);
             }
 
-            return std::make_unique<GeographicLib::GravityModel>("wgs84", dataPath, gravityModelDegree, gravityModelOrder);
+            return std::make_unique<GeographicLib::GravityModel>(
+                "wgs84", dataPath, gravityModelDegree, gravityModelOrder
+            );
         }
 
         case Earth::Type::EGM84:
@@ -348,7 +351,9 @@ Unique<GravityModel> Earth::ExternalImpl::GravityModelFromType(
                 throw ostk::core::error::runtime::Wrong("Gravity Model Order", gravityModelOrder);
             }
 
-            return std::make_unique<GeographicLib::GravityModel>("egm84", dataPath, gravityModelDegree, gravityModelOrder);
+            return std::make_unique<GeographicLib::GravityModel>(
+                "egm84", dataPath, gravityModelDegree, gravityModelOrder
+            );
         }
 
         case Earth::Type::WGS84_EGM96:
@@ -364,7 +369,9 @@ Unique<GravityModel> Earth::ExternalImpl::GravityModelFromType(
                 throw ostk::core::error::runtime::Wrong("Gravity Model Order", gravityModelOrder);
             }
 
-            return std::make_unique<GeographicLib::GravityModel>("egm96", dataPath, gravityModelDegree, gravityModelOrder);
+            return std::make_unique<GeographicLib::GravityModel>(
+                "egm96", dataPath, gravityModelDegree, gravityModelOrder
+            );
         }
 
         case Earth::Type::EGM2008:
@@ -379,7 +386,9 @@ Unique<GravityModel> Earth::ExternalImpl::GravityModelFromType(
                 throw ostk::core::error::runtime::Wrong("Gravity Model Order", gravityModelOrder);
             }
 
-            return std::make_unique<GeographicLib::GravityModel>("egm2008", dataPath, gravityModelDegree, gravityModelOrder);
+            return std::make_unique<GeographicLib::GravityModel>(
+                "egm2008", dataPath, gravityModelDegree, gravityModelOrder
+            );
         }
 
         default:

--- a/src/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth.cpp
@@ -43,9 +43,12 @@ class Earth::Impl
    public:
     Impl(const Earth::Type& aType, const Directory& aDataDirectory);
 
+    Impl(const Impl& anImpl);
+
     ~Impl();
 
     Earth::Type getType() const;
+    Directory getDataDirectory() const;
 
     bool isDefined() const;
 
@@ -53,31 +56,42 @@ class Earth::Impl
 
    private:
     Earth::Type type_;
+    Directory dataDirectory_;
 
-    MagneticModel* magneticModelPtr_;
+    Unique<MagneticModel> magneticModelUPtr_;
 
     static MagneticModel* MagneticModelFromType(const Earth::Type& aType, const Directory& aDataDirectory);
 };
 
 Earth::Impl::Impl(const Earth::Type& aType, const Directory& aDataDirectory)
     : type_(aType),
-      magneticModelPtr_(Earth::Impl::MagneticModelFromType(aType, aDataDirectory))
+      dataDirectory_(aDataDirectory),
+      magneticModelUPtr_(Earth::Impl::MagneticModelFromType(aType, aDataDirectory))
 {
 }
 
-Earth::Impl::~Impl()
+Earth::Impl::Impl(const Earth::Impl& anImpl)
+    : type_(anImpl.getType()),
+      dataDirectory_(anImpl.getDataDirectory()),
+      magneticModelUPtr_(Earth::Impl::MagneticModelFromType(anImpl.getType(), anImpl.getDataDirectory()))
 {
-    delete magneticModelPtr_;
 }
+
+Earth::Impl::~Impl(){}
 
 Earth::Type Earth::Impl::getType() const
 {
     return type_;
 }
 
+Directory Earth::Impl::getDataDirectory() const
+{
+    return dataDirectory_;
+}
+
 bool Earth::Impl::isDefined() const
 {
-    return magneticModelPtr_ != nullptr;
+    return magneticModelUPtr_ != nullptr;
 }
 
 Vector3d Earth::Impl::getFieldValueAt(const Vector3d& aPosition, const Instant& anInstant) const
@@ -97,11 +111,11 @@ Vector3d Earth::Impl::getFieldValueAt(const Vector3d& aPosition, const Instant& 
 
     const Integer year = anInstant.getDateTime(Scale::UTC).accessDate().getYear();
 
-    if (((year < static_cast<int>(magneticModelPtr_->MinTime())) ||
-         (year > static_cast<int>(magneticModelPtr_->MaxTime()))))
+    if (((year < static_cast<int>(magneticModelUPtr_->MinTime())) ||
+         (year > static_cast<int>(magneticModelUPtr_->MaxTime()))))
     {
         throw ostk::core::error::RuntimeError(
-            "Year [{}] is out of [{}, {}] bounds.", year, magneticModelPtr_->MinTime(), magneticModelPtr_->MaxTime()
+            "Year [{}] is out of [{}, {}] bounds.", year, magneticModelUPtr_->MinTime(), magneticModelUPtr_->MaxTime()
         );
     }
 
@@ -117,7 +131,7 @@ Vector3d Earth::Impl::getFieldValueAt(const Vector3d& aPosition, const Instant& 
     double By_nT;  // [nT] Northerly component of the magnetic field
     double Bz_nT;  // [nT] Vertical component of the magnetic field
 
-    (*magneticModelPtr_)(year, latitude_deg, longitude_deg, altitude_m, Bx_nT, By_nT, Bz_nT);
+    (*magneticModelUPtr_)(year, latitude_deg, longitude_deg, altitude_m, Bx_nT, By_nT, Bz_nT);
 
     const Vector3d magneticField_NED = Vector3d {By_nT, Bx_nT, -Bz_nT} / 1e9;  // [T]
 
@@ -244,7 +258,6 @@ Earth& Earth::operator=(const Earth& anEarthMagneticModel)
 
 Earth::~Earth() {}
 
-// Might want to look into using a Shared Pointer for Earth::Impl
 Earth* Earth::clone() const
 {
     return new Earth(*this);

--- a/src/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth.cpp
@@ -77,7 +77,7 @@ Earth::Impl::Impl(const Earth::Impl& anImpl)
 {
 }
 
-Earth::Impl::~Impl(){}
+Earth::Impl::~Impl() {}
 
 Earth::Type Earth::Impl::getType() const
 {

--- a/test/OpenSpaceToolkit/Physics/Environment/Object/Celestial/Earth.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Object/Celestial/Earth.test.cpp
@@ -312,23 +312,17 @@ TEST(OpenSpaceToolkit_Physics_Environment_Object_Celestial_Earth, FromModels)
     EXPECT_TRUE(earth.atmosphericModelIsDefined());
 }
 
-
 TEST(OpenSpaceToolkit_Physics_Environment_Object_Celestial_Earth, DoubleFreeError)
 {
     {
         // This test checks for double frees in memory
         // Each Earth model has a complicated chain of ownership that sometimes
-        // relies on objects defined in other places. 
+        // relies on objects defined in other places.
         // This was a problem with the Earth Gravity Model when defining the following:
 
-
         // This gets deallocated, which deletes the Geographiclib::GravityModel
-        const EarthGravitationalModel grav = EarthGravitationalModel(
-            EarthGravitationalModel::Type::EGM96,
-            Directory::Undefined(),
-            20,
-            20
-        );
+        const EarthGravitationalModel grav =
+            EarthGravitationalModel(EarthGravitationalModel::Type::EGM96, Directory::Undefined(), 20, 20);
         const EarthMagneticModel mag = EarthMagneticModel(EarthMagneticModel::Type::Undefined);
         const EarthAtmosphericModel atm = EarthAtmosphericModel(EarthAtmosphericModel::Type::NRLMSISE00);
 
@@ -338,7 +332,5 @@ TEST(OpenSpaceToolkit_Physics_Environment_Object_Celestial_Earth, DoubleFreeErro
             std::make_shared<EarthMagneticModel>(mag),
             std::make_shared<EarthAtmosphericModel>(atm)
         );
-
-
     }
 }


### PR DESCRIPTION
The Earth Gravity and Magnetic models held raw pointers to the underlying functionality, which was manually deleted upon calling their destructors. 

The problem is that when building an Earth celestial this way:
```cpp
        const EarthGravitationalModel grav =
            EarthGravitationalModel(EarthGravitationalModel::Type::EGM96, Directory::Undefined(), 20, 20);
        const EarthMagneticModel mag = EarthMagneticModel(EarthMagneticModel::Type::Undefined);
        const EarthAtmosphericModel atm = EarthAtmosphericModel(EarthAtmosphericModel::Type::NRLMSISE00);

        // This gets deallocated, which again tries to delete the model
        const Earth earth = Earth::FromModels(
            std::make_shared<EarthGravitationalModel>(grav),
            std::make_shared<EarthMagneticModel>(mag),
            std::make_shared<EarthAtmosphericModel>(atm)
        );
```


The destructors get called twice, which leads to a double free. This hasn't been noticed before because usually we call them like this:
```cpp

        const Earth earth = Earth::FromModels(
            std::make_shared<EarthGravitationalModel>(
                EarthGravitationalModel::Type::EGM96,
                Directory::Undefined(),
                20,
                20),
            std::make_shared<EarthMagneticModel>(EarthMagneticModel::Type::Undefined),
            std::make_shared<EarthAtmosphericModel>(EarthAtmosphericModel::Type::NRLMSISE00)
        );
```

or directly assign the models to shared pointers. In these cases, the destructors are only ever called once. 



This MR fixes it by changing the raw pointers to Unique pointers, which automatically clean up themselves and are resilient to double frees when deconstructed twice.