### PR TITLE
fix: parse manifest urls without leading slashes

### DIFF
--- a/src/OpenSpaceToolkit/Physics/Data/Manager.cpp
+++ b/src/OpenSpaceToolkit/Physics/Data/Manager.cpp
@@ -206,7 +206,18 @@ File Manager::fetchLatestManifestFile_() const
 
     this->lockLocalRepository_(localRepositoryLockTimeout_);
 
-    const URL latestDataManifestUrl = Manager::DefaultRemoteUrl() + dataManifestFileName;
+    String remoteUrlString = Manager::DefaultRemoteUrl().toString();
+
+    if (remoteUrlString.getLast() == '/')
+    {
+        remoteUrlString = remoteUrlString + dataManifestFileName;
+    }
+    else
+    {
+        remoteUrlString = remoteUrlString + "/" + dataManifestFileName;
+    }
+
+    const URL latestDataManifestUrl = URL::Parse(remoteUrlString);
 
     File latestDataManifestFile = File::Undefined();
     Directory destinationDirectory = Directory::Undefined();


### PR DESCRIPTION
Deals with the case that the data URL does not contain a trailing slash:
`OSTK_PHYSICS_DATA_REMOTE_URL=https://some-data.com/some-bucket/physics`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved URL construction logic for data manifest handling to enhance reliability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->