### PR TITLE
fix: environment unsafe central object behavior

### DIFF
--- a/src/OpenSpaceToolkit/Physics/Environment.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment.cpp
@@ -206,7 +206,7 @@ Shared<const Celestial> Environment::accessCentralCelestialObject() const
 
     if (const auto centralCelestialObjectSPtr = std::dynamic_pointer_cast<const Celestial>(centralCelestialObject_))
     {
-        return celestialObjectSPtr;
+        return centralCelestialObjectSPtr;
     }
     
     throw ostk::core::error::RuntimeError("No central celestial object.");

--- a/src/OpenSpaceToolkit/Physics/Environment.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment.cpp
@@ -154,16 +154,7 @@ Array<Shared<const Object>> Environment::accessObjects() const
         throw ostk::core::error::runtime::Undefined("Environment");
     }
 
-    Array<Shared<const Object>> objects = Array<Shared<const Object>>::Empty();
-
-    objects.reserve(objects_.getSize());
-
-    for (const auto& objectSPtr : objects_)
-    {
-        objects.add(objectSPtr);
-    }
-
-    return objects;
+    return objects_;
 }
 
 Shared<const Object> Environment::accessObjectWithName(const String& aName) const
@@ -213,12 +204,14 @@ Shared<const Celestial> Environment::accessCentralCelestialObject() const
         throw ostk::core::error::runtime::Undefined("Environment");
     }
 
-    if (centralCelestialObject_ == nullptr)
+    if (const auto centralCelestialObjectSPtr = std::dynamic_pointer_cast<const Celestial>(centralCelestialObject_))
     {
-        throw ostk::core::error::RuntimeError("No central celestial object.");
+        return celestialObjectSPtr;
     }
+    
+    throw ostk::core::error::RuntimeError("No central celestial object.");
 
-    return std::static_pointer_cast<const Celestial>(centralCelestialObject_);
+    return nullptr;
 }
 
 Instant Environment::getInstant() const

--- a/src/OpenSpaceToolkit/Physics/Environment.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment.cpp
@@ -208,7 +208,7 @@ Shared<const Celestial> Environment::accessCentralCelestialObject() const
     {
         return centralCelestialObjectSPtr;
     }
-    
+
     throw ostk::core::error::RuntimeError("No central celestial object.");
 
     return nullptr;


### PR DESCRIPTION
We shouldn't be using a `static_pointer_cast`, because they are only for upcasting or safe downcasting where you're sure that the return type is the derived class type. Since there is no guarantee that the `centralCelestialObjectSPtr_` is of type `Shared<const Celestial>` instead of type `Shared<const Object>`, we should use `dynamic_pointer_cast` instead and throw and error if it returns a nullpointer.

This technically would change the behavior of the method in question if someone has an `Environment` with a non-Celestial `Object` as the `centralCelestialObjectSPtr_`.

Source: https://stackoverflow.com/questions/28002/regular-cast-vs-static-cast-vs-dynamic-cast




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of environment objects and central celestial object to enhance reliability and error detection, with no impact on user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->