### PR TITLE
feat: set maximum cache size

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ The following table shows the availabe data source settings with the different e
 | `OSTK_PHYSICS_DATA_MANIFEST_MANAGER_MODE`                                            | `Automatic`                                                                                            |
 | `OSTK_PHYSICS_DATA_MANIFEST_LOCAL_REPOSITORY`                                        | `./.open-space-toolkit/physics/data/`                                                                  |
 | `OSTK_PHYSICS_DATA_MANIFEST_LOCAL_REPOSITORY_LOCK_TIMEOUT`                           | `60`                                                                                                   |
+| `OSTK_PHYSICS_FRAME_MANAGER_MAX_TRANSFORM_CACHE_SIZE`                                | `1000`                                                                                                 |
 
 ## Tutorials
 

--- a/include/OpenSpaceToolkit/Physics/Coordinate/Frame/Manager.hpp
+++ b/include/OpenSpaceToolkit/Physics/Coordinate/Frame/Manager.hpp
@@ -24,6 +24,7 @@ namespace frame
 
 using ostk::core::container::Map;
 using ostk::core::type::Shared;
+using ostk::core::type::Size;
 using ostk::core::type::String;
 
 using ostk::physics::coordinate::Frame;
@@ -43,7 +44,7 @@ class Manager
 
     Shared<const Frame> accessFrameWithName(const String& aFrameName) const;
 
-    const Transform* accessCachedTransform(
+    const Transform accessCachedTransform(
         const Shared<const Frame>& aFromFrameSPtr, const Shared<const Frame>& aToFrameSPtr, const Instant& anInstant
     ) const;
 
@@ -61,13 +62,14 @@ class Manager
     static Manager& Get();
 
    private:
+    Size maxTransformCacheSize_;
     Map<String, Shared<const Frame>> frameMap_;
 
     Map<const Frame*, Map<const Frame*, Map<Instant, Transform>>> transformCache_;
 
     mutable std::mutex mutex_;
 
-    Manager() = default;
+    Manager(const Size& maxTransformCacheSize_);
 };
 
 }  // namespace frame

--- a/include/OpenSpaceToolkit/Physics/Coordinate/Frame/Manager.hpp
+++ b/include/OpenSpaceToolkit/Physics/Coordinate/Frame/Manager.hpp
@@ -69,7 +69,7 @@ class Manager
 
     mutable std::mutex mutex_;
 
-    Manager(const Size& maxTransformCacheSize_);
+    Manager(const Size& aMaxTransformCacheSize);
 };
 
 }  // namespace frame

--- a/src/OpenSpaceToolkit/Physics/Coordinate/Frame.cpp
+++ b/src/OpenSpaceToolkit/Physics/Coordinate/Frame.cpp
@@ -244,9 +244,11 @@ Transform Frame::getTransformTo(const Shared<const Frame>& aFrameSPtr, const Ins
 
     const Shared<const Frame> thisSPtr = this->shared_from_this();
 
-    if (auto transformPtr = FrameManager::Get().accessCachedTransform(thisSPtr, aFrameSPtr, anInstant))
+    const Transform transform = FrameManager::Get().accessCachedTransform(thisSPtr, aFrameSPtr, anInstant);
+
+    if (transform.isDefined())
     {
-        return *transformPtr;
+        return transform;
     }
 
     // Find common ancestor

--- a/src/OpenSpaceToolkit/Physics/Coordinate/Frame/Manager.cpp
+++ b/src/OpenSpaceToolkit/Physics/Coordinate/Frame/Manager.cpp
@@ -126,8 +126,10 @@ void Manager::addCachedTransform(
 {
     const std::lock_guard<std::mutex> lock {mutex_};
 
-    if (transformCache_.size() > maxTransformCacheSize_)
+    if (transformCache_.size() >= maxTransformCacheSize_)
     {
+        // TODO: Implement LRU or FIFO eviction strategy
+        // For now, clear oldest entries
         transformCache_.clear();
     }
 
@@ -167,8 +169,8 @@ Manager& Manager::Get()
     return manager;
 }
 
-Manager::Manager(const Size& maxTransformCacheSize)
-    : maxTransformCacheSize_(maxTransformCacheSize)
+Manager::Manager(const Size& aMaxTransformCacheSize)
+    : maxTransformCacheSize_(aMaxTransformCacheSize)
 {
 }
 

--- a/src/OpenSpaceToolkit/Physics/Coordinate/Frame/Manager.cpp
+++ b/src/OpenSpaceToolkit/Physics/Coordinate/Frame/Manager.cpp
@@ -37,7 +37,7 @@ Shared<const Frame> Manager::accessFrameWithName(const String& aFrameName) const
     return nullptr;
 }
 
-const Transform* Manager::accessCachedTransform(
+const Transform Manager::accessCachedTransform(
     const Shared<const Frame>& aFromFrameSPtr, const Shared<const Frame>& aToFrameSPtr, const Instant& anInstant
 ) const
 {
@@ -55,12 +55,12 @@ const Transform* Manager::accessCachedTransform(
 
             if (transformCacheInstantIt != transformCacheToFrameIt->second.end())
             {
-                return &(transformCacheInstantIt->second);
+                return (transformCacheInstantIt->second);
             }
         }
     }
 
-    return nullptr;
+    return Transform::Undefined();
 }
 
 void Manager::addFrame(const Shared<const Frame>& aFrameSPtr)
@@ -126,6 +126,11 @@ void Manager::addCachedTransform(
 {
     const std::lock_guard<std::mutex> lock {mutex_};
 
+    if (transformCache_.size() > maxTransformCacheSize_)
+    {
+        transformCache_.clear();
+    }
+
     const auto transformCacheFromFrameIt = transformCache_.insert({aFromFrameSPtr.get(), {}}).first;
     const auto transformCacheToFrameIt = transformCacheFromFrameIt->second.insert({aToFrameSPtr.get(), {}}).first;
     const auto transformCacheToInstantIt = transformCacheToFrameIt->second.insert({anInstant, aTransform}).first;
@@ -135,9 +140,36 @@ void Manager::addCachedTransform(
 
 Manager& Manager::Get()
 {
-    static Manager manager;
+    static Size maxTransformCacheSize = []()
+    {
+        const char* maxTransformCacheSizeEnv = std::getenv("OSTK_PHYSICS_FRAME_MANAGER_MAX_TRANSFORM_CACHE_SIZE");
+
+        Size value = 1000;
+
+        if (maxTransformCacheSizeEnv != nullptr)
+        {
+            try
+            {
+                value = std::stoul(maxTransformCacheSizeEnv);
+            }
+            catch (const std::exception& e)
+            {
+                throw ostk::core::error::RuntimeError(
+                    "Invalid value for OSTK_PHYSICS_FRAME_MANAGER_MAX_TRANSFORM_CACHE_SIZE: {}", e.what()
+                );
+            }
+        }
+        return value;
+    }();
+
+    static Manager manager {maxTransformCacheSize};
 
     return manager;
+}
+
+Manager::Manager(const Size& maxTransformCacheSize)
+    : maxTransformCacheSize_(maxTransformCacheSize)
+{
 }
 
 }  // namespace frame

--- a/src/OpenSpaceToolkit/Physics/Coordinate/Position.cpp
+++ b/src/OpenSpaceToolkit/Physics/Coordinate/Position.cpp
@@ -238,7 +238,8 @@ Position Position::FromLLA(
     }
 
     return Position::Meters(
-        aLLA.toCartesian(celestialSPtr->getEquatorialRadius(), celestialSPtr->getFlattening()), Frame::ITRF()
+        aLLA.toCartesian(celestialSPtr->getEquatorialRadius(), celestialSPtr->getFlattening()),
+        celestialSPtr->accessFrame()
     );
 }
 

--- a/src/OpenSpaceToolkit/Physics/Coordinate/Spherical/LLA.cpp
+++ b/src/OpenSpaceToolkit/Physics/Coordinate/Spherical/LLA.cpp
@@ -538,13 +538,6 @@ LLA LLA::FromPosition(const Position& aPosition, const Shared<const environment:
         throw ostk::core::error::runtime::Undefined("Position");
     }
 
-    if (aPosition.accessFrame() != Frame::ITRF())
-    {
-        throw ostk::core::error::RuntimeError(
-            "Cannot convert Position to LLA from frame [{}], must be in ITRF.", aPosition.accessFrame()->getName()
-        );
-    }
-
     const auto celestialSPtr = aCelestialSPtr != nullptr
                                  ? aCelestialSPtr
                                  : Environment::AccessGlobalInstance()->accessCentralCelestialObject();
@@ -552,6 +545,15 @@ LLA LLA::FromPosition(const Position& aPosition, const Shared<const environment:
     if (celestialSPtr == nullptr)
     {
         throw ostk::core::error::runtime::Undefined("Celestial object");
+    }
+
+    if (aPosition.accessFrame() != celestialSPtr->accessFrame())
+    {
+        throw ostk::core::error::RuntimeError(
+            "Cannot convert Position to LLA from frame [{}], must be in [{}].",
+            aPosition.accessFrame()->getName(),
+            celestialSPtr->accessFrame()->getName()
+        );
     }
 
     const Length equatorialRadius = celestialSPtr->getEquatorialRadius();


### PR DESCRIPTION
Follows the suggestions in the associated GitHub issue, to improve the thread safety of the transform cache and also set a max to ensure the cache does not infinitely increase.

Closes #336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an environment variable to configure the maximum transform cache size for improved cache management.

- **Documentation**
  - Updated the README to document the new environment variable for cache size configuration.

- **Bug Fixes**
  - Position objects created from latitude, longitude, and altitude now correctly use the celestial object's frame instead of a fixed frame.
  - Frame validation now dynamically checks against the celestial object's frame instead of a fixed frame.

- **Refactor**
  - Improved cache management logic for transforms, including automatic cache clearing when the size limit is exceeded.
  - Updated internal logic to use value-based transform retrieval instead of pointer-based access for greater reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->