### PR TITLE
refactor: change Interval and Instant toString to print Undefined instead of throwing an exception

### DIFF
--- a/src/OpenSpaceToolkit/Physics/Time/Instant.cpp
+++ b/src/OpenSpaceToolkit/Physics/Time/Instant.cpp
@@ -338,7 +338,7 @@ String Instant::toString(const Scale& aTimeScale, const DateTime::Format& aDateT
 {
     if (!this->isDefined())
     {
-        throw ostk::core::error::runtime::Undefined("Instant");
+        return String("Undefined");
     }
 
     if ((aDateTimeFormat == DateTime::Format::ISO8601) && (aTimeScale == Scale::UTC))

--- a/src/OpenSpaceToolkit/Physics/Time/Interval.cpp
+++ b/src/OpenSpaceToolkit/Physics/Time/Interval.cpp
@@ -104,7 +104,7 @@ String Interval::toString(const Scale& aTimeScale) const
 
     if (!this->isDefined())
     {
-        throw ostk::core::error::runtime::Undefined("Interval");
+        return String("Undefined");
     }
 
     switch (this->getType())

--- a/test/OpenSpaceToolkit/Physics/Time/Instant.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Time/Instant.test.cpp
@@ -1642,7 +1642,10 @@ TEST(OpenSpaceToolkit_Physics_Time_Instant, ToString)
     {
         for (auto const& scale : scales)
         {
-            EXPECT_ANY_THROW(Instant::Undefined().toString(scale));
+            EXPECT_EQ(
+                "Undefined",
+                Instant::Undefined().toString(scale)
+            );
         }
     }
 

--- a/test/OpenSpaceToolkit/Physics/Time/Interval.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Time/Interval.test.cpp
@@ -334,7 +334,10 @@ TEST(OpenSpaceToolkit_Physics_Time_Interval, ToString)
     }
 
     {
-        EXPECT_ANY_THROW(Interval::Undefined().toString(Scale::TT));
+        EXPECT_EQ(
+            "Undefined",
+            Interval::Undefined().toString(Scale::TT)
+        );
     }
 }
 


### PR DESCRIPTION
change Interval and Instant toString to print Undefined insteat of throwing an exception