### PR TITLE
build: boost 1.87 compatibility

### DIFF
--- a/src/OpenSpaceToolkit/Physics/Manager.cpp
+++ b/src/OpenSpaceToolkit/Physics/Manager.cpp
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <numeric>


### PR DESCRIPTION
Boost 1.87 silently dropped support for their `compatibility` library:
- https://github.com/boostorg/boost/compare/boost-1.86.0...boost-1.87.0#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584L356
- https://github.com/boostorg/compatibility/issues/8

This file makes a call to `strcmp` further below, but never explicitly included `<cstring>`. I suspect this library only compiled up til now because `compatibility` had [included](https://www.boost.org/doc/libs/1_86_0/boost/compatibility/cpp_c_headers/cstring) the function. I'm guessing this wasn't intentional. 

This fix should mean this library is now prepped to use Boost 1.87. 

Confirmed locally that this now builds with boost 1.87 and passes all the tests. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Added standard C++ string manipulation header for internal processing
	- Minor internal dependency update for string comparison functionality
<!-- end of auto-generated comment: release notes by coderabbit.ai -->