### PR TITLE
fix: compare objects when comparing frames

### DIFF
--- a/src/OpenSpaceToolkit/Physics/Coordinate/Position.cpp
+++ b/src/OpenSpaceToolkit/Physics/Coordinate/Position.cpp
@@ -102,7 +102,7 @@ bool Position::isNear(const Position& aPosition, const Length& aTolerance) const
         throw ostk::core::error::runtime::Undefined("Position");
     }
 
-    if (frameSPtr_ != aPosition.frameSPtr_)
+    if ((*frameSPtr_) != (*aPosition.frameSPtr_))
     {
         throw ostk::core::error::RuntimeError("Position are expressed in different frames.");
     }

--- a/src/OpenSpaceToolkit/Physics/Data/Vector.cpp
+++ b/src/OpenSpaceToolkit/Physics/Data/Vector.cpp
@@ -26,7 +26,7 @@ bool Vector::operator==(const Vector& aVector) const
         return false;
     }
 
-    return (value_ == aVector.value_) && (unit_ == aVector.unit_) && (frameSPtr_ == aVector.frameSPtr_);
+    return (value_ == aVector.value_) && (unit_ == aVector.unit_) && ((*frameSPtr_) == (*aVector.frameSPtr_));
 }
 
 bool Vector::operator!=(const Vector& aVector) const


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected frame comparison logic in coordinate position and vector operations to ensure proper frame equivalence validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->