### PR TITLE
fix: duplicate celestial objects in environment

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment.cpp
@@ -40,6 +40,9 @@ inline void OpenSpaceToolkitPhysicsPy_Environment(pybind11::module& aModule)
                     instant (Instant): An Instant.
                     objects (list[Object]): List of objects.
                     set_global_instance (bool, optional): True if the global environment instance should be set. Defaults to False.
+
+                Raises:
+                    RuntimeError: If duplicate Celestial Objects with the same name are found.
             )doc"
         )
         .def(
@@ -56,6 +59,9 @@ inline void OpenSpaceToolkitPhysicsPy_Environment(pybind11::module& aModule)
                     objects (list[Object]): List of objects.
                     instant (Instant, optional): An Instant. Default is J2000 epoch.
                     set_global_instance (bool, optional): True if the global environment instance should be set. Defaults to False.
+
+                Raises:
+                    RuntimeError: If duplicate Celestial Objects with the same name are found.
             )doc"
         )
 

--- a/include/OpenSpaceToolkit/Physics/Environment.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment.hpp
@@ -38,6 +38,8 @@ class Environment
     /// @param              [in] An array of shared pointers to objects
     /// @param              [in] setGlobalInstance True if the global environment instance should be set
 
+    /// @throw             RuntimeError if duplicate Celestial Objects with the same name are found
+
     Environment(
         const Instant& anInstant,
         const Array<Shared<const Object>>& anObjectArray,
@@ -49,6 +51,8 @@ class Environment
     /// @param              [in] anObjectArray An array of shared pointers to objects
     /// @param              [in] anInstant An instant. Defaults to J2000 epoch.
     /// @param              [in] setGlobalInstance True if the global environment instance should be set
+
+    /// @throw             RuntimeError if duplicate Celestial Objects with the same name are found
 
     Environment(
         const Shared<const Object>& aCentralCelestialObject,
@@ -209,6 +213,12 @@ class Environment
     Instant instant_;
     Array<Shared<const Object>> objects_;
     Shared<const Object> centralCelestialObject_;
+
+    /// @brief              Validates the Celestial Objects in the environment, checking for duplicates
+    ///
+    /// @throw              RuntimeError if duplicate Celestial Objects with the same name are found
+
+    void validateCelestialObjects();
 
     /// @brief              Set the singleton instance of the environment
     ///

--- a/test/OpenSpaceToolkit/Physics/Environment.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment.test.cpp
@@ -3,7 +3,6 @@
 #include <OpenSpaceToolkit/Core/Container/Map.hpp>
 #include <OpenSpaceToolkit/Core/Type/Shared.hpp>
 #include <OpenSpaceToolkit/Core/Type/String.hpp>
-#include <OpenSpaceToolkit/Core/Type/Weak.hpp>
 
 #include <OpenSpaceToolkit/Mathematics/Geometry/2D/Object/Point.hpp>
 #include <OpenSpaceToolkit/Mathematics/Geometry/2D/Object/Polygon.hpp>
@@ -36,7 +35,6 @@ using ostk::core::container::Map;
 using ostk::core::type::Real;
 using ostk::core::type::Shared;
 using ostk::core::type::String;
-using ostk::core::type::Weak;
 
 using ostk::mathematics::geometry::d3::Intersection;
 using ostk::mathematics::geometry::d3::object::Ellipsoid;
@@ -75,7 +73,6 @@ using EarthGravitationalModel = ostk::physics::environment::gravitational::Earth
 using ostk::core::container::Array;
 using ostk::core::type::Shared;
 using ostk::core::type::String;
-using ostk::core::type::Weak;
 
 class OpenSpaceToolkit_Physics_Environment : public ::testing::Test
 {
@@ -106,20 +103,30 @@ TEST_F(OpenSpaceToolkit_Physics_Environment, Constructor)
 
     {
         const Shared<Earth> earthSPtr = std::make_shared<Earth>(Earth::EGM2008(2190, 2160));
-        const Array<Shared<const Object>> objects = {earthSPtr};
 
         {
-            EXPECT_NO_THROW(Environment(earthSPtr, objects, instant_, true));
+            EXPECT_NO_THROW(Environment(earthSPtr, {}, instant_, true));
             Environment::ResetGlobalInstance();
         }
 
         {
-            EXPECT_NO_THROW(Environment(earthSPtr, objects, instant_));
+            EXPECT_NO_THROW(Environment(earthSPtr, {}, instant_));
         }
 
         {
-            EXPECT_NO_THROW(Environment(earthSPtr, objects));
+            EXPECT_NO_THROW(Environment(earthSPtr, {}));
         }
+    }
+
+    // Duplicate celestial objects by name for both constructors
+    {
+        const Shared<Earth> earth1SPtr = std::make_shared<Earth>(Earth::Default());
+        const Shared<Earth> earth2SPtr = std::make_shared<Earth>(Earth::Default());
+
+        const Array<Shared<const Object>> objects = {earth1SPtr, earth2SPtr};
+
+        EXPECT_THROW(Environment(instant_, objects), ostk::core::error::RuntimeError);
+        EXPECT_THROW(Environment(earth1SPtr, objects), ostk::core::error::RuntimeError);
     }
 }
 
@@ -170,9 +177,8 @@ TEST_F(OpenSpaceToolkit_Physics_Environment, HasCentralCelestial)
 
     {
         const Shared<Earth> earthSPtr = std::make_shared<Earth>(Earth::Default());
-        const Array<Shared<const Object>> objects = {earthSPtr};
 
-        Environment environment = Environment(earthSPtr, objects);
+        Environment environment = Environment(earthSPtr, {});
 
         EXPECT_TRUE(environment.hasCentralCelestialObject());
     }
@@ -270,9 +276,8 @@ TEST_F(OpenSpaceToolkit_Physics_Environment, AccessCentralCelestial)
 
     {
         const Shared<Earth> earthSPtr = std::make_shared<Earth>(Earth::Default());
-        const Array<Shared<const Object>> objects = {earthSPtr};
 
-        const Environment environment = {earthSPtr, objects};
+        const Environment environment = {earthSPtr, {}};
         EXPECT_NO_THROW(environment.accessCentralCelestialObject());
     }
 }


### PR DESCRIPTION
Realized that I had accidentally created an environment with two suns the other day, so I think we should explicitly disallow that. The logic has to check for similarity based on the name of the object because there's no way to downcast a `Celestial` to all child types because users could have extended ostk classes themselves with their own `Celestial` implementations.

Therefore if someone still wants to (for whatever reason) create two earths, they could still do it by naming the second Earth something else.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented creating environments with duplicate celestial object names by adding validation that raises an error on duplicates.
* **Documentation**
  * Clarified in user-facing docs and Python bindings that constructors will raise an error if duplicate celestial object names are provided.
* **Tests**
  * Added tests verifying an error is raised when constructing an environment with duplicate celestial object names.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->