### PR TITLE
build: fix packaging

### DIFF
--- a/bindings/python/tools/python/pyproject.toml.in
+++ b/bindings/python/tools/python/pyproject.toml.in
@@ -45,7 +45,7 @@ ext-modules = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["ostk.physics"]
+include = ["ostk.physics", "ostk.physics.*"]
 
 [tool.setuptools.package-data]
 "ostk.physics" = ["${SHARED_LIBRARY_TARGET}.${PROJECT_VERSION_MAJOR}", "${LIBRARY_TARGET}.*${EXTENSION}*.so"]


### PR DESCRIPTION
"submodules" weren't packaged. In this case, it was only stubs that were missing.