### PR TITLE
fix: Engine manual mode load kernels

### DIFF
--- a/src/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Engine.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Engine.cpp
@@ -351,20 +351,11 @@ void Engine::setup()
 
     errdev_c("SET", 4096, (SpiceChar*)"NULL");
 
-    if (mode_ == Engine::Mode::Automatic)
+    // Load default kernels
+
+    for (const auto& kernel : Engine::DefaultKernels())
     {
-        Directory kernelDirectory = Manager::Get().getLocalRepository();
-        if (!kernelDirectory.exists())
-        {
-            kernelDirectory.create();
-        }
-
-        // Load default kernels
-
-        for (const auto& kernel : Engine::DefaultKernels())
-        {
-            this->loadKernel_(kernel);
-        }
+        this->loadKernel_(kernel);
     }
 }
 
@@ -436,15 +427,15 @@ void Engine::loadKernel_(const Kernel& aKernel)
         return;
     }
 
-    const File kernelFile = aKernel.getFile();
+    File kernelFile = aKernel.getFile();
 
     if (!kernelFile.exists())
     {
         if (mode_ == Engine::Mode::Automatic)
         {
-            // Fetch kernel
-
             Manager::Get().fetchKernel(aKernel);
+            const Path filePath = Manager::Get().getLocalRepository().getPath() + Path::Parse(aKernel.getName());
+            kernelFile = File::Path(filePath);
         }
         else
         {

--- a/test/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE.test.cpp
@@ -21,31 +21,31 @@
 
 using ostk::physics::environment::ephemeris::SPICE;
 
-using ostk::core::type::Shared;
-using ostk::core::type::Real;
-using ostk::core::type::String;
-using ostk::core::container::Tuple;
 using ostk::core::container::Array;
 using ostk::core::container::Table;
-using ostk::core::filesystem::Path;
-using ostk::core::filesystem::File;
+using ostk::core::container::Tuple;
 using ostk::core::filesystem::Directory;
+using ostk::core::filesystem::File;
+using ostk::core::filesystem::Path;
+using ostk::core::type::Real;
+using ostk::core::type::Shared;
+using ostk::core::type::String;
 
-using ostk::mathematics::object::Vector3d;
 using ostk::mathematics::geometry::d3::transformation::rotation::Quaternion;
 using ostk::mathematics::geometry::d3::transformation::rotation::RotationVector;
+using ostk::mathematics::object::Vector3d;
 
-using ostk::physics::unit::Angle;
-using ostk::physics::time::Scale;
-using ostk::physics::time::Instant;
-using ostk::physics::time::DateTime;
 using ostk::physics::coordinate::Frame;
 using ostk::physics::coordinate::Position;
 using ostk::physics::coordinate::Transform;
+using ostk::physics::time::DateTime;
+using ostk::physics::time::Instant;
+using ostk::physics::time::Scale;
+using ostk::physics::unit::Angle;
 
 using ostk::physics::environment::ephemeris::spice::Engine;
-using ostk::physics::environment::ephemeris::spice::Manager;
 using ostk::physics::environment::ephemeris::spice::Kernel;
+using ostk::physics::environment::ephemeris::spice::Manager;
 
 TEST(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE, Constructor)
 {
@@ -247,7 +247,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE, ManualMode)
 
         Position sunPosition = Position::Undefined();
 
-        EXPECT_ANY_THROW({ sunPosition = sunFrameSPtr->getOriginIn(Frame::GCRF(), instant); });
+        EXPECT_NO_THROW({ sunPosition = sunFrameSPtr->getOriginIn(Frame::GCRF(), instant); });
 
         Engine::Get().loadKernel(Kernel::File(File::Path(spiceLocalRepository.getPath() + Path::Parse("./naif0012.tls"))
         ));
@@ -301,28 +301,5 @@ TEST(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE, AutomaticMode)
         Engine::Get().setMode(Engine::DefaultMode());
 
         Engine::Get().reset();
-    }
-}
-
-TEST(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Engine, DefaultKernels)
-{
-    using ostk::core::container::Array;
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::Directory;
-
-    using ostk::physics::environment::ephemeris::spice::Engine;
-    using ostk::physics::environment::ephemeris::spice::Kernel;
-
-    {
-        Manager::Get().setLocalRepository(
-            Directory::Path(Path::Parse("/app/test/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE"))
-        );
-
-        const Array<Kernel> kernels = Engine::DefaultKernels();
-
-        for (const auto& kernel : kernels)
-        {
-            EXPECT_TRUE(kernel.isDefined());
-        }
     }
 }

--- a/test/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Engine.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Engine.test.cpp
@@ -1,0 +1,154 @@
+/// Apache License 2.0
+
+#include <gtest/gtest.h>
+
+#include <OpenSpaceToolkit/Core/FileSystem/File.hpp>
+#include <OpenSpaceToolkit/Core/Type/Shared.hpp>
+#include <OpenSpaceToolkit/Core/Type/String.hpp>
+
+#include <OpenSpaceToolkit/Physics/Coordinate/Frame.hpp>
+#include <OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Engine.hpp>
+#include <OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Kernel.hpp>
+#include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
+
+using ostk::core::container::Array;
+using ostk::core::filesystem::File;
+using ostk::core::filesystem::Path;
+using ostk::core::type::Shared;
+using ostk::core::type::String;
+
+using ostk::physics::coordinate::Frame;
+using ostk::physics::environment::ephemeris::SPICE;
+using ostk::physics::environment::ephemeris::spice::Engine;
+using ostk::physics::environment::ephemeris::spice::Kernel;
+using ostk::physics::time::Instant;
+
+class OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Engine : public ::testing::Test
+{
+   protected:
+    Engine& engine_;
+    Kernel kernel_;
+
+    OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Engine()
+        : engine_(Engine::Get()),
+          kernel_(Kernel::File(
+              File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/de430.bsp"))
+          ))
+    {
+    }
+
+    void SetUp() override
+    {
+        engine_.loadKernel(kernel_);
+    }
+
+    void TearDown() override
+    {
+        engine_.unloadKernel(kernel_);
+        engine_.setMode(Engine::Mode::Automatic);
+    }
+};
+
+TEST_F(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Engine, IsKernelLoaded_Automatic)
+{
+    EXPECT_TRUE(engine_.isKernelLoaded(kernel_));
+
+    engine_.unloadKernel(kernel_);
+    EXPECT_FALSE(engine_.isKernelLoaded(kernel_));
+}
+
+TEST_F(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Engine, IsKernelLoaded_Manual)
+{
+    engine_.setMode(Engine::Mode::Manual);
+
+    EXPECT_TRUE(engine_.isKernelLoaded(kernel_));
+
+    engine_.unloadKernel(kernel_);
+    EXPECT_FALSE(engine_.isKernelLoaded(kernel_));
+}
+
+TEST_F(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Engine, GetMode)
+{
+    engine_.setMode(Engine::Mode::Automatic);
+    EXPECT_EQ(engine_.getMode(), Engine::Mode::Automatic);
+
+    engine_.setMode(Engine::Mode::Manual);
+    EXPECT_EQ(engine_.getMode(), Engine::Mode::Manual);
+}
+
+TEST_F(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Engine, GetFrameOf)
+{
+    {
+        Shared<const Frame> frame = engine_.getFrameOf(SPICE::Object::Earth);
+
+        EXPECT_TRUE(frame != nullptr);
+        EXPECT_EQ(frame->getName(), "Earth (SPICE)");
+    }
+
+    {
+        engine_.setMode(Engine::Mode::Manual);
+        engine_.reset();
+
+        Shared<const Frame> frame = engine_.getFrameOf(SPICE::Object::Earth);
+
+        EXPECT_TRUE(frame != nullptr);
+        EXPECT_EQ(frame->getName(), "Earth (SPICE)");
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Engine, LoadKernel)
+{
+    {
+        EXPECT_NO_THROW(engine_.loadKernel(kernel_));
+        EXPECT_TRUE(engine_.isKernelLoaded(kernel_));
+    }
+
+    {
+        engine_.reset();
+        const Kernel newKernel = Kernel::File(File::Path(Path::Parse("de430.bsp")));
+
+        // automatic
+        {
+            EXPECT_NO_THROW(engine_.loadKernel(newKernel));
+        }
+
+        // manual
+        {
+            engine_.setMode(Engine::Mode::Manual);
+            engine_.reset();
+
+            EXPECT_ANY_THROW(engine_.loadKernel(newKernel));
+        }
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Engine, UnloadKernel)
+{
+    EXPECT_TRUE(engine_.isKernelLoaded(kernel_));
+
+    EXPECT_NO_THROW(engine_.unloadKernel(kernel_));
+    EXPECT_FALSE(engine_.isKernelLoaded(kernel_));
+}
+
+TEST_F(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Engine, Reset)
+{
+    EXPECT_TRUE(engine_.isKernelLoaded(kernel_));
+
+    engine_.reset();
+    EXPECT_FALSE(engine_.isKernelLoaded(kernel_));
+}
+
+TEST_F(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Engine, DefaultMode)
+{
+    EXPECT_NO_THROW(Engine::DefaultMode());
+}
+
+TEST_F(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Engine, DefaultKernels)
+{
+    const Array<Kernel> kernels = Engine::DefaultKernels();
+
+    for (const auto& kernel : kernels)
+    {
+        EXPECT_TRUE(kernel.isDefined());
+    }
+}


### PR DESCRIPTION
Updated the Engine to load kernels in both manual and automatic mode. In manual mode, if the kernel does not exist, it raises an error, in automatic mode, the kernel is fetched and then loaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced kernel loading process for improved flexibility.
	- Introduced a comprehensive suite of unit tests for the `Engine` class, validating its functionality.

- **Bug Fixes**
	- Updated expected behavior in tests to reflect changes in the `getOriginIn` function.

- **Documentation**
	- Improved clarity and accessibility of types in test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->