### PR TITLE
build: limit max numpy version to below 2.0.0

### DIFF
--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -1,6 +1,6 @@
 # Apache License 2.0
 
-numpy>=1.17.4
+numpy>=1.17.4,<2.0.0
 
 open-space-toolkit-core~=3.0
 open-space-toolkit-io~=3.0


### PR DESCRIPTION
Since numpy 2.0.0 seems to break the numpy <-> eigen conversion in the bindings