### PR TITLE
feat: add commutative operations

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/Duration.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/Duration.cpp
@@ -58,6 +58,7 @@ inline void OpenSpaceToolkitPhysicsPy_Time_Duration(pybind11::module& aModule)
         .def(self - self)
         .def(self * double())
         .def(self / double())
+        .def(double() * self)
 
         .def(self += self)
         .def(self -= self)

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Unit/Length.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Unit/Length.cpp
@@ -45,45 +45,17 @@ inline void OpenSpaceToolkitPhysicsPy_Unit_Length(pybind11::module& aModule)
 
         .def(self + self)
         .def(self - self)
+        .def(self * double())
+        .def(self / double())
+        .def(double() * self)
 
         .def(self += self)
         .def(self -= self)
+        .def(self *= double())
+        .def(self /= double())
 
         .def(+self)
         .def(-self)
-
-        .def(
-            "__mul__",
-            [](const Length& aLength, Real aReal)
-            {
-                return aLength * aReal;
-            },
-            is_operator()
-        )
-        .def(
-            "__truediv__",
-            [](const Length& aLength, Real aReal)
-            {
-                return aLength / aReal;
-            },
-            is_operator()
-        )
-        .def(
-            "__imul__",
-            [](const Length& aLength, Real aReal)
-            {
-                return aLength * aReal;
-            },
-            is_operator()
-        )
-        .def(
-            "__itruediv__",
-            [](const Length& aLength, Real aReal)
-            {
-                return aLength / aReal;
-            },
-            is_operator()
-        )
 
         .def("__str__", &(shiftToString<Length>))
         .def(

--- a/bindings/python/test/time/test_duration.py
+++ b/bindings/python/test/time/test_duration.py
@@ -43,6 +43,7 @@ class TestDuration:
         assert (duration_A + duration_B) is not None
         assert (duration_A - duration_B) is not None
 
+        assert (2.0 * duration_A) is not None
         assert (duration_A * 2.0) is not None
         assert (duration_A / 2.0) is not None
 

--- a/bindings/python/test/unit/test_length.py
+++ b/bindings/python/test/unit/test_length.py
@@ -107,6 +107,7 @@ def test_unit_length_operators():
     sum_length: Length = length_1 + length_2
     diff_length: Length = length_1 - length_2
     mul_length: Length = length_1 * 2.0
+    mul_length_2: Length = 2.0 * length_1
     div_length: Length = length_1 / 2.0
 
     assert sum_length is not None
@@ -123,6 +124,11 @@ def test_unit_length_operators():
     assert isinstance(mul_length, Length)
     assert mul_length.is_defined()
     assert mul_length == Length(8.0, Unit.Meter)
+
+    assert mul_length_2 is not None
+    assert isinstance(mul_length_2, Length)
+    assert mul_length_2.is_defined()
+    assert mul_length_2 == Length(8.0, Unit.Meter)
 
     assert div_length is not None
     assert isinstance(div_length, Length)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled multiplication of Duration and Length objects by a scalar when the scalar comes first (e.g., `2.0 * Duration` and `2.0 * Length`) in the Python interface.

- **Tests**
  - Added tests to verify correct behavior for scalar-left multiplication with Duration and Length objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->