### PR TITLE
fix: only convert from position to LLA if provided in ITRF

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Magnetic/Earth/Manager.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Magnetic/Earth/Manager.cpp
@@ -20,7 +20,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Magnetic_Earth_Manager(pybind1
 
             The following environment variables can be defined:
 
-            - "OSTK_PHYSICS_ENVIRONMENT_MAGNETIC_EARTH_MANAGER_ENABLED" will override "DefaultEnabled"
+            - "OSTK_PHYSICS_ENVIRONMENT_MAGNETIC_EARTH_MANAGER_MODE" will override "DefaultMode"
             - "OSTK_PHYSICS_ENVIRONMENT_MAGNETIC_EARTH_MANAGER_LOCAL_REPOSITORY" will override "DefaultLocalRepository"
         )doc"
     );

--- a/include/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth/Manager.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Magnetic/Earth/Manager.hpp
@@ -49,8 +49,8 @@ using BaseManager = ostk::physics::Manager;
 ///
 ///                             The following environment variables can be defined:
 ///
-///                             - "OSTK_PHYSICS_ENVIRONMENT_MAGNETIC_EARTH_MANAGER_ENABLED" will override
-///                             "DefaultEnabled"
+///                             - "OSTK_PHYSICS_ENVIRONMENT_MAGNETIC_EARTH_MANAGER_MODE" will override
+///                             "DefaultMode"
 ///                             - "OSTK_PHYSICS_ENVIRONMENT_MAGNETIC_EARTH_MANAGER_LOCAL_REPOSITORY" will override
 ///                             "DefaultLocalRepository"
 

--- a/src/OpenSpaceToolkit/Physics/Coordinate/Spherical/LLA.cpp
+++ b/src/OpenSpaceToolkit/Physics/Coordinate/Spherical/LLA.cpp
@@ -538,9 +538,11 @@ LLA LLA::FromPosition(const Position& aPosition, const Shared<const environment:
         throw ostk::core::error::runtime::Undefined("Position");
     }
 
-    if (aPosition.getFrame() != Frame::ITRF())
+    if (aPosition.accessFrame() != Frame::ITRF())
     {
-        throw ostk::core::error::RuntimeError("Cannot convert Position to LLA from frame [{}], must be in ITRF.", aPosition.getFrame().getName());
+        throw ostk::core::error::RuntimeError(
+            "Cannot convert Position to LLA from frame [{}], must be in ITRF.", aPosition.accessFrame()->getName()
+        );
     }
 
     const auto celestialSPtr = aCelestialSPtr != nullptr

--- a/src/OpenSpaceToolkit/Physics/Coordinate/Spherical/LLA.cpp
+++ b/src/OpenSpaceToolkit/Physics/Coordinate/Spherical/LLA.cpp
@@ -538,6 +538,11 @@ LLA LLA::FromPosition(const Position& aPosition, const Shared<const environment:
         throw ostk::core::error::runtime::Undefined("Position");
     }
 
+    if (aPosition.getFrame() != Frame::ITRF())
+    {
+        throw ostk::core::error::RuntimeError("Cannot convert Position to LLA from frame [{}], must be in ITRF.", aPosition.getFrame().getName());
+    }
+
     const auto celestialSPtr = aCelestialSPtr != nullptr
                                  ? aCelestialSPtr
                                  : Environment::AccessGlobalInstance()->accessCentralCelestialObject();

--- a/test/OpenSpaceToolkit/Physics/Coordinate/Spherical/LLA.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Coordinate/Spherical/LLA.test.cpp
@@ -1128,6 +1128,12 @@ TEST_F(OpenSpaceToolkit_Physics_Coordinate_Spherical_LLA, FromPosition)
     }
 
     {
+        // Test with Position in a different frame
+        const Position position = Position::Meters({0.0, 0.0, 0.0}, Frame::GCRF());
+        EXPECT_THROW(LLA::FromPosition(position, earthSPtr), ostk::core::error::RuntimeError);
+    }
+
+    {
         // Test with null celestial object and no global environment
         const Position position = Position::Meters({0.0, 0.0, 0.0}, frameSPtr);
         EXPECT_THROW(LLA::FromPosition(position, nullptr), ostk::core::error::RuntimeError);


### PR DESCRIPTION
- add a check to ensure position -> LLA conversions are done in the correct frame
- Fix an issue in the docstrings for magnetic manager

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to clarify the correct environment variable for overriding the Earth magnetic model data manager mode.

- **Bug Fixes**
  - Improved input validation for coordinate conversion to ensure positions are in the correct reference frame, with clear error messages when not.

- **Tests**
  - Added a test to verify that an error is raised when converting positions from an unsupported coordinate frame.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->