### PR TITLE
chore: rearrange bindings creation order

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy.cxx
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy.cxx
@@ -36,6 +36,6 @@ PYBIND11_MODULE(OpenSpaceToolkitPhysicsPy, m)
     OpenSpaceToolkitPhysicsPy_Unit(m);
     OpenSpaceToolkitPhysicsPy_Time(m);
     OpenSpaceToolkitPhysicsPy_Coordinate(m);
-    OpenSpaceToolkitPhysicsPy_Data(m);
     OpenSpaceToolkitPhysicsPy_Environment(m);
+    OpenSpaceToolkitPhysicsPy_Data(m);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Adjusted the order of submodule initialization in the Python bindings for improved organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->