### PR TITLE
refactor: simplify bug prone CSSI data fetch

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth/Manager.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth/Manager.cpp
@@ -15,7 +15,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth_Manager(pybi
         .def("get_mode", &Manager::getMode)
         .def("get_local_repository", &Manager::getLocalRepository)
         .def("get_cssi_space_weather_directory", &Manager::getCSSISpaceWeatherDirectory)
-        .def("get_cssi_space_weather_array", &Manager::getCSSISpaceWeatherArray)
+        .def("get_loaded_cssi_space_weather", &Manager::getLoadedCSSISpaceWeather)
         .def("get_cssi_space_weather_at", &Manager::getCSSISpaceWeatherAt, arg("instant"))
         .def("get_kp_3_hour_solar_indices_at", &Manager::getKp3HourSolarIndicesAt, arg("instant"))
         .def("get_ap_3_hour_solar_indices_at", &Manager::getAp3HourSolarIndicesAt, arg("instant"))

--- a/bindings/python/test/environment/atmospheric/earth/test_manager.py
+++ b/bindings/python/test/environment/atmospheric/earth/test_manager.py
@@ -135,11 +135,11 @@ class TestManager:
     def test_load_cssi_space_weather_success(
         self, manager: Manager, cssi_space_weather: CSSISpaceWeather
     ):
-        assert manager.get_loaded_cssi_space_weather().is_defined()
+        assert not manager.get_loaded_cssi_space_weather().is_defined()
 
         manager.load_cssi_space_weather(cssi_space_weather)
 
-        assert not manager.get_loaded_cssi_space_weather().is_defined()
+        assert manager.get_loaded_cssi_space_weather().is_defined()
 
     def test_fetch_latest_cssi_space_weather_success(self, manager: Manager):
         file: File = manager.fetch_latest_cssi_space_weather()

--- a/bindings/python/test/environment/atmospheric/earth/test_manager.py
+++ b/bindings/python/test/environment/atmospheric/earth/test_manager.py
@@ -32,9 +32,9 @@ class TestManager:
         assert isinstance(manager.get_cssi_space_weather_directory(), Directory)
         assert len(str(manager.get_cssi_space_weather_directory().to_string())) > 0
 
-    def test_get_cssi_space_weather_array_success(self, manager: Manager):
-        assert isinstance(manager.get_cssi_space_weather_array(), list)
-        assert len(manager.get_cssi_space_weather_array()) == 0
+    def test_get_loaded_cssi_space_weather_success(self, manager: Manager):
+        assert isinstance(manager.get_loaded_cssi_space_weather(), CSSISpaceWeather)
+        assert not manager.get_loaded_cssi_space_weather().is_defined()
 
     def test_get_cssi_space_weather_at_success(self, manager: Manager):
         try:
@@ -135,11 +135,11 @@ class TestManager:
     def test_load_cssi_space_weather_success(
         self, manager: Manager, cssi_space_weather: CSSISpaceWeather
     ):
-        assert len(manager.get_cssi_space_weather_array()) == 0
+        assert manager.get_loaded_cssi_space_weather().is_defined()
 
         manager.load_cssi_space_weather(cssi_space_weather)
 
-        assert len(manager.get_cssi_space_weather_array()) == 1
+        assert not manager.get_loaded_cssi_space_weather().is_defined()
 
     def test_fetch_latest_cssi_space_weather_success(self, manager: Manager):
         file: File = manager.fetch_latest_cssi_space_weather()
@@ -152,11 +152,11 @@ class TestManager:
     def test_reset_success(self, manager: Manager, cssi_space_weather: CSSISpaceWeather):
         manager.load_cssi_space_weather(cssi_space_weather)
 
-        assert len(manager.get_cssi_space_weather_array()) == 1
+        assert manager.get_loaded_cssi_space_weather().is_defined()
 
         manager.reset()
 
-        assert len(manager.get_cssi_space_weather_array()) == 0
+        assert not manager.get_loaded_cssi_space_weather().is_defined()
 
     def test_clear_local_repository_success(self, manager: Manager):
         assert manager.get_local_repository().exists()

--- a/include/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/Manager.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/Manager.hpp
@@ -90,11 +90,11 @@ class Manager
 
     Directory getCSSISpaceWeatherDirectory() const;
 
-    /// @brief                  Get array of CSSI Space Weather
+    /// @brief                  Get currently loaded CSSI Space Weather file
     ///
-    /// @return                 Array of CSSI Space Weather
+    /// @return                 Currently loaded CSSI Space Weather file
 
-    Array<CSSISpaceWeather> getCSSISpaceWeatherArray() const;
+    CSSISpaceWeather getLoadedCSSISpaceWeather() const;
 
     /// @brief                  Get CSSI Space Weather at instant
     ///
@@ -212,13 +212,9 @@ class Manager
     Directory localRepository_;
     Duration localRepositoryLockTimeout_;
 
-    Array<CSSISpaceWeather> CSSISpaceWeatherArray_;
+    CSSISpaceWeather CSSISpaceWeather_;
 
     mutable std::mutex mutex_;
-
-    mutable Index CSSISpaceWeatherIndex_;
-
-    mutable Instant CSSISpaceWeatherUpdateTimestamp_;
 
     Manager(const Manager::Mode& aMode = Manager::DefaultMode());
 

--- a/test/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/Manager.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/Manager.test.cpp
@@ -110,13 +110,6 @@ TEST_F(OpenSpaceToolkit_Physics_Environment_Atmospheric_Earth_Manager, GetLocalR
     }
 }
 
-TEST_F(OpenSpaceToolkit_Physics_Environment_Atmospheric_Earth_Manager, GetCSSISpaceWeatherArray)
-{
-    {
-        EXPECT_NO_THROW(manager_.getCSSISpaceWeatherArray());
-    }
-}
-
 TEST_F(OpenSpaceToolkit_Physics_Environment_Atmospheric_Earth_Manager, GetCSSISpaceWeatherAt)
 {
     {
@@ -484,7 +477,7 @@ TEST_F(OpenSpaceToolkit_Physics_Environment_Atmospheric_Earth_Manager, Reset)
     {
         manager_.reset();
 
-        EXPECT_TRUE(manager_.getCSSISpaceWeatherArray().isEmpty());
+        EXPECT_FALSE(manager_.getLoadedCSSISpaceWeather().isDefined());
     }
 }
 


### PR DESCRIPTION
This bug was bubbling up when trying to obtain density measurements for this timestamp, and _specifically_ for the attached CSSI data file:
```
from ostk.physics.time import Scale, Instant, DateTime
from ostk.physics.environment.atmospheric import Earth as EarthAtmosphericModel

from ostk.physics.coordinate import Frame
from ostk.physics.coordinate import Position

atmos = EarthAtmosphericModel(EarthAtmosphericModel.Type.NRLMSISE00)

instant = Instant.date_time(DateTime.parse("2024-03-21 23:00:00.565.999"), Scale.UTC)
position = Position.meters([4029942.66955136, -3891161.1573942, -4022548.89540997], Frame.GCRF())

atmos.get_density_at(position, instant)
```
[SW-Last5Years-breaking.csv](https://github.com/open-space-collective/open-space-toolkit-physics/files/14794326/SW-Last5Years-breaking.csv)


However, this only occurred when that data file was placed into the data repository manually, rather than being manually loaded with the Manager bindings.

This turned out to be a[nother] problem with how the manager tries to auto-load CSSI data files. There was an implicit assumption that data files that were newly loaded from disk would always have observational data for a requested point. 

There's a system that tries to cache the CSSI files that are loaded into memory so that multiple can be referenced at once. This code was mostly leftover cruft from a past era, and for space weather doesn't matter too much because:
- newer files are always preferable, since they have more observational data.
- this system only triggered when either an updated file became available during runtime (happens every 3 days) or we go off the end of the data set (which is 5 years back and 20 years ahead).

I don't think there's any interest in supporting either of these edge cases, since we will hopefully never need a propagation with a runtime of >3 days and will not need to have a single propagation with a span of 25 years. 

This MR simplifies the CSSI fetching part of the code. It should be more bulletproof and slightly faster this way.