### PR TITLE
perf: eagerly cache reverse transforms

### DIFF
--- a/src/OpenSpaceToolkit/Physics/Coordinate/Frame/Manager.cpp
+++ b/src/OpenSpaceToolkit/Physics/Coordinate/Frame/Manager.cpp
@@ -140,6 +140,21 @@ void Manager::addCachedTransform(
     const auto transformCacheToInstantIt = transformCacheToFrameIt->second.insert({anInstant, aTransform}).first;
 
     (void)transformCacheToInstantIt;
+
+    // Eagerly cache the reverse transform (toFrame -> fromFrame -> instant)
+    const auto reverseTransformCacheToFrameIt = transformCache_.insert({aToFrameSPtr.get(), {}}).first;
+    const auto reverseTransformCacheFromFrameIt =
+        reverseTransformCacheToFrameIt->second.insert({aFromFrameSPtr.get(), {}}).first;
+
+    // Check size for this specific frame pair
+    if (reverseTransformCacheFromFrameIt->second.size() >= maxTransformCacheSize_)
+    {
+        // Clear instants for this frame pair only
+        // TBI: Improve caching strategy, perhaps LRU.
+        reverseTransformCacheFromFrameIt->second.clear();
+    }
+
+    reverseTransformCacheFromFrameIt->second.insert({anInstant, aTransform.getInverse()}).first;
 }
 
 Manager& Manager::Get()


### PR DESCRIPTION
Frame transformations have been identified as a significant source of runtime slowness. Ideally this should be directly addressed (e.g. using SPICE transforms between ITRF and GCRF rather than analytically as we do now). 

Until then, we can improve things by ~30-50% by eagerly caching the reverse transform when adding a Transform to the cache. This is beneficial because when we transform things from one frame to another, we often need to transform them back too (e.g. estimation <> observation frame for OD, propagation <> ITRF to compute dynamics in the numerical propagator). We also don't need to "properly" compute the reverse transform (which can actually be a series of transforms, e.g. ITRF -> TIRF -> CIRF -> GCRF), and rather just take the inverse. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved coordinate frame transform caching efficiency with enhanced reverse transform caching mechanisms.
  * Optimized cache management for frame-pair transformations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->