### PR TITLE
docs: fix date format

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/DateTime.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/DateTime.cpp
@@ -239,7 +239,7 @@ inline void OpenSpaceToolkitPhysicsPy_Time_DateTime(pybind11::module& aModule)
             "Standard",
             DateTime::Format::Standard,
             R"doc(
-                Standard format (YYYY:MM:DD hh:mm:ss.sss.sss.sss).
+                Standard format (YYYY-MM-DD hh:mm:ss.sss.sss.sss).
             )doc"
         )
         .value(

--- a/include/OpenSpaceToolkit/Physics/Time/Date.hpp
+++ b/include/OpenSpaceToolkit/Physics/Time/Date.hpp
@@ -28,7 +28,7 @@ class Date
     {
 
         Undefined,  ///< Undefined format
-        Standard,   ///< Standard format (YYYY:MM:DD)
+        Standard,   ///< Standard format (YYYY-MM-DD)
         STK         ///< STK format (d Mon YYYY)
 
     };

--- a/include/OpenSpaceToolkit/Physics/Time/DateTime.hpp
+++ b/include/OpenSpaceToolkit/Physics/Time/DateTime.hpp
@@ -40,8 +40,8 @@ class DateTime
     {
 
         Undefined,  ///< Undefined format
-        Standard,   ///< Standard format (YYYY:MM:DD hh:mm:ss.sss.sss.sss)
-        ISO8601,    ///< ISO 8601 format (YYYY:MM:DDThh:mm:ss.sssssssss)
+        Standard,   ///< Standard format (YYYY-MM-DD hh:mm:ss.sss.sss.sss)
+        ISO8601,    ///< ISO 8601 format (YYYY-MM-DDThh:mm:ss.sssssssss)
         STK         ///< STK format (d Mon YYYY hh:mm:ss.sssssssss)
 
     };


### PR DESCRIPTION
The Standard date format was wrongly defined in the documentation here: [ostk.physics.time.DateTime.Format](https://open-space-collective.github.io/open-space-toolkit-physics/_build/html/_autosummary/ostk.physics.time.DateTime.html#ostk.physics.time.DateTime.Format)

Standard format (**YYYY:MM:DD** hh:mm:ss.sss.sss.sss)
--> Standard format (**YYYY-MM-DD** hh:mm:ss.sss.sss.sss).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the API's date format descriptions to use the conventional hyphen-separated pattern (YYYY-MM-DD) instead of colons.
  - Revised the ISO8601 date-time format details for improved clarity and consistency in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->