### PR TITLE
refactor: loosen datetime conversion limit to 2554 (from 2030)

### DIFF
--- a/src/OpenSpaceToolkit/Physics/Time/Instant.cpp
+++ b/src/OpenSpaceToolkit/Physics/Time/Instant.cpp
@@ -432,26 +432,13 @@ Instant Instant::DateTime(const time::DateTime& aDateTime, const Scale& aTimeSca
         throw ostk::core::error::runtime::Wrong("Scale");
     }
 
-    if ((aDateTime.accessDate().getYear() < 1970) || (aDateTime.accessDate().getYear() > 2030))
+    // Limit the year based on the max number of nanoseconds we can store with a UInt64
+    if ((aDateTime.accessDate().getYear() < 1970) || (aDateTime.accessDate().getYear() > 2500))
     {
         throw ostk::core::error::RuntimeError(
-            "DateTime year {} out of supported range [{} - {}]", aDateTime.accessDate().getYear(), 1970, 2030
+            "DateTime year {} out of supported range [{} - {}]", aDateTime.accessDate().getYear(), 1970, 2500
         );
     }
-
-    // auto getTimePointString =
-    // [ ] (const std::chrono::time_point<std::chrono::system_clock>& aTimePoint) -> String
-    // {
-
-    //     const std::time_t time = std::chrono::system_clock::to_time_t(aTimePoint) ;
-
-    //     std::stringstream stringStream ;
-
-    //     stringStream << std::put_time(std::gmtime(&time), "%F %T %z") ;
-
-    //     return stringStream.str() ;
-
-    // } ;
 
     // Epoch
 
@@ -504,9 +491,6 @@ Instant Instant::DateTime(const time::DateTime& aDateTime, const Scale& aTimeSca
                           aDateTime.accessTime().getMicrosecond() * 1000 - aDateTime.accessTime().getNanosecond();
         postEpoch = false;
     }
-
-    // const Int64 nanosecondCount = nanoseconds.count() + aDateTime.accessTime().getMillisecond() * 1000000 +
-    // aDateTime.accessTime().getMicrosecond() * 1000 + aDateTime.accessTime().getNanosecond() ;
 
     // Output
 

--- a/src/OpenSpaceToolkit/Physics/Time/Instant.cpp
+++ b/src/OpenSpaceToolkit/Physics/Time/Instant.cpp
@@ -433,10 +433,10 @@ Instant Instant::DateTime(const time::DateTime& aDateTime, const Scale& aTimeSca
     }
 
     // Limit the year based on the max number of nanoseconds we can store with a UInt64
-    if ((aDateTime.accessDate().getYear() < 1970) || (aDateTime.accessDate().getYear() > 2500))
+    if ((aDateTime.accessDate().getYear() < 1970) || (aDateTime.accessDate().getYear() > 2554))
     {
         throw ostk::core::error::RuntimeError(
-            "DateTime year {} out of supported range [{} - {}]", aDateTime.accessDate().getYear(), 1970, 2500
+            "DateTime year {} out of supported range [{} - {}]", aDateTime.accessDate().getYear(), 1970, 2554
         );
     }
 

--- a/test/OpenSpaceToolkit/Physics/Time/Instant.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Time/Instant.test.cpp
@@ -1777,7 +1777,7 @@ TEST(OpenSpaceToolkit_Physics_Time_Instant, DateTime)
         for (const auto scale : scales)
         {
             EXPECT_ANY_THROW(Instant::DateTime(DateTime(1969, 1, 1, 0, 0, 0), scale));
-            EXPECT_ANY_THROW(Instant::DateTime(DateTime(2031, 1, 1, 0, 0, 0), scale));
+            EXPECT_ANY_THROW(Instant::DateTime(DateTime(2501, 1, 1, 0, 0, 0), scale));
         }
     }
 }

--- a/test/OpenSpaceToolkit/Physics/Time/Instant.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Time/Instant.test.cpp
@@ -1777,7 +1777,7 @@ TEST(OpenSpaceToolkit_Physics_Time_Instant, DateTime)
         for (const auto scale : scales)
         {
             EXPECT_ANY_THROW(Instant::DateTime(DateTime(1969, 1, 1, 0, 0, 0), scale));
-            EXPECT_ANY_THROW(Instant::DateTime(DateTime(2501, 1, 1, 0, 0, 0), scale));
+            EXPECT_ANY_THROW(Instant::DateTime(DateTime(2555, 1, 1, 0, 0, 0), scale));
         }
     }
 }


### PR DESCRIPTION
The hypothesis about this limit is that we want to avoid overflow of the Uint64 nanosecond count value that is stored.
The number of years we can store is roughly 584.8, so this sets the limit to 584 years in the future.