### PR TITLE
feat: add print method for the Geometry class

### DIFF
--- a/include/OpenSpaceToolkit/Physics/Environment/Object/Geometry.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Object/Geometry.hpp
@@ -90,6 +90,14 @@ class Geometry
 
     bool isDefined() const;
 
+    /// @brief              Print geometry to output stream
+    ///
+    /// @param              [in] anOutputStream An output stream
+    /// @param              [in] displayDecorators Whether to display decorators
+    /// @return             void
+
+    void print(std::ostream& anOutputStream, bool displayDecorators = true) const;
+
     /// @brief              Check if geometry intersects another geometry
     ///
     /// @param              [in] aGeometry A geometry

--- a/src/OpenSpaceToolkit/Physics/Environment/Object/Geometry.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Object/Geometry.cpp
@@ -91,8 +91,7 @@ void Geometry::print(std::ostream& anOutputStream, bool displayDecorators) const
     composite_.print(anOutputStream, false);
 
     ostk::core::utils::Print::Line(anOutputStream)
-        << "Frame:"
-        << (((frameSPtr_ != nullptr) && frameSPtr_->isDefined()) ? frameSPtr_->getName() : "Undefined");
+        << "Frame:" << (((frameSPtr_ != nullptr) && frameSPtr_->isDefined()) ? frameSPtr_->getName() : "Undefined");
 
     displayDecorators ? ostk::core::utils::Print::Footer(anOutputStream) : void();
 }

--- a/src/OpenSpaceToolkit/Physics/Environment/Object/Geometry.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Object/Geometry.cpp
@@ -77,20 +77,24 @@ bool Geometry::operator!=(const Geometry& aGeometry) const
 
 std::ostream& operator<<(std::ostream& anOutputStream, const Geometry& aGeometry)
 {
-    ostk::core::utils::Print::Header(anOutputStream, "Geometry");
+    aGeometry.print(anOutputStream, true);
+
+    return anOutputStream;
+}
+
+void Geometry::print(std::ostream& anOutputStream, bool displayDecorators) const
+{
+    displayDecorators ? ostk::core::utils::Print::Header(anOutputStream, "Geometry") : void();
 
     ostk::core::utils::Print::Line(anOutputStream) << "Objects:";
 
-    aGeometry.composite_.print(anOutputStream, false);
+    composite_.print(anOutputStream, false);
 
     ostk::core::utils::Print::Line(anOutputStream)
         << "Frame:"
-        << (((aGeometry.frameSPtr_ != nullptr) && aGeometry.frameSPtr_->isDefined()) ? aGeometry.frameSPtr_->getName()
-                                                                                     : "Undefined");
+        << (((frameSPtr_ != nullptr) && frameSPtr_->isDefined()) ? frameSPtr_->getName() : "Undefined");
 
-    ostk::core::utils::Print::Footer(anOutputStream);
-
-    return anOutputStream;
+    displayDecorators ? ostk::core::utils::Print::Footer(anOutputStream) : void();
 }
 
 bool Geometry::isDefined() const

--- a/test/OpenSpaceToolkit/Physics/Environment/Object/Geometry.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Object/Geometry.test.cpp
@@ -5,6 +5,8 @@
 #include <OpenSpaceToolkit/Core/Type/String.hpp>
 #include <OpenSpaceToolkit/Core/Type/Weak.hpp>
 
+#include <sstream>
+
 #include <OpenSpaceToolkit/Mathematics/Geometry/3D/Intersection.hpp>
 #include <OpenSpaceToolkit/Mathematics/Geometry/3D/Object/Ellipsoid.hpp>
 #include <OpenSpaceToolkit/Mathematics/Geometry/3D/Object/LineString.hpp>
@@ -31,6 +33,7 @@
 
 using ostk::core::type::Real;
 using ostk::core::type::Shared;
+using ostk::core::type::String;
 
 using ostk::mathematics::geometry::d3::object::Composite;
 using ostk::mathematics::geometry::d3::object::LineString;
@@ -121,6 +124,19 @@ TEST_F(OpenSpaceToolkit_Physics_Environment_Object_Geometry, StreamOperator)
         EXPECT_NO_THROW(std::cout << geometry_ << std::endl);
 
         EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Physics_Environment_Object_Geometry, Print)
+{
+    {
+        testing::internal::CaptureStdout();
+
+        EXPECT_NO_THROW(geometry_.print(std::cout, true));
+        EXPECT_NO_THROW(geometry_.print(std::cout, false));
+
+        const String capturedStdout = testing::internal::GetCapturedStdout();
+        EXPECT_FALSE(capturedStdout.empty());
     }
 }
 

--- a/test/OpenSpaceToolkit/Physics/Environment/Object/Geometry.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Object/Geometry.test.cpp
@@ -1,11 +1,11 @@
 /// Apache License 2.0
 
+#include <sstream>
+
 #include <OpenSpaceToolkit/Core/Container/Map.hpp>
 #include <OpenSpaceToolkit/Core/Type/Shared.hpp>
 #include <OpenSpaceToolkit/Core/Type/String.hpp>
 #include <OpenSpaceToolkit/Core/Type/Weak.hpp>
-
-#include <sstream>
 
 #include <OpenSpaceToolkit/Mathematics/Geometry/3D/Intersection.hpp>
 #include <OpenSpaceToolkit/Mathematics/Geometry/3D/Object/Ellipsoid.hpp>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added printing of geometry details to output streams, with an option to show or hide decorative headers/footers.
  * Printed output includes contained objects and the reference frame, and handles undefined data gracefully.
  * Stream insertion (<<) now uses the new printing behavior for consistent formatting.

* **Tests**
  * Added unit tests to validate geometry printing with and without decorators, ensuring non-empty output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->