### PR TITLE
fix!: stubs breaking mypy

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -162,9 +162,9 @@ FUNCTION (PY_ADD_PACKAGE_DIRECTORY NAME)
                             COMMAND cp "${CMAKE_SOURCE_DIR}/lib/${LIBRARY_TARGET}.*${EXTENSION}*.so" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_PATH}/"
                             COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/requirements.txt" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/requirements.txt"
                             COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/README.md" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/README.md"
-                            COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/py.typed" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_PATH}/py.typed"
                             COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" && python${PYTHON_VERSION} -m pip install .
                             COMMAND python${PYTHON_VERSION} -m "pybind11_stubgen" -o "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" "${PROJECT_GROUP}.${PROJECT_SUBGROUP}" # generate stubs in same dir as binaries
+                            COMMAND find "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_GROUP}" -type f -name "*.pyi" -exec sed -i "s/: \\\\.\\\\.\\\\./: typing.Any/g" {} + # crudely fix stubs with invalid syntax
                             COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" && python${PYTHON_VERSION} -m build --no-isolation -w
                             COMMAND mkdir -p "${CMAKE_CURRENT_BINARY_DIR}/dist"
                             COMMAND cp "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/dist/*" "${CMAKE_CURRENT_BINARY_DIR}/dist"

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Unit.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Unit.cpp
@@ -38,7 +38,7 @@ inline void OpenSpaceToolkitPhysicsPy_Unit(pybind11::module& aModule)
             )doc"
         )
         .value(
-            "None",
+            "NoneType",
             Unit::Type::None,
             R"doc(
                 None unit type.

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Unit.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Unit.cpp
@@ -38,10 +38,10 @@ inline void OpenSpaceToolkitPhysicsPy_Unit(pybind11::module& aModule)
             )doc"
         )
         .value(
-            "Dimensionless",
-            Unit::Type::Dimensionless,
+            "None_",
+            Unit::Type::None,
             R"doc(
-                Dimensionless unit type.
+                None unit type.
             )doc"
         )
         .value(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Unit.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Unit.cpp
@@ -38,10 +38,10 @@ inline void OpenSpaceToolkitPhysicsPy_Unit(pybind11::module& aModule)
             )doc"
         )
         .value(
-            "NoneType",
-            Unit::Type::None,
+            "Dimensionless",
+            Unit::Type::Dimensionless,
             R"doc(
-                None unit type.
+                Dimensionless unit type.
             )doc"
         )
         .value(

--- a/bindings/python/test/coordinate/frame/provider/iers/conftest.py
+++ b/bindings/python/test/coordinate/frame/provider/iers/conftest.py
@@ -6,11 +6,8 @@ import pathlib
 
 from ostk.core.filesystem import Path
 from ostk.core.filesystem import File
-
-import ostk.physics as physics
-
-BulletinA = physics.coordinate.frame.provider.iers.BulletinA
-Finals2000A = physics.coordinate.frame.provider.iers.Finals2000A
+from ostk.physics.coordinate.frame.provider.iers import BulletinA
+from ostk.physics.coordinate.frame.provider.iers import Finals2000A
 
 
 @pytest.fixture

--- a/bindings/python/test/coordinate/frame/provider/iers/test_bulletin_a.py
+++ b/bindings/python/test/coordinate/frame/provider/iers/test_bulletin_a.py
@@ -6,10 +6,7 @@ from ostk.core.filesystem import File
 
 from ostk.physics.time import Scale
 from ostk.physics.time import Instant
-
-import ostk.physics as physics
-
-BulletinA = physics.coordinate.frame.provider.iers.BulletinA
+from ostk.physics.coordinate.frame.provider.iers import BulletinA
 
 
 class TestBulletinA:

--- a/bindings/python/test/coordinate/frame/provider/iers/test_finals_2000a.py
+++ b/bindings/python/test/coordinate/frame/provider/iers/test_finals_2000a.py
@@ -6,10 +6,7 @@ from ostk.core.filesystem import File
 
 from ostk.physics.time import Scale
 from ostk.physics.time import Instant
-
-import ostk.physics as physics
-
-Finals2000A = physics.coordinate.frame.provider.iers.Finals2000A
+from ostk.physics.coordinate.frame.provider.iers import Finals2000A
 
 
 class TestFinals2000A:

--- a/bindings/python/test/environment/atmospheric/earth/test_cssi_space_weather.py
+++ b/bindings/python/test/environment/atmospheric/earth/test_cssi_space_weather.py
@@ -8,7 +8,6 @@ from ostk.core.filesystem import File
 
 from ostk.physics.time import Scale
 from ostk.physics.time import Instant
-
 from ostk.physics.environment.atmospheric.earth import CSSISpaceWeather
 
 
@@ -38,7 +37,7 @@ class TestCSSISpaceWeather:
         )
 
     def test_access_observation_at_success(self, cssi_space_weather: CSSISpaceWeather):
-        observation: Observation = cssi_space_weather.access_observation_at(
+        observation: CSSISpaceWeather.Reading = cssi_space_weather.access_observation_at(
             Instant.date_time(datetime(2023, 6, 19, 0, 0, 0), Scale.UTC)
         )
 
@@ -58,8 +57,10 @@ class TestCSSISpaceWeather:
     def test_access_daily_prediction_at_success(
         self, cssi_space_weather: CSSISpaceWeather
     ):
-        prediction: Reading = cssi_space_weather.access_daily_prediction_at(
-            Instant.date_time(datetime(2023, 8, 3, 0, 0, 0), Scale.UTC)
+        prediction: CSSISpaceWeather.Reading = (
+            cssi_space_weather.access_daily_prediction_at(
+                Instant.date_time(datetime(2023, 8, 3, 0, 0, 0), Scale.UTC)
+            )
         )
 
         assert prediction.date.to_string() == "2023-08-03"
@@ -78,8 +79,10 @@ class TestCSSISpaceWeather:
     def test_access_monthly_prediction_at_success(
         self, cssi_space_weather: CSSISpaceWeather
     ):
-        prediction: Reading = cssi_space_weather.access_monthly_prediction_at(
-            Instant.date_time(datetime(2029, 1, 1, 0, 0, 0), Scale.UTC)
+        prediction: CSSISpaceWeather.Reading = (
+            cssi_space_weather.access_monthly_prediction_at(
+                Instant.date_time(datetime(2029, 1, 1, 0, 0, 0), Scale.UTC)
+            )
         )
 
         assert prediction.date.to_string() == "2029-01-01"
@@ -87,7 +90,7 @@ class TestCSSISpaceWeather:
         assert prediction.f107_obs_center_81 == pytest.approx(83.6)
 
     def test_access_reading_at_success(self, cssi_space_weather: CSSISpaceWeather):
-        reading: Reading = cssi_space_weather.access_reading_at(
+        reading: CSSISpaceWeather.Reading = cssi_space_weather.access_reading_at(
             Instant.date_time(datetime(2029, 1, 1, 0, 0, 0), Scale.UTC)
         )
 
@@ -99,7 +102,7 @@ class TestCSSISpaceWeather:
     def test_access_last_reading_where_success(
         self, cssi_space_weather: CSSISpaceWeather
     ):
-        reading: Reading = cssi_space_weather.access_last_reading_where(
+        reading: CSSISpaceWeather.Reading = cssi_space_weather.access_last_reading_where(
             lambda reading: reading.f107_data_type == "PRD",
             Instant.date_time(datetime(2023, 12, 1, 0, 0, 0), Scale.UTC),
         )


### PR DESCRIPTION
For context, see
1. https://github.com/open-space-collective/open-space-toolkit-core/pull/185
2. https://github.com/open-space-collective/open-space-toolkit-core/pull/186
3. https://github.com/open-space-collective/open-space-toolkit-mathematics/pull/169

⚠️ Additionally, this introduces a (minor) breaking change to `ostk.physics.Unit` - namely, the "None unit type" entry in the `Type` enum has been changed: `Unit.Type.None` -> `Unit.Type.None_`
This isn't expect to affect anything, as the former definition isn't valid in Python anyway. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Bug Fixes**
  - Corrected Python stub file syntax generation
  - Updated unit type naming from "None" to "None_"

- **Refactor**
  - Streamlined import statements in Python test files
  - Enhanced type annotations for CSSI Space Weather test methods

- **Chores**
  - Improved Python package build process
  - Refined module import specificity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->