### PR TITLE
fix: kernel regex contains extraneous escape characters

### DIFF
--- a/src/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Engine.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Engine.cpp
@@ -199,7 +199,7 @@ Array<Kernel> Engine::DefaultKernels()
         Manager::Get().findKernel("de430.bsp"),               // Ephemeris
         Manager::Get().findKernel("pck[0-9]*\\.tpc"),         // System body shape and orientation constants
         Manager::Get().findKernel("earth_assoc_itrf93.tf"),   // Associates Earth to the ITRF93 frame
-        Manager::Get().findKernel("earth\\_200101\\_[0-9]*\\_predict\\.bpc"),  // Earth orientation
+        Manager::Get().findKernel("earth_200101_[0-9]*_predict\\.bpc"),  // Earth orientation
         Manager::Get().findKernel("moon_080317.tf"),
         Manager::Get().findKernel("moon_assoc_me.tf"),
         Manager::Get().findKernel("moon_pa_de421_1900-2050.bpc")

--- a/src/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Engine.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Engine.cpp
@@ -195,10 +195,10 @@ Array<Kernel> Engine::DefaultKernels()
 
     static const Array<Kernel> defaultKernels = {
 
-        Manager::Get().findKernel("latest_leapseconds.tls"),  // Leap seconds
-        Manager::Get().findKernel("de430.bsp"),               // Ephemeris
-        Manager::Get().findKernel("pck[0-9]*\\.tpc"),         // System body shape and orientation constants
-        Manager::Get().findKernel("earth_assoc_itrf93.tf"),   // Associates Earth to the ITRF93 frame
+        Manager::Get().findKernel("latest_leapseconds.tls"),             // Leap seconds
+        Manager::Get().findKernel("de430.bsp"),                          // Ephemeris
+        Manager::Get().findKernel("pck[0-9]*\\.tpc"),                    // System body shape and orientation constants
+        Manager::Get().findKernel("earth_assoc_itrf93.tf"),              // Associates Earth to the ITRF93 frame
         Manager::Get().findKernel("earth_200101_[0-9]*_predict\\.bpc"),  // Earth orientation
         Manager::Get().findKernel("moon_080317.tf"),
         Manager::Get().findKernel("moon_assoc_me.tf"),

--- a/test/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Manager.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Manager.test.cpp
@@ -158,6 +158,7 @@ TEST_F(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Manager, FindKernel)
             Path::Parse("FindKernelTest/")
         )
     );
+
     if (manager_.getLocalRepository().exists())
     {
         manager_.getLocalRepository().remove();
@@ -191,6 +192,18 @@ TEST_F(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Manager, FindKernel)
         EXPECT_EQ(
             expectedKernelFile.getPath().getNormalizedPath(), foundKernel.getFile().getPath().getNormalizedPath()
         );
+    }
+
+    {
+        // check that it fetches one that is not there, earth_200101_[0-9]*_predict\\.bpc
+        File expectedKernelFile =
+            File::Path(manager_.getLocalRepository().getPath() + Path::Parse("earth_200101_990827_predict.bpc"));
+        
+        EXPECT_FALSE(expectedKernelFile.exists());
+
+        Kernel fetchedKernel = manager_.findKernel("earth_200101_[0-9]*_predict\\.bpc");
+        EXPECT_TRUE(fetchedKernel.isDefined());
+        EXPECT_TRUE(fetchedKernel.getFile().exists());
     }
 
     manager_.getLocalRepository().remove();

--- a/test/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Manager.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Manager.test.cpp
@@ -198,7 +198,7 @@ TEST_F(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Manager, FindKernel)
         // check that it fetches one that is not there, earth_200101_[0-9]*_predict\\.bpc
         File expectedKernelFile =
             File::Path(manager_.getLocalRepository().getPath() + Path::Parse("earth_200101_990827_predict.bpc"));
-        
+
         EXPECT_FALSE(expectedKernelFile.exists());
 
         Kernel fetchedKernel = manager_.findKernel("earth_200101_[0-9]*_predict\\.bpc");


### PR DESCRIPTION
Closes #324 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved regex pattern for locating Earth orientation kernel files, enhancing the accuracy of file retrieval.
- **Tests**
  - Added a new test to ensure the successful fetching of missing kernel files, validating the updated file matching logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->