### PR TITLE
feat: add geocentric radius computation

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Model.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Model.cpp
@@ -116,6 +116,21 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Model(pybind11::
                 )doc"
             )
 
+            .def(
+                "compute_geocentric_radius_at",
+                &Model::Parameters::computeGeocentricRadiusAt,
+                arg("latitude"),
+                R"doc(
+                    Compute geocentric radius of ellipsoid at a given latitude.
+
+                    Args:
+                        latitude (Angle): A latitude.
+
+                    Returns:
+                        Length: Geocentric radius of ellipsoid at a given latitude.
+                )doc"
+            )
+
             .def_readwrite(
                 "gravitational_parameter",
                 &Model::Parameters::gravitationalParameter_,

--- a/include/OpenSpaceToolkit/Physics/Environment/Gravitational/Model.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Gravitational/Model.hpp
@@ -10,7 +10,7 @@
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Derived.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Length.hpp>
-#include <OpenSpaceToolkit/Physics/Unit/Angle.hpp>
+#include <OpenSpaceToolkit/Physics/Unit/Derived/Angle.hpp>
 
 
 namespace ostk

--- a/include/OpenSpaceToolkit/Physics/Environment/Gravitational/Model.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Gravitational/Model.hpp
@@ -9,9 +9,8 @@
 
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Derived.hpp>
-#include <OpenSpaceToolkit/Physics/Unit/Length.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Derived/Angle.hpp>
-
+#include <OpenSpaceToolkit/Physics/Unit/Length.hpp>
 
 namespace ostk
 {
@@ -27,10 +26,10 @@ using ostk::core::type::Real;
 using ostk::mathematics::object::Vector3d;
 
 using ostk::physics::time::Instant;
+using ostk::physics::unit::Angle;
 using ostk::physics::unit::Derived;
 using ostk::physics::unit::Length;
 using ostk::physics::unit::Time;
-using ostk::physics::unit::Angle;
 
 /// @brief                      Gravitational model (interface)
 

--- a/include/OpenSpaceToolkit/Physics/Environment/Gravitational/Model.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Gravitational/Model.hpp
@@ -10,6 +10,8 @@
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Derived.hpp>
 #include <OpenSpaceToolkit/Physics/Unit/Length.hpp>
+#include <OpenSpaceToolkit/Physics/Unit/Angle.hpp>
+
 
 namespace ostk
 {
@@ -28,6 +30,7 @@ using ostk::physics::time::Instant;
 using ostk::physics::unit::Derived;
 using ostk::physics::unit::Length;
 using ostk::physics::unit::Time;
+using ostk::physics::unit::Angle;
 
 /// @brief                      Gravitational model (interface)
 
@@ -107,6 +110,13 @@ class Model
         // @return             An undefined parameter set
 
         static Parameters Undefined();
+
+        // @brief              Compute geocentric radius of ellipsoid at a given latitude
+        //
+        // @param              [in] aLatitude A latitude
+        // @return             Geocentric radius of ellipsoid at a given latitude
+
+        Length computeGeocentricRadiusAt(const Angle& aLatitude) const;
 
         Derived gravitationalParameter_;
         Length equatorialRadius_;

--- a/src/OpenSpaceToolkit/Physics/Environment/Gravitational/Model.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Gravitational/Model.cpp
@@ -126,6 +126,25 @@ std::ostream& operator<<(std::ostream& anOutputStream, const Model::Parameters& 
     return anOutputStream;
 }
 
+Length Model::Parameters::computeGeocentricRadiusAt(const Angle& aLatitude) const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("Parameters");
+    }
+
+    const Real polarRadius = equatorialRadius_.inMeters() * (1.0 - flattening_);
+
+    const Real cosLatitude = std::cos(aLatitude);
+    const Real sinLatitude = std::sin(aLatitude);
+
+    return Length::Meters(std::sqrt(
+        (equatorialRadius_ * equatorialRadius_ * cosLatitude * cosLatitude +
+         polarRadius * polarRadius * sinLatitude * sinLatitude) /
+        (equatorialRadius_ * cosLatitude * cosLatitude + polarRadius * sinLatitude * sinLatitude)
+    ));
+}
+
 Model::Model(const Parameters& aSetOfParameters)
     : parameters_(aSetOfParameters)
 {

--- a/src/OpenSpaceToolkit/Physics/Environment/Gravitational/Model.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Gravitational/Model.cpp
@@ -143,11 +143,10 @@ Length Model::Parameters::computeGeocentricRadiusAt(const Angle& aLatitude) cons
     const Real polarRadiusSquared = polarRadius_Meters * polarRadius_Meters;
     const Real equatorialRadiusSquared = equatorialRadius_Meters * equatorialRadius_Meters;
 
-    const Real numerator = 
-        std::pow((equatorialRadiusSquared * cosLatitude), 2) +
-        std::pow((polarRadiusSquared * sinLatitude), 2);
-    const Real denominator =        std::pow((equatorialRadius_Meters * cosLatitude), 2) +
-        std::pow((polarRadius_Meters * sinLatitude), 2);
+    const Real numerator =
+        std::pow((equatorialRadiusSquared * cosLatitude), 2) + std::pow((polarRadiusSquared * sinLatitude), 2);
+    const Real denominator =
+        std::pow((equatorialRadius_Meters * cosLatitude), 2) + std::pow((polarRadius_Meters * sinLatitude), 2);
 
     return Length::Meters(std::sqrt(numerator / denominator));
 }

--- a/src/OpenSpaceToolkit/Physics/Environment/Gravitational/Model.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Gravitational/Model.cpp
@@ -133,16 +133,23 @@ Length Model::Parameters::computeGeocentricRadiusAt(const Angle& aLatitude) cons
         throw ostk::core::error::runtime::Undefined("Parameters");
     }
 
-    const Real polarRadius = equatorialRadius_.inMeters() * (1.0 - flattening_);
+    const Real equatorialRadius_Meters = equatorialRadius_.inMeters();
+    const Real polarRadius_Meters = equatorialRadius_Meters * (1.0 - flattening_);
 
-    const Real cosLatitude = std::cos(aLatitude);
-    const Real sinLatitude = std::sin(aLatitude);
+    const Real latitude_Radians = aLatitude.inRadians();
+    const Real cosLatitude = std::cos(latitude_Radians);
+    const Real sinLatitude = std::sin(latitude_Radians);
 
-    return Length::Meters(std::sqrt(
-        (equatorialRadius_ * equatorialRadius_ * cosLatitude * cosLatitude +
-         polarRadius * polarRadius * sinLatitude * sinLatitude) /
-        (equatorialRadius_ * cosLatitude * cosLatitude + polarRadius * sinLatitude * sinLatitude)
-    ));
+    const Real polarRadiusSquared = polarRadius_Meters * polarRadius_Meters;
+    const Real equatorialRadiusSquared = equatorialRadius_Meters * equatorialRadius_Meters;
+
+    const Real numerator = 
+        std::pow((equatorialRadiusSquared * cosLatitude), 2) +
+        std::pow((polarRadiusSquared * sinLatitude), 2);
+    const Real denominator =        std::pow((equatorialRadius_Meters * cosLatitude), 2) +
+        std::pow((polarRadius_Meters * sinLatitude), 2);
+
+    return Length::Meters(std::sqrt(numerator / denominator));
 }
 
 Model::Model(const Parameters& aSetOfParameters)

--- a/test/OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.test.cpp
@@ -802,7 +802,7 @@ TEST(OpenSpaceToolkit_Physics_Environment_Gravitational_Earth, StreamOperator)
 TEST(OpenSpaceToolkit_Physics_Environment_Gravitational_Earth, ComputeGeocentricRadiusAt)
 {
     using ostk::physics::unit::Angle;
-    
+
     // Test different Earth models
     const Array<EarthGravitationalModel::Type> modelTypes = {
         EarthGravitationalModel::Type::Spherical,
@@ -810,25 +810,25 @@ TEST(OpenSpaceToolkit_Physics_Environment_Gravitational_Earth, ComputeGeocentric
         EarthGravitationalModel::Type::EGM96,
         EarthGravitationalModel::Type::EGM2008
     };
-    
+
     for (const auto& modelType : modelTypes)
     {
         const EarthGravitationalModel::Parameters parameters = EarthGravitationalModel::ParametersFromType(modelType);
-        
+
         // Test at equator
         {
             const Angle latitude = Angle::Degrees(0.0);
             const Length radius = parameters.computeGeocentricRadiusAt(latitude);
-            
+
             // At equator, radius should equal equatorial radius
-            EXPECT_NEAR(radius.inMeters(), parameters.equatorialRadius_.inMeters(), 1e-10) ;
+            EXPECT_NEAR(radius.inMeters(), parameters.equatorialRadius_.inMeters(), 1e-10);
         }
-        
+
         // Test at poles
         {
             const Angle latitude = Angle::Degrees(90.0);
             const Length radius = parameters.computeGeocentricRadiusAt(latitude);
-            
+
             // At poles, for non-spherical models, radius should be less than equatorial radius
             if (modelType != EarthGravitationalModel::Type::Spherical)
             {
@@ -836,12 +836,12 @@ TEST(OpenSpaceToolkit_Physics_Environment_Gravitational_Earth, ComputeGeocentric
                 EXPECT_NEAR(radius.inMeters(), polarRadius, 1e-10);
             }
         }
-        
+
         // Test at 45 degrees latitude
         {
             const Angle latitude = Angle::Degrees(45.0);
             const Length radius = parameters.computeGeocentricRadiusAt(latitude);
-            
+
             // At 45 degrees, radius should be between equatorial and polar radius
             if (modelType != EarthGravitationalModel::Type::Spherical)
             {
@@ -851,36 +851,36 @@ TEST(OpenSpaceToolkit_Physics_Environment_Gravitational_Earth, ComputeGeocentric
             }
         }
     }
-    
+
     // Test undefined parameters
     {
-        const EarthGravitationalModel::Parameters undefinedParameters = EarthGravitationalModel::Parameters::Undefined();
+        const EarthGravitationalModel::Parameters undefinedParameters =
+            EarthGravitationalModel::Parameters::Undefined();
         const Angle latitude = Angle::Degrees(45.0);
-        
+
         EXPECT_THROW(undefinedParameters.computeGeocentricRadiusAt(latitude), ostk::core::error::runtime::Undefined);
     }
-    
+
     // Test specific values for WGS84
     {
         const EarthGravitationalModel::Parameters wgs84Parameters = EarthGravitationalModel::WGS84;
-        
+
         // Test values at specific latitudes - computed using reference implementation
         // Reference values from https://planetcalc.com/7721/
         const Array<Tuple<Real, Real>> testCases = {
-            {0.0, 6378137.0}, // Equator
-            {45.0, 6367489.5}, // 45 degrees (approximate value)
-            {90.0, 6356752.3}, // North pole (approximate value)
+            {0.0, 6378137.0},   // Equator
+            {45.0, 6367489.5},  // 45 degrees (approximate value)
+            {90.0, 6356752.3},  // North pole (approximate value)
         };
-        
+
         for (const auto& testCase : testCases)
         {
             const Angle latitude = Angle::Degrees(std::get<0>(testCase));
             const Real expectedRadius = std::get<1>(testCase);
             const Length radius = wgs84Parameters.computeGeocentricRadiusAt(latitude);
-            
+
             // Using larger tolerance due to approximation in test values
-            EXPECT_NEAR(radius.inMeters(), expectedRadius, 1e-1) 
-                << "Latitude: " << latitude.inDegrees() << " degrees";
+            EXPECT_NEAR(radius.inMeters(), expectedRadius, 1e-1) << "Latitude: " << latitude.inDegrees() << " degrees";
         }
     }
 }


### PR DESCRIPTION
- add a method to compute the ellipsoidal radius, also known as the geocentric radius.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to compute the geocentric radius of the ellipsoid at a given latitude for various Earth gravitational models.

- **Tests**
  - Introduced comprehensive tests to verify geocentric radius calculations across multiple models and latitudes, including validation against reference values and error handling for undefined parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->