### PR TITLE
fix: change error condition that tried to reference a function from a null pointer

### DIFF
--- a/src/OpenSpaceToolkit/Physics/Coordinate/Axes.cpp
+++ b/src/OpenSpaceToolkit/Physics/Coordinate/Axes.cpp
@@ -105,7 +105,7 @@ Axes Axes::inFrame(const Shared<const Frame>& aFrameSPtr, const Instant& anInsta
 {
     using ostk::physics::coordinate::Transform;
 
-    if ((aFrameSPtr == nullptr) && (!aFrameSPtr->isDefined()))
+    if ((aFrameSPtr == nullptr) || (!aFrameSPtr->isDefined()))
     {
         throw ostk::core::error::runtime::Undefined("Frame");
     }


### PR DESCRIPTION


Fixes a small potential undefined behavior that I saw the compiler complaining about:
```
/app/src/OpenSpaceToolkit/Physics/Coordinate/Axes.cpp:108:59: warning: 'this' pointer is null [-Wnonnull]
  108 |     if ((aFrameSPtr == nullptr) && (!aFrameSPtr->isDefined()))
      |                                      ~~~~~~~~~~~~~~~~~~~~~^~
In file included from /app/src/OpenSpaceToolkit/Physics/Coordinate/Axes.cpp:7:
/app/include/OpenSpaceToolkit/Physics/Coordinate/Frame.hpp:63:10: note: in a call to non-static member function 'bool ostk::physics::coordinate::Frame::isDefined() const'
   63 |     bool isDefined() const;
      |          ^~~~~~~~~
```

If the second part of the `&&` were ever reached, we would get undefined behavior and likely a crash. Not a huge deal since the code is about to throw an error anyway, but would probably be confusing.