### PR TITLE
fix: check transform cache size properly

### DIFF
--- a/src/OpenSpaceToolkit/Physics/Coordinate/Frame/Manager.cpp
+++ b/src/OpenSpaceToolkit/Physics/Coordinate/Frame/Manager.cpp
@@ -126,15 +126,17 @@ void Manager::addCachedTransform(
 {
     const std::lock_guard<std::mutex> lock {mutex_};
 
-    if (transformCache_.size() >= maxTransformCacheSize_)
-    {
-        // TODO: Implement LRU or FIFO eviction strategy
-        // For now, clear oldest entries
-        transformCache_.clear();
-    }
-
     const auto transformCacheFromFrameIt = transformCache_.insert({aFromFrameSPtr.get(), {}}).first;
     const auto transformCacheToFrameIt = transformCacheFromFrameIt->second.insert({aToFrameSPtr.get(), {}}).first;
+
+    // Check size for this specific frame pair
+    if (transformCacheToFrameIt->second.size() >= maxTransformCacheSize_)
+    {
+        // Clear instants for this frame pair only
+        // TBI: Improve caching strategy, perhaps LRU.
+        transformCacheToFrameIt->second.clear();
+    }
+
     const auto transformCacheToInstantIt = transformCacheToFrameIt->second.insert({anInstant, aTransform}).first;
 
     (void)transformCacheToInstantIt;


### PR DESCRIPTION
Re-addresses [Issue 336](https://github.com/open-space-collective/open-space-toolkit-physics/issues/336).

The transform cache looks something like this:
```
GCRF:
    ITRF:
        instant1: transform1
        instant2: transform2
    TEME:
        instant1: transform1
        instant2: transform2
ITRF:
    GCRF:
        instant1: transform1
        instant2: transform2
```

Previously, we were only checking the size of the outermost layer, which usually has very few elements (noting the default cache size of 1000). Rather, we should be checking the amount of `<Instant, Transform>` pairs for a given pair of reference frames. 

With the default size of 1000, this reduces the memory footprint by about ~3.5x, and fixes the memory accumulation. 

This MR is just to fix the original intent; a follow-up MR will improve the speed of the FrameManager and likely refactor this anyway. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache management for coordinate frame transformations to prevent unnecessary data clearing and ensure more predictable cache behavior during operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->