### PR TITLE
chore: fix dockerfile and setuptools warnings, bump ostk-core and boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,9 +335,9 @@ ELSE ()
     MESSAGE (SEND_ERROR "[GeographicLib] not found.")
 ENDIF ()
 
-### Open Space Toolkit ▸ Core [4.x.y]
+### Open Space Toolkit ▸ Core [5.x.y]
 
-FIND_PACKAGE ("OpenSpaceToolkitCore" "4" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitCore" "5" REQUIRED)
 
 IF (NOT OpenSpaceToolkitCore_FOUND)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,7 +236,7 @@ ENDFOREACH ()
 
 ## Dependencies
 
-### Boost [1.82.0]
+### Boost [1.87.0]
 
 IF (BUILD_WITH_BOOST_STATIC)
     SET (Boost_USE_STATIC_LIBS ON)
@@ -248,7 +248,7 @@ SET (Boost_USE_MULTITHREADED ON)
 
 IF (BUILD_WITH_BOOST_STACKTRACE)
 
-    FIND_PACKAGE ("Boost" "1.82" REQUIRED COMPONENTS "date_time" "regex" "filesystem")
+    FIND_PACKAGE ("Boost" "1.87" REQUIRED COMPONENTS "date_time" "regex" "filesystem")
 
     ## Stacktrace definitions
     # Detect system architecture
@@ -266,7 +266,7 @@ IF (BUILD_WITH_BOOST_STACKTRACE)
     ADD_DEFINITIONS(-DBOOST_STACKTRACE_USE_BACKTRACE)
     ADD_DEFINITIONS(-DBOOST_STACKTRACE_BACKTRACE_INCLUDE_FILE=<${BACKTRACE_INCLUDE}>)
 ELSE()
-    FIND_PACKAGE ("Boost" "1.82" REQUIRED COMPONENTS "date_time" "regex" "filesystem" "stacktrace_basic")
+    FIND_PACKAGE ("Boost" "1.87" REQUIRED COMPONENTS "date_time" "regex" "filesystem" "stacktrace_basic")
 ENDIF()
 
 IF (NOT Boost_FOUND)

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -1,5 +1,5 @@
 # Apache License 2.0
 
-open-space-toolkit-core~=4.1
+open-space-toolkit-core~=5.0
 open-space-toolkit-io~=4.0
 open-space-toolkit-mathematics~=4.3

--- a/bindings/python/tools/python/setup.cfg.in
+++ b/bindings/python/tools/python/setup.cfg.in
@@ -1,9 +1,9 @@
 # Apache License 2.0
 
 [bdist_wheel]
-python-tag=py${EXTENSION}
-bdist-dir=./dist${EXTENSION}
-plat-name=${PLATFORM}
+python_tag=py${EXTENSION}
+bdist_dir=./dist${EXTENSION}
+plat_name=${PLATFORM}
 
 [metadata]
 name = open-space-toolkit-physics

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE_VERSION="latest"
 
 # General purpose development image (root user)
 
-FROM openspacecollective/open-space-toolkit-base-development:${BASE_IMAGE_VERSION} as root-user
+FROM openspacecollective/open-space-toolkit-base-development:${BASE_IMAGE_VERSION} AS root-user
 
 LABEL maintainer="lucas@loftorbital.com"
 
@@ -192,7 +192,7 @@ LABEL VERSION="${VERSION}"
 
 # Development image for humans (non-root user)
 
-FROM root-user as non-root-user
+FROM root-user AS non-root-user
 
 # Install dev utilities
 

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -129,7 +129,7 @@ RUN git clone https://github.com/geographiclib/geographiclib /tmp/geographiclib 
 ## Open Space Toolkit ▸ Core
 
 ARG TARGETPLATFORM
-ARG OSTK_CORE_MAJOR="4"
+ARG OSTK_CORE_MAJOR="5"
 
 ## Force an image rebuild when new Core minor or patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-core/git/matching-refs/tags/${OSTK_CORE_MAJOR} /tmp/open-space-toolkit-core/versions.json

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -6,7 +6,7 @@ FROM ${JUPYTER_NOTEBOOK_IMAGE_REPOSITORY}
 
 LABEL maintainer="lucas@loftorbital.com"
 
-ENV JUPYTER_ENABLE_LAB yes
+ENV JUPYTER_ENABLE_LAB="yes"
 
 # Set user to root
 

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -5,7 +5,7 @@ ARG VERSION
 ARG PYTHON_TEST_VERSION="3.11"
 ARG PYTHON_TEST_VERSION_WITHOUT_DOT="311"
 
-FROM openspacecollective/open-space-toolkit-physics-development:${VERSION} as cpp-builder
+FROM openspacecollective/open-space-toolkit-physics-development:${VERSION} AS cpp-builder
 
 RUN mkdir -p /app/bin /app/build /app/lib
 
@@ -28,7 +28,7 @@ RUN cmake .. \
  && make -j $(nproc) \
  && make install
 
-FROM debian:buster as cpp-release
+FROM debian:buster AS cpp-release
 
 ENV LD_LIBRARY_PATH="/usr/local/lib"
 
@@ -46,13 +46,13 @@ COPY --from=cpp-builder /usr/local/test/OpenSpaceToolkit /usr/local/test/OpenSpa
 
 ENTRYPOINT ["/usr/local/test/OpenSpaceToolkit/Physics/open-space-toolkit-physics.test"]
 
-FROM python:${PYTHON_TEST_VERSION}-slim as python-builder
+FROM python:${PYTHON_TEST_VERSION}-slim AS python-builder
 
 COPY --from=cpp-builder /app/build/bindings/python/dist /dist
 
 RUN pip install /dist/*${PYTHON_TEST_VERSION_WITHOUT_DOT}*.whl
 
-FROM python:${PYTHON_TEST_VERSION}-slim as python-release
+FROM python:${PYTHON_TEST_VERSION}-slim AS python-release
 
 LABEL maintainer="lucas@loftorbital.com"
 


### PR DESCRIPTION
In addition to the changes [described here](https://github.com/open-space-collective/open-space-toolkit-core/pull/181), also bumps the ostk-core dependency to 5.0 following [its release](https://github.com/open-space-collective/open-space-toolkit-core/releases/tag/5.0.0) (no breaking changes expected for this repo), and bumps Boost to 1.87 following the [bump in the base image](https://github.com/open-space-collective/open-space-toolkit/releases/tag/0.8.4). 