### PR TITLE
feat: add gravitational Earth constructor required directory

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Earth.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Earth.cpp
@@ -74,6 +74,21 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Earth(pybind11::
             )
 
             .def(
+                init<const Earth::Type&, const Integer&, const Integer&>(),
+                arg("type"),
+                arg("gravitational_model_degree"),
+                arg("gravitational_model_order"),
+                R"doc(
+                    Construct an Earth gravitational model.
+
+                    Args:
+                        type (Earth.Type): Earth model type.
+                        gravitational_model_degree (int): Degree of the gravitational model.
+                        gravitational_model_order (int): Order of the gravitational model.
+                )doc"
+            )
+
+            .def(
                 "is_defined",
                 &Earth::isDefined,
                 R"doc(

--- a/bindings/python/test/environment/gravitational/test_earth.py
+++ b/bindings/python/test/environment/gravitational/test_earth.py
@@ -55,6 +55,14 @@ class TestEarth:
         assert isinstance(earth_gravitational_model, EarthGravitationalModel)
         assert isinstance(earth_gravitational_model, GravitationalModel)
 
+    def test_constructor_success_without_directory_with_degree_and_order(self):
+        earth_gravitational_model = EarthGravitationalModel(
+            EarthGravitationalModel.Type.EGM2008, 2, 2
+        )
+
+        assert isinstance(earth_gravitational_model, EarthGravitationalModel)
+        assert isinstance(earth_gravitational_model, GravitationalModel)
+
     def test_get_type_success(self, earth_gravitational_model: EarthGravitationalModel):
         assert (
             earth_gravitational_model.get_type() == EarthGravitationalModel.Type.EGM2008

--- a/include/OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.hpp
@@ -62,7 +62,7 @@ class Earth : public Model
         EGM2008       ///< The Earth Gravity Model 2008, which includes terms up to degree 2190.
     };
 
-    /// @brief              Constructor with max degree and order variables
+    /// @brief              Constructor with directory specification and max degree and order variables
     ///
     /// @param              [in] aType A gravitational model type
     /// @param              [in] (optional) aDataDirectory A gravitational model data directory
@@ -75,6 +75,14 @@ class Earth : public Model
         const Integer& aGravityModelDegree = Integer::Undefined(),
         const Integer& aGravityModelOrder = Integer::Undefined()
     );
+
+    /// @brief              Constructor with max degree and order variables
+    ///
+    /// @param              [in] aType A gravitational model type
+    /// @param              [in] aGravityModelDegree A gravitational model degree
+    /// @param              [in] aGravityModelOrder A gravitational model order
+
+    Earth(const Earth::Type& aType, const Integer& aGravityModelDegree, const Integer& aGravityModelOrder);
 
     /// @brief              Copy constructor
     ///

--- a/src/OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.cpp
@@ -409,6 +409,11 @@ Earth::Earth(
 {
 }
 
+Earth::Earth(const Earth::Type& aType, const Integer& aGravityModelDegree, const Integer& aGravityModelOrder)
+    : Earth(aType, Directory::Undefined(), aGravityModelDegree, aGravityModelOrder)
+{
+}
+
 Earth::Earth(const Earth& anEarthGravitationalModel)
     : Model(anEarthGravitationalModel),
       implUPtr_(

--- a/test/OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.test.cpp
@@ -156,6 +156,27 @@ TEST(OpenSpaceToolkit_Physics_Environment_Gravitational_Earth, Constructor)
             EarthGravitationalModel::Type::EGM2008, Directory::Path(Path::Parse("/does/not/exist"))
         ));
     }
+
+    // Test succinct constructor without directory
+
+    {
+        EarthGravitationalModelManager::Get().setLocalRepository(
+            Directory::Path(Path::Parse("/app/test/OpenSpaceToolkit/Physics/Environment/Gravitational/Earth"))
+        );
+
+        EarthGravitationalModelManager::Get().setMode(EarthGravitationalModelManager::Mode::Automatic);
+
+        EXPECT_NO_THROW(std::make_shared<EarthGravitationalModel>(EarthGravitationalModel::Type::Spherical, 3000, 3000)
+        );
+
+        EXPECT_ANY_THROW(std::make_shared<EarthGravitationalModel>(EarthGravitationalModel::Type::WGS84, 3000, 3000));
+        EXPECT_ANY_THROW(std::make_shared<EarthGravitationalModel>(EarthGravitationalModel::Type::EGM84, 3000, 3000));
+        EXPECT_ANY_THROW(std::make_shared<EarthGravitationalModel>(EarthGravitationalModel::Type::EGM96, 3000, 3000));
+        EXPECT_ANY_THROW(std::make_shared<EarthGravitationalModel>(EarthGravitationalModel::Type::EGM2008, 3000, 3000));
+
+        EarthGravitationalModelManager::Get().setLocalRepository(EarthGravitationalModelManager::DefaultLocalRepository(
+        ));
+    }
 }
 
 TEST(OpenSpaceToolkit_Physics_Environment_Gravitational_Earth, IsDefined)


### PR DESCRIPTION
Currently when creating a gravitational model with specific degree/order, you must pass in a dummy directory to fill the argument slot:

```
earth = Earth(
  Type.EGM96,
  Directory.Undefined(),
  10,
  10,
)
```

This adds a new constructor so that the Directory is no longer required:
```
earth = Earth(
  Type.EGM96,
  10,
  10,
)
```