### PR TITLE
feat: add an Instant::Parse utility function and the GPS Epoch

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/Instant.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/Instant.cpp
@@ -196,6 +196,16 @@ inline void OpenSpaceToolkitPhysicsPy_Time_Instant(pybind11::module &aModule)
             )doc"
         )
         .def_static(
+            "GPS_epoch",
+            &Instant::GPSEpoch,
+            R"doc(
+                Get the GPS epoch instant.
+
+                Returns:
+                    Instant: GPS epoch instant.
+            )doc"
+        )
+        .def_static(
             "date_time",
             &Instant::DateTime,
             R"doc(
@@ -229,6 +239,27 @@ inline void OpenSpaceToolkitPhysicsPy_Time_Instant(pybind11::module &aModule)
 
                 Args:
                     modified_julian_date (float): Modified Julian date.
+
+                Returns:
+                    Instant: Instant.
+            )doc"
+        )
+
+        .def_static(
+            "parse",
+            &Instant::Parse,
+            arg("string"),
+            arg_v("scale", DEFAULT_TIME_SCALE, "Scale.UTC"),
+            arg_v("date_time_format", DEFAULT_DATE_TIME_FORMAT, "Format.Standard"),
+
+            R"doc(
+                Create an instant from a string representation.
+
+                Args:
+                    string (str): String representation.
+                    scale (Time.Scale): Time scale.
+                    date_time_format (DateTime.Format): Date-time format.
+
 
                 Returns:
                     Instant: Instant.

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/Instant.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/Instant.cpp
@@ -249,7 +249,7 @@ inline void OpenSpaceToolkitPhysicsPy_Time_Instant(pybind11::module &aModule)
             "parse",
             &Instant::Parse,
             arg("string"),
-            arg_v("scale", DEFAULT_TIME_SCALE, "Scale.UTC"),
+            arg("scale"),
             arg_v("date_time_format", DEFAULT_DATE_TIME_FORMAT, "Format.Standard"),
 
             R"doc(

--- a/bindings/python/test/time/test_instant.py
+++ b/bindings/python/test/time/test_instant.py
@@ -21,6 +21,10 @@ def test_instant_J2000():
     assert Instant.J2000() is not None
 
 
+def test_instant_GPS_epock():
+    assert Instant.GPS_epoch() is not None
+
+
 def test_instant_datetime():
     assert (
         Instant.date_time(DateTime(2018, 1, 1, 0, 0, 0, 0, 0, 0), Scale.UTC) is not None
@@ -35,6 +39,18 @@ def test_instant_julian_date():
 
 def test_instant_modified_julian_date():
     assert Instant.modified_julian_date(58119.0, Scale.UTC) is not None
+
+
+def test_instant_parse():
+    assert Instant.parse("2024-01-01 00:01:02.000", Scale.UTC) is not None
+    assert (
+        Instant.parse("2024-01-01 00:01:02.000", Scale.UTC, DateTime.Format.Standard)
+        is not None
+    )
+    assert (
+        Instant.parse("2024-01-01T00:01:02.000", Scale.UTC, DateTime.Format.ISO8601)
+        is not None
+    )
 
 
 def test_instant_operators():

--- a/include/OpenSpaceToolkit/Physics/Time/Instant.hpp
+++ b/include/OpenSpaceToolkit/Physics/Time/Instant.hpp
@@ -314,6 +314,15 @@ class Instant
 
     static Instant J2000();
 
+    /// @brief              Constructs instant at GPS epoch
+    ///
+    ///                     The GPS epoch is equivalent to:
+    ///                     - January 6, 1980, 00:00:00 UTC (Coordinated Universal Time).
+    ///
+    /// @return             Instant at GPSEpoch epoch
+
+    static Instant GPSEpoch();
+
     /// @brief              Constructs instant from date-time
     ///
     /// @code
@@ -355,6 +364,22 @@ class Instant
     /// @return             Instant
 
     static Instant ModifiedJulianDate(const Real& aModifiedJulianDate, const Scale& aTimeScale);
+
+    /// @brief              Constructs an Instant from a string representation and Scale.
+    ///
+    /// @code
+    ///                     Instant instant = Instant::Parse("2018-01-02 12:34:56.123.456.789", Scale::UTC) ; //
+    ///                     2018-01-02
+    /// @endcode
+    ///
+    /// @param              [in] aString A string
+    /// @param              [in] aTimeScale A time scale
+    /// @param              [in] (optional) aFormat A date-time format (automatic detection if Undefined)
+    /// @return             Instant
+
+    static Instant Parse(
+        const String& aString, const Scale& aTimeScale, const DateTime::Format& aFormat = DateTime::Format::Undefined
+    );
 
    private:
     class Count

--- a/src/OpenSpaceToolkit/Physics/Time/Instant.cpp
+++ b/src/OpenSpaceToolkit/Physics/Time/Instant.cpp
@@ -413,6 +413,11 @@ Instant Instant::J2000()
     return Instant({0, true}, Scale::TT);
 }
 
+Instant Instant::GPSEpoch()
+{
+    return Instant::DateTime(time::DateTime(1980, 1, 6), Scale::UTC);
+}
+
 Instant Instant::DateTime(const time::DateTime& aDateTime, const Scale& aTimeScale)
 {
     using ostk::core::type::Int32;
@@ -540,6 +545,11 @@ Instant Instant::ModifiedJulianDate(const Real& aModifiedJulianDate, const Scale
     }
 
     return Instant::DateTime(DateTime::ModifiedJulianDate(aModifiedJulianDate), aTimeScale);
+}
+
+Instant Instant::Parse(const String& aString, const Scale& aTimeScale, const DateTime::Format& aFormat)
+{
+    return Instant::DateTime(DateTime::Parse(aString, aFormat), aTimeScale);
 }
 
 Instant::Instant(const Instant::Count& aCount, const Scale& aTimeScale)

--- a/test/OpenSpaceToolkit/Physics/Time/Instant.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Time/Instant.test.cpp
@@ -1700,6 +1700,21 @@ TEST(OpenSpaceToolkit_Physics_Time_Instant, J2000)
     }
 }
 
+TEST(OpenSpaceToolkit_Physics_Time_Instant, GPSEpoch)
+{
+    using ostk::physics::time::Scale;
+    using ostk::physics::time::DateTime;
+    using ostk::physics::time::Instant;
+
+    {
+        EXPECT_NO_THROW(Instant::GPSEpoch());
+        EXPECT_TRUE(Instant::GPSEpoch().isDefined());
+
+        EXPECT_EQ(DateTime(1980, 1, 6, 0, 0, 0), Instant::GPSEpoch().getDateTime(Scale::GPST));
+        EXPECT_EQ(DateTime(1980, 1, 6, 0, 0, 0), Instant::GPSEpoch().getDateTime(Scale::UTC));
+    }
+}
+
 TEST(OpenSpaceToolkit_Physics_Time_Instant, DateTime)
 {
     using ostk::physics::time::Scale;
@@ -1817,6 +1832,308 @@ TEST(OpenSpaceToolkit_Physics_Time_Instant, ModifiedJulianDate)
         }
 
         EXPECT_ANY_THROW(Instant::ModifiedJulianDate(0.0, Scale::Undefined));
+    }
+}
+
+TEST(OpenSpaceToolkit_Physics_Time_Instant, Parse)
+{
+    using ostk::physics::time::Scale;
+    using ostk::physics::time::DateTime;
+    using ostk::physics::time::Instant;
+
+    // Undefined (automatic format detection)
+
+    {
+        // Standard
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 456, 789),
+            Instant::Parse("2018-01-02 12:34:56.123.456.789", Scale::UTC).getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 456, 789),
+            Instant::Parse("2018-01-02T12:34:56.123456789+0000", Scale::UTC).getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 456, 789),
+            Instant::Parse("2018-01-02 12:34:56.123.456.789+0000", Scale::UTC).getDateTime(Scale::UTC)
+        );
+
+        // ISO8601
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 456, 789),
+            Instant::Parse("2018-01-02T12:34:56.123456789", Scale::UTC).getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 456, 789),
+            Instant::Parse("2018-01-02T12:34:56.123456789Z", Scale::UTC).getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 456, 789),
+            Instant::Parse("2018-01-02 12:34:56.123.456.789Z", Scale::UTC).getDateTime(Scale::UTC)
+        );
+
+        // STK
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 456, 789),
+            Instant::Parse("2 Jan 2018 12:34:56.123456789", Scale::UTC).getDateTime(Scale::UTC)
+        );
+    }
+
+    // Standard
+
+    {
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56),
+            Instant::Parse("2018-01-02 12:34:56", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 100),
+            Instant::Parse("2018-01-02 12:34:56.1", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 120),
+            Instant::Parse("2018-01-02 12:34:56.12", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123),
+            Instant::Parse("2018-01-02 12:34:56.123", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 400),
+            Instant::Parse("2018-01-02 12:34:56.123.4", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 450),
+            Instant::Parse("2018-01-02 12:34:56.123.45", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 456),
+            Instant::Parse("2018-01-02 12:34:56.123.456", Scale::UTC, DateTime::Format::Standard)
+                .getDateTime(Scale::UTC)
+        );
+
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 456, 700),
+            Instant::Parse("2018-01-02 12:34:56.123.456.7", Scale::UTC, DateTime::Format::Standard)
+                .getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 456, 780),
+            Instant::Parse("2018-01-02 12:34:56.123.456.78", Scale::UTC, DateTime::Format::Standard)
+                .getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 456, 789),
+            Instant::Parse("2018-01-02 12:34:56.123.456.789", Scale::UTC, DateTime::Format::Standard)
+                .getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 456, 789),
+            Instant::Parse("2018-01-02 12:34:56.123.456.789+0000", Scale::UTC, DateTime::Format::Standard)
+                .getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 456, 789),
+            Instant::Parse("2018-01-02 12:34:56.123.456.789Z", Scale::UTC, DateTime::Format::Standard)
+                .getDateTime(Scale::UTC)
+        );
+    }
+
+    {
+        EXPECT_ANY_THROW(
+            Instant::Parse("1400-01-01 00:00:00", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+        EXPECT_ANY_THROW(
+            Instant::Parse("9999-12-31 23:59:59", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+        EXPECT_ANY_THROW(Instant::Parse("", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("abc", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("2018", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("2018-01", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("2018-01-02", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("2018-01-02 01", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+        EXPECT_ANY_THROW(
+            Instant::Parse("2018-01-02 1:34", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+        EXPECT_ANY_THROW(
+            Instant::Parse("2018-01-02 1:34:56", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+        EXPECT_ANY_THROW(
+            Instant::Parse("2018-01-02 12:3:56", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+        EXPECT_ANY_THROW(
+            Instant::Parse("2018-01-02 12:34:5", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+        EXPECT_ANY_THROW(
+            Instant::Parse("2018-00-01 24:34:56", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+        EXPECT_ANY_THROW(
+            Instant::Parse("2018-13-01 24:34:56", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+        EXPECT_ANY_THROW(
+            Instant::Parse("2018-01-00 24:34:56", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+        EXPECT_ANY_THROW(
+            Instant::Parse("2018-01-32 24:34:56", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+        EXPECT_ANY_THROW(
+            Instant::Parse("2018-01-02 24:34:56", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+        EXPECT_ANY_THROW(
+            Instant::Parse("2018-01-02 12:60:56", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+        EXPECT_ANY_THROW(
+            Instant::Parse("2018-01-02 12:34:61", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+        EXPECT_ANY_THROW(
+            Instant::Parse("2018-01-02 12:34:61.", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+        EXPECT_ANY_THROW(
+            Instant::Parse("2018-01-02 -12:34:56", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+        EXPECT_ANY_THROW(
+            Instant::Parse("1399-12-31 23:59:59", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+        EXPECT_ANY_THROW(
+            Instant::Parse("10000-01-01 00:00:00", Scale::UTC, DateTime::Format::Standard).getDateTime(Scale::UTC)
+        );
+    }
+
+    // ISO 8601
+
+    {
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56),
+            Instant::Parse("2018-01-02T12:34:56", Scale::UTC, DateTime::Format::ISO8601).getDateTime(Scale::UTC)
+        );
+
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 100),
+            Instant::Parse("2018-01-02T12:34:56.1", Scale::UTC, DateTime::Format::ISO8601).getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 120),
+            Instant::Parse("2018-01-02T12:34:56.12", Scale::UTC, DateTime::Format::ISO8601).getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123),
+            Instant::Parse("2018-01-02T12:34:56.123", Scale::UTC, DateTime::Format::ISO8601).getDateTime(Scale::UTC)
+        );
+
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 400),
+            Instant::Parse("2018-01-02T12:34:56.1234", Scale::UTC, DateTime::Format::ISO8601).getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 450),
+            Instant::Parse("2018-01-02T12:34:56.12345", Scale::UTC, DateTime::Format::ISO8601).getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 456),
+            Instant::Parse("2018-01-02T12:34:56.123456", Scale::UTC, DateTime::Format::ISO8601).getDateTime(Scale::UTC)
+        );
+
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 456, 700),
+            Instant::Parse("2018-01-02T12:34:56.1234567", Scale::UTC, DateTime::Format::ISO8601).getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 456, 780),
+            Instant::Parse("2018-01-02T12:34:56.12345678", Scale::UTC, DateTime::Format::ISO8601)
+                .getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 456, 789),
+            Instant::Parse("2018-01-02T12:34:56.123456789", Scale::UTC, DateTime::Format::ISO8601)
+                .getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 456, 789),
+            Instant::Parse("2018-01-02T12:34:56.123456789+0000", Scale::UTC, DateTime::Format::ISO8601)
+                .getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 456, 789),
+            Instant::Parse("2018-01-02T12:34:56.123456789Z", Scale::UTC, DateTime::Format::ISO8601)
+                .getDateTime(Scale::UTC)
+        );
+    }
+
+    // STK
+
+    {
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56),
+            Instant::Parse("2 Jan 2018 12:34:56", Scale::UTC, DateTime::Format::STK).getDateTime(Scale::UTC)
+        );
+
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 100),
+            Instant::Parse("2 Jan 2018 12:34:56.1", Scale::UTC, DateTime::Format::STK).getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 120),
+            Instant::Parse("2 Jan 2018 12:34:56.12", Scale::UTC, DateTime::Format::STK).getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123),
+            Instant::Parse("2 Jan 2018 12:34:56.123", Scale::UTC, DateTime::Format::STK).getDateTime(Scale::UTC)
+        );
+
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 400),
+            Instant::Parse("2 Jan 2018 12:34:56.1234", Scale::UTC, DateTime::Format::STK).getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 450),
+            Instant::Parse("2 Jan 2018 12:34:56.12345", Scale::UTC, DateTime::Format::STK).getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 456),
+            Instant::Parse("2 Jan 2018 12:34:56.123456", Scale::UTC, DateTime::Format::STK).getDateTime(Scale::UTC)
+        );
+
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 456, 700),
+            Instant::Parse("2 Jan 2018 12:34:56.1234567", Scale::UTC, DateTime::Format::STK).getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 456, 780),
+            Instant::Parse("2 Jan 2018 12:34:56.12345678", Scale::UTC, DateTime::Format::STK).getDateTime(Scale::UTC)
+        );
+        EXPECT_EQ(
+            DateTime(2018, 1, 2, 12, 34, 56, 123, 456, 789),
+            Instant::Parse("2 Jan 2018 12:34:56.123456789", Scale::UTC, DateTime::Format::STK).getDateTime(Scale::UTC)
+        );
+    }
+
+    {
+        EXPECT_ANY_THROW(Instant::Parse("", Scale::UTC).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("abc", Scale::UTC).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("2018", Scale::UTC).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("2018-01", Scale::UTC).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("2018-01-02", Scale::UTC).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("2018-01-02T01", Scale::UTC).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("2018-01-02T1:34", Scale::UTC).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("2018-01-02T1:34:56", Scale::UTC).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("2018-01-02T12:3:56", Scale::UTC).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("2018-01-02T12:34:5", Scale::UTC).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("2018-00-01T24:34:56", Scale::UTC).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("2018-13-01T24:34:56", Scale::UTC).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("2018-01-00T24:34:56", Scale::UTC).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("2018-01-32T24:34:56", Scale::UTC).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("2018-01-02T24:34:56", Scale::UTC).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("2018-01-02T12:60:56", Scale::UTC).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("2018-01-02T12:34:61", Scale::UTC).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("2018-01-02T12:34:61.", Scale::UTC).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("2018-01-02T-12:34:56", Scale::UTC).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("1399-12-31T23:59:59", Scale::UTC).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("10000-01-01T00:00:00", Scale::UTC).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("2018-01-02T12:34:56.123.456", Scale::UTC).getDateTime(Scale::UTC));
+        EXPECT_ANY_THROW(Instant::Parse("2018-01-02T12:34:56.123.456.789", Scale::UTC).getDateTime(Scale::UTC));
     }
 }
 


### PR DESCRIPTION
Add a utility function that lets us do:

`Instant.parse("2021-12-02 00:00:00.000", Scale.UTC)`
instead of:
`Instant.date_time(DateTime.parse("2021-12-02 00:00:00.000", Scale.UTC))`

Also adds a shortcut for the GPS epoch, which is Jan 6, 1980 UTC
`Instant.GPS_epoch()`