### PR TITLE
fix!: preserve altitude when manipulating LLAs

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Spherical/LLA.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Spherical/LLA.cpp
@@ -163,7 +163,8 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
             &LLA::calculateIntermediateTo,
             R"doc(
                 Calculate a point between this LLA coordinate and another LLA coordinate.
-                If ellipsoid parameters are not provided, values from the global Environment central celestial are used. 
+                The altitude of the returned coordinate is linearly interpolated between the two coordinates' altitudes at the given ratio.
+                If ellipsoid parameters are not provided, values from the global Environment central celestial are used.
 
                 Args:
                     lla (LLA): Another LLA coordinate.
@@ -172,7 +173,7 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
                     ellipsoid_flattening (float): Flattening of the ellipsoid.
 
                 Returns:
-                    LLA: A point between the two LLA coordinates.
+                    LLA: A point between the two LLA coordinates, with altitude linearly interpolated between the two coordinates' altitudes.
             )doc",
             arg("lla"),
             arg("ratio"),
@@ -184,7 +185,8 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
             &LLA::calculateForward,
             R"doc(
                 Propagate this LLA coordinate in provided direction and distance.
-                If ellipsoid parameters are not provided, values from the global Environment central celestial are used. 
+                The altitude of this coordinate is preserved in the returned coordinate.
+                If ellipsoid parameters are not provided, values from the global Environment central celestial are used.
 
                 Args:
                     azimuth (Angle): Azimuth.
@@ -193,7 +195,7 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
                     ellipsoid_flattening (float): Flattening of the ellipsoid.
 
                 Returns:
-                    LLA: Propagated LLA coordinate.
+                    LLA: Propagated LLA coordinate, preserving this coordinate's altitude.
             )doc",
             arg("azimuth"),
             arg("distance"),
@@ -205,7 +207,8 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
             &LLA::calculateLinspaceTo,
             R"doc(
                 Generate LLAs between this LLA coordinate and another LLA coordinate at a given interval.
-                If ellipsoid parameters are not provided, values from the global Environment central celestial are used. 
+                The altitude of each generated coordinate is linearly interpolated between the two coordinates' altitudes.
+                If ellipsoid parameters are not provided, values from the global Environment central celestial are used.
 
                 Args:
                     lla (LLA): Another LLA coordinate.
@@ -214,7 +217,7 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
                     ellipsoid_flattening (float): Flattening of the ellipsoid.
 
                 Returns:
-                    list[LLA]: List of LLA coordinates.
+                    list[LLA]: List of LLA coordinates, with altitudes linearly interpolated between the two coordinates' altitudes.
             )doc",
             arg("lla"),
             arg("number_of_points"),
@@ -350,7 +353,8 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
             &LLA::IntermediateBetween,
             R"doc(
                 Calculate a point between two LLA coordinates.
-                If ellipsoid parameters are not provided, values from the global Environment central celestial are used. 
+                The altitude of the returned coordinate is linearly interpolated between the two coordinates' altitudes at the given ratio.
+                If ellipsoid parameters are not provided, values from the global Environment central celestial are used.
 
                 Args:
                     lla_1 (LLA): First LLA coordinate.
@@ -360,7 +364,7 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
                     ellipsoid_flattening (float): Flattening of the ellipsoid.
 
                 Returns:
-                    LLA: A point between the two LLA coordinates.
+                    LLA: A point between the two LLA coordinates, with altitude linearly interpolated between the two coordinates' altitudes.
             )doc",
             arg("lla_1"),
             arg("lla_2"),
@@ -373,7 +377,8 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
             &LLA::Forward,
             R"doc(
                 Propagate an LLA coordinate in provided direction and distance.
-                If ellipsoid parameters are not provided, values from the global Environment central celestial are used. 
+                The altitude of the provided coordinate is preserved in the returned coordinate.
+                If ellipsoid parameters are not provided, values from the global Environment central celestial are used.
 
                 Args:
                     lla (LLA): LLA coordinate.
@@ -383,7 +388,7 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
                     ellipsoid_flattening (float): Flattening of the ellipsoid.
 
                 Returns:
-                    LLA: Propagated LLA coordinate.
+                    LLA: Propagated LLA coordinate, preserving the provided coordinate's altitude.
             )doc",
             arg("lla"),
             arg("azimuth"),
@@ -396,7 +401,8 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
             &LLA::Linspace,
             R"doc(
                 Generate LLAs between two LLA coordinates at a given interval.
-                If ellipsoid parameters are not provided, values from the global Environment central celestial are used. 
+                The altitude of each generated coordinate is linearly interpolated between the two coordinates' altitudes.
+                If ellipsoid parameters are not provided, values from the global Environment central celestial are used.
 
                 Args:
                     lla_1 (LLA): First LLA coordinate.
@@ -406,7 +412,7 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
                     ellipsoid_flattening (float): Flattening of the ellipsoid.
 
                 Returns:
-                    list[LLA]: List of LLA coordinates.
+                    list[LLA]: List of LLA coordinates, with altitudes linearly interpolated between the two coordinates' altitudes.
             )doc",
             arg("lla_1"),
             arg("lla_2"),

--- a/include/OpenSpaceToolkit/Physics/Coordinate/Spherical/LLA.hpp
+++ b/include/OpenSpaceToolkit/Physics/Coordinate/Spherical/LLA.hpp
@@ -193,8 +193,10 @@ class LLA
         const Real& anEllipsoidFlattening = Real::Undefined()
     ) const;
 
-    /// @brief Calculate a point between this LLA coordinate and another LLA coordinate. Will use
-    /// the central celestial from the global environment if no ellipsoid parameters are provided.
+    /// @brief Calculate a point between this LLA coordinate and another LLA coordinate. The altitude
+    /// of the returned coordinate is linearly interpolated between the two coordinates' altitudes at
+    /// the given ratio. Will use the central celestial from the global environment if no ellipsoid
+    /// parameters are provided.
     ///
     /// @code
     ///     lla.calculateIntermediateTo(otherLLA, 0.5);
@@ -204,7 +206,8 @@ class LLA
     /// @param [in] aRatio A ratio
     /// @param [in] anEllipsoidEquatorialRadius An ellipsoid equatorial radius
     /// @param [in] anEllipsoidFlattening An ellipsoid flattening
-    /// @return A point between the two LLA coordinates
+    /// @return A point between the two LLA coordinates, with altitude linearly interpolated between
+    /// the two coordinates' altitudes
 
     LLA calculateIntermediateTo(
         const LLA& aLLA,
@@ -213,8 +216,9 @@ class LLA
         const Real& anEllipsoidFlattening = Real::Undefined()
     ) const;
 
-    /// @brief Propagate this LLA coordinate in provided direction and distance. Will use
-    /// the central celestial from the global environment if no ellipsoid parameters are provided.
+    /// @brief Propagate this LLA coordinate in provided direction and distance. The altitude of this
+    /// coordinate is preserved in the returned coordinate. Will use the central celestial from the
+    /// global environment if no ellipsoid parameters are provided.
     ///
     /// @code
     ///     lla.calculateForward(Angle::Degrees(90.0), Length::Meters(1000.0));
@@ -224,7 +228,7 @@ class LLA
     /// @param [in] aDistance A distance
     /// @param [in] anEllipsoidEquatorialRadius An ellipsoid equatorial radius
     /// @param [in] anEllipsoidFlattening An ellipsoid flattening
-    /// @return Propagated LLA coordinate
+    /// @return Propagated LLA coordinate, preserving this coordinate's altitude
 
     LLA calculateForward(
         const Angle& aDirection,
@@ -234,7 +238,9 @@ class LLA
     ) const;
 
     /// @brief Generate LLAs between this LLA coordinate and another LLA coordinate at a given
-    /// interval. Will use the central celestial from the global environment if no ellipsoid parameters are provided.
+    /// interval. The altitude of each generated coordinate is linearly interpolated between the two
+    /// coordinates' altitudes. Will use the central celestial from the global environment if no
+    /// ellipsoid parameters are provided.
     ///
     /// @code
     ///     lla.calculateLinspaceTo(otherLLA, 10);
@@ -244,6 +250,7 @@ class LLA
     /// @param [in] aNumberOfPoints A number of points
     /// @param [in] anEllipsoidEquatorialRadius An ellipsoid equatorial radius
     /// @param [in] anEllipsoidFlattening An ellipsoid flattening
+    /// @return Intermediate LLAs, with altitudes linearly interpolated between the two coordinates' altitudes
 
     Array<LLA> calculateLinspaceTo(
         const LLA& aLLA,
@@ -379,7 +386,8 @@ class LLA
         const Real& anEllipsoidFlattening = Real::Undefined()
     );
 
-    /// @brief Calculate a point between two LLA coordinates. Will use
+    /// @brief Calculate a point between two LLA coordinates. The altitude of the returned coordinate
+    /// is linearly interpolated between the two coordinates' altitudes at the given ratio. Will use
     /// the central celestial from the global environment if no ellipsoid parameters are provided.
     ///
     /// @code
@@ -391,7 +399,8 @@ class LLA
     /// @param [in] aRatio A ratio
     /// @param [in] anEllipsoidEquatorialRadius An ellipsoid equatorial radius
     /// @param [in] anEllipsoidFlattening An ellipsoid flattening
-    /// @return A point between the two LLA coordinates
+    /// @return A point between the two LLA coordinates, with altitude linearly interpolated between
+    /// the two coordinates' altitudes
 
     static LLA IntermediateBetween(
         const LLA& aFirstLLA,
@@ -401,8 +410,9 @@ class LLA
         const Real& anEllipsoidFlattening = Real::Undefined()
     );
 
-    /// @brief Propagate LLA coordinates in provided direction and distance. Will use
-    /// the central celestial from the global environment if no ellipsoid parameters are provided.
+    /// @brief Propagate LLA coordinates in provided direction and distance. The altitude of the
+    /// provided coordinate is preserved in the returned coordinate. Will use the central celestial
+    /// from the global environment if no ellipsoid parameters are provided.
     ///
     /// @code
     ///     LLA::Forward(lla, Angle::Degrees(90.0), Length::Meters(1000.0));
@@ -413,7 +423,7 @@ class LLA
     /// @param [in] aDistance A distance
     /// @param [in] anEllipsoidEquatorialRadius An ellipsoid equatorial radius
     /// @param [in] anEllipsoidFlattening An ellipsoid flattening
-    /// @return Propagated LLA coordinate
+    /// @return Propagated LLA coordinate, preserving the provided coordinate's altitude
 
     static LLA Forward(
         const LLA& aLLA,
@@ -424,7 +434,9 @@ class LLA
     );
 
     /// @brief Generate equidistant LLAs between two LLA coordinates for the specified number of
-    /// points. Will use the central celestial from the global environment if no ellipsoid parameters are provided.
+    /// points. The altitude of each generated coordinate is linearly interpolated between the two
+    /// coordinates' altitudes. Will use the central celestial from the global environment if no
+    /// ellipsoid parameters are provided.
     ///
     /// @code
     ///     LLA::Linspace(firstLLA, secondLLA, 10);
@@ -435,7 +447,8 @@ class LLA
     /// @param [in] aNumberOfPoints A number of points
     /// @param [in] anEllipsoidEquatorialRadius An ellipsoid equatorial radius
     /// @param [in] anEllipsoidFlattening An ellipsoid flattening
-    /// @return intermediate equidistant LLAs between the two LLA coordinates
+    /// @return Intermediate equidistant LLAs between the two LLA coordinates, with altitudes linearly
+    /// interpolated between the two coordinates' altitudes
 
     static Array<LLA> Linspace(
         const LLA& aFirstLLA,

--- a/src/OpenSpaceToolkit/Physics/Coordinate/Spherical/LLA.cpp
+++ b/src/OpenSpaceToolkit/Physics/Coordinate/Spherical/LLA.cpp
@@ -449,7 +449,10 @@ LLA LLA::IntermediateBetween(
 
     geodesicLine.Position(distance.inMeters() * aRatio, latitude_deg, longitude_deg);
 
-    return {Angle::Degrees(latitude_deg), Angle::Degrees(longitude_deg), Length::Meters(0.0)};
+    // Linearly interpolate the altitude between the two coordinates at the given ratio
+    const Length altitude = aFirstLLA.getAltitude() + (aSecondLLA.getAltitude() - aFirstLLA.getAltitude()) * aRatio;
+
+    return {Angle::Degrees(latitude_deg), Angle::Degrees(longitude_deg), altitude};
 }
 
 LLA LLA::Forward(
@@ -485,7 +488,8 @@ LLA LLA::Forward(
         longitude_deg
     );
 
-    return {Angle::Degrees(latitude_deg), Angle::Degrees(longitude_deg), Length::Meters(0.0)};
+    // Preserve the altitude of the source coordinate
+    return {Angle::Degrees(latitude_deg), Angle::Degrees(longitude_deg), aLLA.getAltitude()};
 }
 
 Array<LLA> LLA::Linspace(
@@ -522,10 +526,19 @@ Array<LLA> LLA::Linspace(
     GeographicLib::Math::real latitude_deg;
     GeographicLib::Math::real longitude_deg;
 
+    const Length firstAltitude = aFirstLLA.getAltitude();
+    const Length altitudeDifference = aSecondLLA.getAltitude() - firstAltitude;
+
     for (Size i = 0; i < aNumberOfPoints; ++i)
     {
         geodesicLine.Position((i + 1) * geodesicLine.Distance() / (aNumberOfPoints + 1), latitude_deg, longitude_deg);
-        intermediateLLAs.add(LLA(Angle::Degrees(latitude_deg), Angle::Degrees(longitude_deg), Length::Meters(0.0)));
+
+        // Linearly interpolate the altitude between the two coordinates at this point's ratio along the geodesic
+        const Real ratio = static_cast<double>(i + 1) / static_cast<double>(aNumberOfPoints + 1);
+
+        intermediateLLAs.add(
+            LLA(Angle::Degrees(latitude_deg), Angle::Degrees(longitude_deg), firstAltitude + altitudeDifference * ratio)
+        );
     }
 
     return intermediateLLAs;

--- a/test/OpenSpaceToolkit/Physics/Coordinate/Spherical/LLA.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Coordinate/Spherical/LLA.test.cpp
@@ -25,6 +25,7 @@ using ostk::core::filesystem::File;
 using ostk::core::filesystem::Path;
 using ostk::core::type::Real;
 using ostk::core::type::Shared;
+using ostk::core::type::Size;
 using ostk::core::type::String;
 
 using ostk::mathematics::object::Vector3d;
@@ -365,6 +366,17 @@ TEST_F(OpenSpaceToolkit_Physics_Coordinate_Spherical_LLA, calculateIntermediateT
         EXPECT_EQ(llaIntermediate.getLongitude(), Angle::Degrees(-30.281783237740761));
     }
 
+    // altitude is linearly interpolated between the two coordinates
+    {
+        const LLA lla1 = LLA(Angle::Degrees(0.0), Angle::Degrees(0.0), Length::Meters(100.0));
+        const LLA lla2 = LLA(Angle::Degrees(0.0), Angle::Degrees(10.0), Length::Meters(200.0));
+
+        const LLA llaIntermediate =
+            lla1.calculateIntermediateTo(lla2, 0.25, WGS84EarthEquatorialRadius, WGS84EarthFlattening);
+
+        EXPECT_NEAR(llaIntermediate.getAltitude().inMeters(), 125.0, 1e-13);
+    }
+
     {
         const LLA llaNorthPole = LLA(Angle::Degrees(90.0), Angle::Degrees(15.0), Length::Meters(1.0));
         const LLA llaSouthPole = LLA(Angle::Degrees(-90.0), Angle::Degrees(15.0), Length::Meters(1.0));
@@ -431,6 +443,18 @@ TEST_F(OpenSpaceToolkit_Physics_Coordinate_Spherical_LLA, calculateForward_WGS84
         EXPECT_NEAR(llaExpected.getLongitude().inDegrees(), llaCalculated.getLongitude().inDegrees(), 1e-13);
     }
 
+    // altitude of the source coordinate is preserved
+    {
+        const LLA lla = LLA(Angle::Degrees(0.0), Angle::Degrees(0.0), Length::Meters(500.0));
+        const Angle azimuth = Angle::Degrees(90.0);
+        const Length distance = Length::Meters(1113194.9079327357);
+
+        const LLA llaCalculated =
+            lla.calculateForward(azimuth, distance, WGS84EarthEquatorialRadius, WGS84EarthFlattening);
+
+        EXPECT_NEAR(llaCalculated.getAltitude().inMeters(), 500.0, 1e-13);
+    }
+
     {
         const LLA llaNorthPole = LLA(Angle::Degrees(90.0), Angle::Degrees(15.0), Length::Meters(1.0));
         const Angle azimuth = Angle::Degrees(-108.0281189033601);
@@ -471,6 +495,23 @@ TEST_F(OpenSpaceToolkit_Physics_Coordinate_Spherical_LLA, calculateLinspaceTo_WG
             const LLA llaExpected = std::get<1>(element);
             EXPECT_NEAR(lla.getLatitude().inDegrees(), llaExpected.getLatitude().inDegrees(), 1e-13);
             EXPECT_NEAR(lla.getLongitude().inDegrees(), llaExpected.getLongitude().inDegrees(), 1e-13);
+        }
+    }
+
+    // altitude is linearly interpolated between the two coordinates
+    {
+        const LLA lla1 = LLA(Angle::Degrees(30.0), Angle::Degrees(15.0), Length::Meters(0.0));
+        const LLA lla2 = LLA(Angle::Degrees(40.0), Angle::Degrees(-20.0), Length::Meters(1000.0));
+
+        const Array<LLA> llas = lla1.calculateLinspaceTo(lla2, 4, WGS84EarthEquatorialRadius, WGS84EarthFlattening);
+
+        // 4 points at ratios 1/5, 2/5, 3/5, 4/5 along the geodesic
+        const Array<Real> expectedAltitudes_m = {200.0, 400.0, 600.0, 800.0};
+
+        EXPECT_EQ(llas.getSize(), 4);
+        for (Size i = 0; i < llas.getSize(); ++i)
+        {
+            EXPECT_NEAR(llas[i].getAltitude().inMeters(), expectedAltitudes_m[i], 1e-13);
         }
     }
 
@@ -982,6 +1023,17 @@ TEST_F(OpenSpaceToolkit_Physics_Coordinate_Spherical_LLA, IntermediateBetween_WG
         EXPECT_EQ(llaIntermediate.getLongitude(), Angle::Degrees(-30.281783237740761));
     }
 
+    // altitude is linearly interpolated between the two coordinates
+    {
+        const LLA lla1 = LLA(Angle::Degrees(0.0), Angle::Degrees(0.0), Length::Meters(100.0));
+        const LLA lla2 = LLA(Angle::Degrees(0.0), Angle::Degrees(10.0), Length::Meters(200.0));
+
+        const LLA llaIntermediate =
+            LLA::IntermediateBetween(lla1, lla2, 0.25, WGS84EarthEquatorialRadius, WGS84EarthFlattening);
+
+        EXPECT_NEAR(llaIntermediate.getAltitude().inMeters(), 125.0, 1e-13);
+    }
+
     {
         const LLA llaNorthPole = LLA(Angle::Degrees(90.0), Angle::Degrees(15.0), Length::Meters(1.0));
         const LLA llaSouthPole = LLA(Angle::Degrees(-90.0), Angle::Degrees(15.0), Length::Meters(1.0));
@@ -1049,6 +1101,18 @@ TEST_F(OpenSpaceToolkit_Physics_Coordinate_Spherical_LLA, Forward_WGS84)
         EXPECT_NEAR(llaExpected.getLongitude().inDegrees(), llaCalculated.getLongitude().inDegrees(), 1e-13);
     }
 
+    // altitude of the source coordinate is preserved
+    {
+        const LLA lla = LLA(Angle::Degrees(0.0), Angle::Degrees(0.0), Length::Meters(500.0));
+        const Angle azimuth = Angle::Degrees(90.0);
+        const Length distance = Length::Meters(1113194.9079327357);
+
+        const LLA llaCalculated =
+            LLA::Forward(lla, azimuth, distance, WGS84EarthEquatorialRadius, WGS84EarthFlattening);
+
+        EXPECT_NEAR(llaCalculated.getAltitude().inMeters(), 500.0, 1e-13);
+    }
+
     {
         const LLA llaNorthPole = LLA(Angle::Degrees(90.0), Angle::Degrees(15.0), Length::Meters(1.0));
         const Angle azimuth = Angle::Degrees(-108.0281189033601);
@@ -1090,6 +1154,23 @@ TEST_F(OpenSpaceToolkit_Physics_Coordinate_Spherical_LLA, Linspace_WGS84)
             const LLA llaExpected = std::get<1>(element);
             EXPECT_NEAR(lla.getLatitude().inDegrees(), llaExpected.getLatitude().inDegrees(), 1e-13);
             EXPECT_NEAR(lla.getLongitude().inDegrees(), llaExpected.getLongitude().inDegrees(), 1e-13);
+        }
+    }
+
+    // altitude is linearly interpolated between the two coordinates
+    {
+        const LLA lla1 = LLA(Angle::Degrees(30.0), Angle::Degrees(15.0), Length::Meters(0.0));
+        const LLA lla2 = LLA(Angle::Degrees(40.0), Angle::Degrees(-20.0), Length::Meters(1000.0));
+
+        const Array<LLA> llas = LLA::Linspace(lla1, lla2, 4, WGS84EarthEquatorialRadius, WGS84EarthFlattening);
+
+        // 4 points at ratios 1/5, 2/5, 3/5, 4/5 along the geodesic
+        const Array<Real> expectedAltitudes_m = {200.0, 400.0, 600.0, 800.0};
+
+        EXPECT_EQ(llas.getSize(), 4);
+        for (Size i = 0; i < llas.getSize(); ++i)
+        {
+            EXPECT_NEAR(llas[i].getAltitude().inMeters(), expectedAltitudes_m[i], 1e-13);
         }
     }
 


### PR DESCRIPTION
Fixes an issue where the altitude was hardcoded to 0.0 when interpolating for forward propagating LLAs.
Intermediate points now linearly interpolate altitude between endpoints, while forward calculations preserve the source altitude.

⚠️ This is marked as a breaking change, as though it is a fix, it changes the underlying behaviour of the functions and the returned values.