### PR TITLE
feat: improve earth atmospheric constructors

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth.cpp
@@ -193,6 +193,51 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth(pybind11::mo
                 )doc"
             )
 
+            .def_static(
+                "exponential",
+                &Earth::Exponential,
+                R"doc(
+                    Create an exponential atmospheric model.
+
+                    Returns:
+                        Earth: Exponential atmospheric model.
+                )doc"
+            )
+
+            .def_static(
+                "nrlmsise00_with_cssi",
+                &Earth::NRLMSISE00WithCSSI,
+                arg("sun_celestial") = nullptr,
+                R"doc(
+                    Create an NRLMSISE00 atmospheric model with CSSI input data.
+
+                    Args:
+                        sun_celestial (Celestial, optional): A shared pointer to the Sun celestial body. Defaults to None.
+
+                    Returns:
+                        Earth: NRLMSISE00 atmospheric model with CSSI input data.
+                )doc"
+            )
+
+            .def_static(
+                "nrlmsise00_with_constant_flux",
+                &Earth::NRLMSISE00WithConstantFlux,
+                arg("f107_constant_value"),
+                arg("f107_average_constant_value"),
+                arg("kp_constant_value"),
+                R"doc(
+                    Create an NRLMSISE00 atmospheric model with constant flux and geo magnetic input data.
+
+                    Args:
+                        f107_constant_value (float): A constant value for F10.7 input parameter.
+                        f107_average_constant_value (float): A constant value for F10.7a input parameter.
+                        kp_constant_value (float): A constant value for Kp input parameter.
+
+                    Returns:
+                        Earth: NRLMSISE00 atmospheric model with constant flux and geo magnetic input data.
+                )doc"
+            )
+
             ;
     }
 

--- a/bindings/python/test/environment/atmospheric/test_earth.py
+++ b/bindings/python/test/environment/atmospheric/test_earth.py
@@ -176,3 +176,16 @@ class TestEarth:
         )
 
         assert density is not None
+
+    def test_exponential_static_method_success(self):
+        assert isinstance(EarthAtmosphericModel.exponential(), EarthAtmosphericModel)
+
+    def test_nrlmsise00_with_cssi_static_method_success(self):
+        assert isinstance(EarthAtmosphericModel.nrlmsise00_with_cssi(), EarthAtmosphericModel)
+
+    def test_nrlmsise00_with_cssi_static_method_with_sun_success(self):
+        assert isinstance(EarthAtmosphericModel.nrlmsise00_with_cssi(sun_celestial=Sun.default()), EarthAtmosphericModel)
+        assert isinstance(EarthAtmosphericModel.nrlmsise00_with_cssi(), EarthAtmosphericModel)
+
+    def test_nrlmsise00_with_constant_flux_static_method_success(self):
+        assert isinstance(EarthAtmosphericModel.nrlmsise00_with_constant_flux(f107_constant_value=150.0, f107_average_constant_value=150.0, kp_constant_value=3.0), EarthAtmosphericModel)

--- a/include/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.hpp
@@ -130,7 +130,18 @@ class Earth : public Model
     /// @param              [in] anInstant An Instant
     /// @return             Atmospheric density value [kg.m^-3]
 
+    [[deprecated("getDensityAt(const Position& aPosition, const Instant& anInstant) is deprecated. Please use getDensityAt(const LLA& aLLA, const Instant& anInstant) or getDensityAt(const Position& aPosition, const Instant& anInstant, const Length& anEquatorialRadius, const Real& aFlattening) instead.")]]
     Real getDensityAt(const Position& aPosition, const Instant& anInstant) const override;
+
+    /// @brief              Get the atmospheric density value at a given position and instant
+    ///
+    /// @param              [in] aPosition A Position, must be supplied in an celestial body frame.
+    /// @param              [in] anInstant An Instant
+    /// @param              [in] anEquatorialRadius An Equatorial Radius
+    /// @param              [in] aFlattening A Flattening
+    /// @return             Atmospheric density value [kg.m^-3]
+
+    Real getDensityAt(const Position& aPosition, const Instant& anInstant, const Length& anEquatorialRadius, const Real& aFlattening) const override;
 
     /// @brief              Get the atmospheric density value at a given position and instant
     ///
@@ -139,6 +150,28 @@ class Earth : public Model
     /// @return             Atmospheric density value [kg.m^-3]
 
     Real getDensityAt(const LLA& aLLA, const Instant& anInstant) const;
+
+    /// @brief              Create an exponential atmospheric model
+    ///
+    /// @return             Exponential atmospheric model
+
+    static Earth Exponential();
+
+    /// @brief              Create an NRLMSISE00 atmospheric model with CSSI input data
+    ///
+    /// @param              [in] aSunCelestialSPtr A shared pointer to the Sun celestial body. Optional, defaults to nullptr.
+    /// @return             NRLMSISE00 atmospheric model with CSSI input data
+
+    static Earth NRLMSISE00WithCSSI(const Shared<Celestial>& aSunCelestialSPtr = nullptr);
+
+    /// @brief              Create an NRLMSISE00 atmospheric model with constant flux and geo magnetic input data
+    ///
+    /// @param              [in] aF107ConstantValue A constant value for F10.7 input parameter
+    /// @param              [in] aF107AConstantValue A constant value for F10.7a input parameter
+    /// @param              [in] aKpConstantValue A constant value for Kp input parameter
+    /// @return             NRLMSISE00 atmospheric model with constant flux and geo magnetic input data
+
+    static Earth NRLMSISE00WithConstantFlux(const Real& aF107ConstantValue, const Real& aF107AConstantValue, const Real& aKpConstantValue);
 
     static constexpr double defaultF107ConstantValue = 150.0;   // 10⁻²² W⋅m⁻²⋅Hz⁻¹
     static constexpr double defaultF107AConstantValue = 150.0;  // 10⁻²² W⋅m⁻²⋅Hz⁻¹

--- a/include/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.hpp
@@ -135,7 +135,7 @@ class Earth : public Model
 
     /// @brief              Get the atmospheric density value at a given position and instant
     ///
-    /// @param              [in] aPosition A Position, must be supplied in an celestial body frame.
+    /// @param              [in] aPosition A Position, must be supplied in a celestial body frame.
     /// @param              [in] anInstant An Instant
     /// @param              [in] anEquatorialRadius An Equatorial Radius
     /// @param              [in] aFlattening A Flattening

--- a/include/OpenSpaceToolkit/Physics/Environment/Atmospheric/Model.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Atmospheric/Model.hpp
@@ -7,6 +7,7 @@
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Position.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
+#include <OpenSpaceToolkit/Physics/Unit/Length.hpp>
 
 namespace ostk
 {
@@ -21,6 +22,7 @@ using ostk::core::type::Real;
 
 using ostk::physics::coordinate::Position;
 using ostk::physics::time::Instant;
+using ostk::physics::unit::Length;
 
 /// @brief                      Atmospheric model (interface)
 
@@ -53,7 +55,18 @@ class Model
     /// @param              [in] anInstant An Instant
     /// @return             Atmospheric density value [kg.m^-3]
 
+    [[deprecated("getDensityAt(const Position& aPosition, const Instant& anInstant) is deprecated. Please use getDensityAt(const Position& aPosition, const Instant& anInstant, const Length& anEquatorialRadius, const Real& aFlattening) instead.")]]
     virtual Real getDensityAt(const Position& aPosition, const Instant& anInstant) const = 0;
+
+    /// @brief              Get the atmospheric density value at a given position and instant
+    ///
+    /// @param              [in] aPosition A Position
+    /// @param              [in] anInstant An Instant
+    /// @param              [in] anEquatorialRadius An Equatorial Radius
+    /// @param              [in] aFlattening A Flattening
+    /// @return             Atmospheric density value [kg.m^-3]
+
+    virtual Real getDensityAt(const Position& aPosition, const Instant& anInstant, const Length& anEquatorialRadius, const Real& aFlattening) const = 0;
 };
 
 }  // namespace atmospheric

--- a/src/OpenSpaceToolkit/Physics/Environment/Object/Celestial.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Object/Celestial.cpp
@@ -370,7 +370,7 @@ Scalar Celestial::getAtmosphericDensityAt(const Position& aPosition, const Insta
         throw ostk::core::error::runtime::Undefined("Atmospheric model");
     }
 
-    const Real atmosphericDensityValue = atmosphericModelSPtr_->getDensityAt(aPosition, anInstant);
+    const Real atmosphericDensityValue = atmosphericModelSPtr_->getDensityAt(aPosition.inFrame(ephemeris_->accessFrame(), anInstant), anInstant, this->getEquatorialRadius(), this->getFlattening());
 
     const static Unit atmosphericDensityUnit =
         Unit::Derived(Derived::Unit::MassDensity(Mass::Unit::Kilogram, Length::Unit::Meter));


### PR DESCRIPTION
This PR improves the Earth atmospheric model constructors by adding convenient static factory methods and deprecating the complex constructor signature that required frame/radius/flattening parameters, which are no longer used. Instead, users should provide them with the `getDensityAt(position, instant, earthRadius, flattening)` signature, providing a position in a celestial body frame.

### New Static Factory Methods:
  - Earth::Exponential() - Creates an exponential atmospheric model with sensible defaults
  - Earth::NRLMSISE00WithCSSI(sunCelestial) - Creates an NRLMSISE00 model with CSSI space weather data
  - Earth::NRLMSISE00WithConstantFlux(f107, f107a, kp) - Creates an NRLMSISE00 model with constant flux parameters

### API Improvements:
  - Added new getDensityAt(Position, Instant, Length, Real) overload that accepts equatorial radius and flattening explicitly
  - Deprecated the old getDensityAt(Position, Instant) method (users should use LLA-based or the new 4-parameter version)
  - Updated Celestial::getAtmosphericDensityAt() to use the new API, passing celestial body parameters (this allows the frame conversions to leverage the ephemeris frame, rather than the hardcoded ITRF frame)

### Internal Refactoring:
  - Moved Position→LLA conversion logic to the base Impl class, removing duplicate code from ExponentialImpl and NRLMSISE00Impl
  - Added runtime deprecation warnings when using the old constructor with frame/radius/flattening parameters

### Python Bindings
  - Added bindings for exponential(), nrlmsise00_with_cssi(), and nrlmsise00_with_constant_flux() static methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New static factory options to create Earth atmospheric models: Exponential, NRLMSISE00 (with optional Sun/CSSI), and NRLMSISE00 with constant flux.
  * New density calculation overload that accepts explicit equatorial radius and flattening for more accurate, frame-aware results.

* **Deprecated**
  * getDensityAt(Position, Instant) is deprecated; migrate to overloads including planetary parameters.

* **Tests**
  * Added tests for new factories and updated density overloads.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->