### PR TITLE
fix: space weather fetching

### DIFF
--- a/include/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/CSSISpaceWeather.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/CSSISpaceWeather.hpp
@@ -110,6 +110,12 @@ class CSSISpaceWeather
 
     const Date& accessLastObservationDate() const;
 
+    /// @brief                  Access timestamp at which the CSSISpaceWeather file was last modified
+    ///
+    /// @return                 Instant indicating when the file was last updated based on file modification time
+
+    const Instant& accessLastModifiedTimestamp() const;
+
     /// @brief                  Access observation Interval.
     ///
     /// @return                 Observation Interval of Instants.
@@ -185,6 +191,7 @@ class CSSISpaceWeather
 
    private:
     Date lastObservationDate_;
+    Instant lastModifiedTimestamp_;
 
     Interval observationInterval_;
     Map<Integer, CSSISpaceWeather::Reading> observations_;

--- a/src/OpenSpaceToolkit/Physics/Data/Manager.cpp
+++ b/src/OpenSpaceToolkit/Physics/Data/Manager.cpp
@@ -180,8 +180,8 @@ void Manager::checkManifestAgeAndUpdate_() const
 
     const Duration manifestAge = Instant::Now() - manifest_.getLastModifiedTimestamp();
 
-    // If loaded manifest is old enough, fetch a new one and load it.
-    if (nextUpdateCheckTimestamp < manifest_.getLastModifiedTimestamp() && manifestAge > DataRefreshRate_())
+    // If current time is past next update check time or manifest is old enough, fetch a new one and load it.
+    if (Instant::Now() > nextUpdateCheckTimestamp || manifestAge > DataRefreshRate_())
     {
         if (mode_ == Manager::Mode::Manual)
         {

--- a/src/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/CSSISpaceWeather.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/CSSISpaceWeather.cpp
@@ -13,6 +13,7 @@
 #include <OpenSpaceToolkit/Core/Type/String.hpp>
 #include <OpenSpaceToolkit/Core/Utility.hpp>
 
+#include <OpenSpaceToolkit/Physics/Data/Utility.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/CSSISpaceWeather.hpp>
 
 namespace ostk
@@ -38,6 +39,8 @@ using ostk::core::utils::Print;
 using ostk::physics::time::DateTime;
 using ostk::physics::time::Scale;
 using ostk::physics::time::Time;
+
+using ostk::physics::data::utilities::getFileModifiedInstant;
 
 std::ostream& operator<<(std::ostream& anOutputStream, const CSSISpaceWeather& aCSSISpaceWeather)
 {
@@ -202,6 +205,16 @@ const Date& CSSISpaceWeather::accessLastObservationDate() const
     }
 
     return lastObservationDate_;
+}
+
+const Instant& CSSISpaceWeather::accessLastModifiedTimestamp() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("CSSI Space Weather");
+    }
+
+    return lastModifiedTimestamp_;
 }
 
 const Interval& CSSISpaceWeather::accessObservationInterval() const
@@ -544,6 +557,7 @@ CSSISpaceWeather CSSISpaceWeather::Load(const File& aFile)
     if (!spaceWeather.observations_.empty())
     {
         spaceWeather.lastObservationDate_ = spaceWeather.observations_.rbegin()->second.date;
+        spaceWeather.lastModifiedTimestamp_ = getFileModifiedInstant(aFile);
 
         const Instant observationStartInstant =
             Instant::ModifiedJulianDate(Real::Integer(spaceWeather.observations_.begin()->first), Scale::UTC);
@@ -691,6 +705,7 @@ CSSISpaceWeather CSSISpaceWeather::LoadLegacy(const File& aFile)
             readingObserved = false;
 
             spaceWeather.lastObservationDate_ = spaceWeather.observations_.rbegin()->second.date;
+            spaceWeather.lastModifiedTimestamp_ = getFileModifiedInstant(aFile);
 
             const Instant observationStartInstant =
                 Instant::ModifiedJulianDate(Real::Integer(spaceWeather.observations_.begin()->first), Scale::UTC);
@@ -878,6 +893,7 @@ CSSISpaceWeather CSSISpaceWeather::LoadLegacy(const File& aFile)
 
 CSSISpaceWeather::CSSISpaceWeather()
     : lastObservationDate_(Date::Undefined()),
+      lastModifiedTimestamp_(Instant::Undefined()),
       observationInterval_(Interval::Undefined()),
       observations_(Map<Integer, CSSISpaceWeather::Reading>()),
 

--- a/src/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/Manager.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/Manager.cpp
@@ -373,16 +373,39 @@ const CSSISpaceWeather* Manager::accessCSSISpaceWeatherAt_(const Instant& anInst
 
 File Manager::getLatestCSSISpaceWeatherFile_() const
 {
-    // Parse CSSI Space Weather Directories, e.g.,
-    // `.open-space-toolkit/physics/environment/atmospheric/earth/CSSI-Space-Weather/2022-05-19/`, and find the
-    // latest one.
+    File localCSSISpaceWeatherFile = File::Undefined();
 
+    // Check if local file exists
     if (this->getCSSISpaceWeatherDirectory().containsFileWithName(CSSISpaceWeatherFileName))
     {
-        return File::Path(this->getCSSISpaceWeatherDirectory().getPath() + Path::Parse(CSSISpaceWeatherFileName));
+        localCSSISpaceWeatherFile =
+            File::Path(this->getCSSISpaceWeatherDirectory().getPath() + Path::Parse(CSSISpaceWeatherFileName));
+
+        // Load local file to access its timestamp
+        const CSSISpaceWeather localSpaceWeather = CSSISpaceWeather::Load(localCSSISpaceWeatherFile);
+
+        // Get the Data Manager instance to query manifest
+        ManifestManager& manifestManager = ManifestManager::Get();
+
+        // Query when the remote file was last updated (this may trigger a manifest fetch)
+        const Instant remoteUpdateTimestamp = manifestManager.getLastUpdateTimestampFor(CSSISpaceWeatherManifestName);
+
+        // Get when the local file was last modified
+        const Instant localUpdateTimestamp = localSpaceWeather.accessLastModifiedTimestamp();
+
+        // If remote is newer, fetch it
+        if (remoteUpdateTimestamp > localUpdateTimestamp)
+        {
+            localCSSISpaceWeatherFile = const_cast<Manager*>(this)->fetchLatestCSSISpaceWeather_();
+        }
+    }
+    else
+    {
+        // No local file exists, fetch from remote
+        localCSSISpaceWeatherFile = const_cast<Manager*>(this)->fetchLatestCSSISpaceWeather_();
     }
 
-    return const_cast<Manager*>(this)->fetchLatestCSSISpaceWeather_();
+    return localCSSISpaceWeatherFile;
 }
 
 void Manager::setup_()

--- a/test/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/CSSISpaceWeather.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/CSSISpaceWeather.test.cpp
@@ -521,3 +521,29 @@ TEST_F(OpenSpaceToolkit_Physics_Environment_Atmospheric_Earth_CSSISpaceWeather, 
         );
     }
 }
+
+TEST_F(OpenSpaceToolkit_Physics_Environment_Atmospheric_Earth_CSSISpaceWeather, AccessLastModifiedTimestamp)
+{
+    {
+        // Test with valid CSV file
+        const File file =
+            File::Path(Path::Parse("/app/test/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/CSSISpaceWeather/"
+                                   "SW-Last5Years.test.csv"));
+
+        const CSSISpaceWeather spaceWeather = CSSISpaceWeather::Load(file);
+
+        EXPECT_TRUE(spaceWeather.isDefined());
+
+        const Instant timestamp = spaceWeather.accessLastModifiedTimestamp();
+
+        EXPECT_TRUE(timestamp.isDefined());
+        EXPECT_NO_THROW(timestamp.toString());
+    }
+
+    {
+        // Test with undefined CSSISpaceWeather
+        const CSSISpaceWeather spaceWeather = CSSISpaceWeather::Undefined();
+
+        EXPECT_THROW({ spaceWeather.accessLastModifiedTimestamp(); }, ostk::core::error::runtime::Undefined);
+    }
+}


### PR DESCRIPTION
This MR fixes a few different issues that were found in the Manifest manager as well as the space weather data manager.

Problem:
  - Manifest Manager's manifest refresh had inverted logic that prevented automatic updates (comparing nextUpdateCheckTimestamp < lastModifiedTimestamp instead of Instant::Now() > nextUpdateCheckTimestamp)
  - Atmospheric Manager didn't check if remote space weather files were newer
    than local copies, leading to stale data being used indefinitely

  Solution:
  - Fixed manifest refresh condition to check if current time exceeds next
    update check OR if manifest age exceeds refresh rate (24h default)
  - Added lastModifiedTimestamp tracking to CSSISpaceWeather class
  - Updated Atmospheric Manager to follow IERS pattern: load local file, query
    manifest for remote timestamp, and fetch if remote is newer
  - Added tests for both manifest refresh conditions and timestamp checking