### PR TITLE
revert: perf: compute Julian dates arithmetically in Instant (#378)

### DIFF
--- a/src/OpenSpaceToolkit/Physics/Coordinate/Frame/Provider/CIRF.cpp
+++ b/src/OpenSpaceToolkit/Physics/Coordinate/Frame/Provider/CIRF.cpp
@@ -63,7 +63,7 @@ Transform CIRF::getTransformAt(const Instant& anInstant) const
     // Time (TT)
 
     static const Real djmjd0 = 2400000.5;
-    const Real tt = anInstant.getModifiedJulianDate(Scale::TT);
+    const Real tt = anInstant.getDateTime(Scale::TT).getModifiedJulianDate();
 
     // CIP and CIO, IAU 2006/2000A
 

--- a/src/OpenSpaceToolkit/Physics/Coordinate/Frame/Provider/ITRF.cpp
+++ b/src/OpenSpaceToolkit/Physics/Coordinate/Frame/Provider/ITRF.cpp
@@ -66,7 +66,7 @@ Transform ITRF::getTransformAt(const Instant& anInstant) const
     // Time (TT)
 
     static const Real djmjd0 = 2400000.5;
-    const Real tt = anInstant.getModifiedJulianDate(Scale::TT);
+    const Real tt = anInstant.getDateTime(Scale::TT).getModifiedJulianDate();
 
     // The polar motion xp,yp can be obtained from IERS bulletins.  The
     // values are the coordinates (in radians) of the Celestial

--- a/src/OpenSpaceToolkit/Physics/Coordinate/Frame/Provider/TIRF.cpp
+++ b/src/OpenSpaceToolkit/Physics/Coordinate/Frame/Provider/TIRF.cpp
@@ -64,7 +64,7 @@ Transform TIRF::getTransformAt(const Instant& anInstant) const
     // Time (UTC)
 
     static const Real djmjd0 = 2400000.5;
-    const Real utc = anInstant.getModifiedJulianDate(Scale::UTC);
+    const Real utc = anInstant.getDateTime(Scale::UTC).getModifiedJulianDate();
 
     const Real date = std::floor(utc);
     const Real time = utc - date;

--- a/src/OpenSpaceToolkit/Physics/Time/DateTime.cpp
+++ b/src/OpenSpaceToolkit/Physics/Time/DateTime.cpp
@@ -169,41 +169,12 @@ Real DateTime::getJulianDate() const
 
 Real DateTime::getModifiedJulianDate() const
 {
-    using ostk::core::type::Int16;
-    using ostk::core::type::Int32;
-
     if (!this->isDefined())
     {
         throw ostk::core::error::runtime::Undefined("DateTime");
     }
 
-    // Computed directly from the calendar fields rather than as getJulianDate() - 2400000.5:
-    // differencing through a ~2.4e6-magnitude double quantizes the result to ~40 us of time,
-    // while the direct computation resolves ~0.6 us at current epochs.
-
-    const Uint16 year = date_.getYear();
-    const Uint8 month = date_.getMonth();
-    const Uint8 day = date_.getDay();
-
-    const Int32 julianDayNumber = day + 1461 * (year + 4800 + (month - 14) / 12) / 4 +
-                                  367 * (month - 2 - (month - 14) / 12 * 12) / 12 -
-                                  3 * ((year + 4900 + (month - 14) / 12) / 100) / 4 - 32075;
-
-    const Int16 hour = time_.getHour();
-    const Int16 minute = time_.getMinute();
-    const Int16 second = time_.getSecond();
-    const Uint16 millisecond = time_.getMillisecond();
-    const Uint16 microsecond = time_.getMicrosecond();
-    const Uint16 nanosecond = time_.getNanosecond();
-
-    const Real fractionalDay = (hour + (minute / 60.0) + (second / 3600.0) +
-                                ((millisecond / 1e3) + (microsecond / 1e6) + (nanosecond / 1e9)) / 3600.0) /
-                               24.0;
-
-    // The Julian Day Number refers to noon of the calendar day: the Modified Julian Date
-    // (offset 2400000.5) at midnight of that day is JDN - 2400001.
-
-    return Real(julianDayNumber - 2400001) + fractionalDay;
+    return DateTime::ModifiedJulianDateFromJulianDate(this->getJulianDate());
 }
 
 String DateTime::toString(const DateTime::Format& aFormat) const

--- a/src/OpenSpaceToolkit/Physics/Time/Instant.cpp
+++ b/src/OpenSpaceToolkit/Physics/Time/Instant.cpp
@@ -1,7 +1,6 @@
 /// Apache License 2.0
 
 #include <chrono>
-#include <cstdint>
 #include <iomanip>
 #include <stdlib.h>
 
@@ -11,46 +10,6 @@
 #include <OpenSpaceToolkit/Core/Utility.hpp>
 
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
-
-namespace
-{
-
-// Low-level proleptic-Gregorian calendar algorithms, after Howard Hinnant's
-// "chrono-Compatible Low-Level Date Algorithms" (https://howardhinnant.github.io/date_algorithms.html)
-
-/// @brief Number of days from 1970-01-01 to the given civil date
-std::int64_t daysFromCivil(std::int32_t aYear, std::uint32_t aMonth, std::uint32_t aDay)
-{
-    aYear -= aMonth <= 2;
-    const std::int32_t era = (aYear >= 0 ? aYear : aYear - 399) / 400;
-    const std::uint32_t yearOfEra = static_cast<std::uint32_t>(aYear - era * 400);                 // [0, 399]
-    const std::uint32_t dayOfYear = (153 * (aMonth + (aMonth > 2 ? -3 : 9)) + 2) / 5 + aDay - 1;   // [0, 365]
-    const std::uint32_t dayOfEra = yearOfEra * 365 + yearOfEra / 4 - yearOfEra / 100 + dayOfYear;  // [0, 146096]
-
-    return static_cast<std::int64_t>(era) * 146097 + static_cast<std::int64_t>(dayOfEra) - 719468;
-}
-
-/// @brief Civil date from the number of days since 1970-01-01
-void civilFromDays(std::int64_t aDayCount, std::int32_t& aYear, std::uint32_t& aMonth, std::uint32_t& aDay)
-{
-    aDayCount += 719468;
-    const std::int64_t era = (aDayCount >= 0 ? aDayCount : aDayCount - 146096) / 146097;
-    const std::uint32_t dayOfEra = static_cast<std::uint32_t>(aDayCount - era * 146097);  // [0, 146096]
-    const std::uint32_t yearOfEra =
-        (dayOfEra - dayOfEra / 1460 + dayOfEra / 36524 - dayOfEra / 146096) / 365;                   // [0, 399]
-    const std::uint32_t dayOfYear = dayOfEra - (365 * yearOfEra + yearOfEra / 4 - yearOfEra / 100);  // [0, 365]
-    const std::uint32_t monthIndex = (5 * dayOfYear + 2) / 153;                                      // [0, 11]
-
-    aDay = dayOfYear - (153 * monthIndex + 2) / 5 + 1;
-    aMonth = monthIndex < 10 ? monthIndex + 3 : monthIndex - 9;
-    aYear = static_cast<std::int32_t>(yearOfEra) + static_cast<std::int32_t>(era) * 400 + (aMonth <= 2);
-}
-
-constexpr std::int64_t nanosecondsPerDay = 86400000000000LL;
-constexpr std::int64_t nanosecondsPerHalfDay = 43200000000000LL;
-constexpr std::int64_t daysFromUnixEpochTo2000 = 10957;  // 1970-01-01 -> 2000-01-01
-
-}  // namespace
 
 namespace ostk
 {
@@ -280,53 +239,72 @@ time::DateTime Instant::getDateTime(const Scale& aTimeScale) const
         throw ostk::core::error::runtime::Undefined("Instant");
     }
 
-    const Instant::Count count = this->inScale(aTimeScale).count_;
+    // auto getTimePointString =
+    // [ ] (const std::chrono::time_point<std::chrono::system_clock>& aTimePoint) -> String
+    // {
 
-    // Signed nanosecond offset from 2000-01-01 00:00:00 (the midnight preceding the J2000 epoch at noon).
-    // 128-bit arithmetic: the unsigned count can exceed the signed 64-bit range (~292 years from epoch).
+    //     std::time_t time = std::chrono::system_clock::to_time_t(aTimePoint) ;
 
-    const __int128 offsetFromMidnight = (count.postEpoch_ ? static_cast<__int128>(count.countFromEpoch_)
-                                                          : -static_cast<__int128>(count.countFromEpoch_)) +
-                                        nanosecondsPerHalfDay;
+    //     std::stringstream stringStream ;
 
-    // Floored division into a day count and a nanosecond-of-day in [0, 86400e9)
+    //     stringStream << std::put_time(std::gmtime(&time), "%F %T %z") ;
 
-    __int128 dayCount = offsetFromMidnight / nanosecondsPerDay;
-    __int128 nanosecondsOfDay = offsetFromMidnight % nanosecondsPerDay;
+    //     return stringStream.str() ;
 
-    if (nanosecondsOfDay < 0)
+    // } ;
+
+    // Epoch
+
+    std::tm epochTime = {};  // J2000
+
+    epochTime.tm_sec = 0;
+    epochTime.tm_min = 0;
+    epochTime.tm_hour = 12;
+    epochTime.tm_mday = 1;
+    epochTime.tm_mon = 0;
+    epochTime.tm_year = 100;
+
+    const std::chrono::time_point<std::chrono::system_clock> epochTimePoint =
+        std::chrono::system_clock::from_time_t(std::mktime(&epochTime));
+
+    // const Instant::Count dateCount_TT = this->inScale(Scale::TT).count_ ; // [TBM] remove inScale ?
+    const Instant::Count dateCount_TT = this->inScale(aTimeScale).count_;  // [TBM] remove inScale ?
+
+    const std::chrono::time_point<std::chrono::system_clock> dateTimePoint =
+        dateCount_TT.postEpoch_ ? (epochTimePoint + std::chrono::nanoseconds(dateCount_TT.countFromEpoch_))
+                                : (epochTimePoint - std::chrono::nanoseconds(dateCount_TT.countFromEpoch_));
+
+    std::time_t time = std::chrono::system_clock::to_time_t(dateTimePoint);
+
+    std::tm tm = {};
+    if (gmtime_r(&time, &tm) == nullptr)
     {
-        nanosecondsOfDay += nanosecondsPerDay;
-        dayCount -= 1;
+        throw ostk::core::error::RuntimeError("Failed to convert time to UTC.");
     }
 
-    std::int32_t year = 0;
-    std::uint32_t month = 0;
-    std::uint32_t day = 0;
+    const Uint16 year = 1900 + tm.tm_year;
+    const Uint8 month = tm.tm_mon + 1;
+    const Uint8 day = tm.tm_mday;
 
-    civilFromDays(static_cast<std::int64_t>(dayCount) + daysFromUnixEpochTo2000, year, month, day);
+    const Uint8 hours = tm.tm_hour;
+    const Uint8 minutes = tm.tm_min;
+    const Uint8 seconds = tm.tm_sec;
 
-    const std::uint64_t timeOfDay = static_cast<std::uint64_t>(nanosecondsOfDay);
+    const auto fraction = dateTimePoint - std::chrono::time_point_cast<std::chrono::seconds>(dateTimePoint);
 
-    const Uint8 hours = timeOfDay / 3600000000000ULL;
-    const Uint8 minutes = (timeOfDay / 60000000000ULL) % 60;
-    const Uint8 seconds = (timeOfDay / 1000000000ULL) % 60;
-    const Uint16 milliseconds = (timeOfDay / 1000000ULL) % 1000;
-    const Uint16 microseconds = (timeOfDay / 1000ULL) % 1000;
-    const Uint16 nanoseconds = timeOfDay % 1000ULL;
+    const Uint16 milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(fraction).count();
+    const Uint16 microseconds =
+        std::chrono::duration_cast<std::chrono::microseconds>(fraction).count() - milliseconds * 1000;
+    const Uint16 nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(fraction).count() -
+                               milliseconds * 1000000 - microseconds * 1000;
+
+    // [TBI] Time scale conversion
 
     return time::DateTime(year, month, day, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
 }
 
 Real Instant::getJulianDate(const Scale& aTimeScale) const
 {
-    return this->getModifiedJulianDate(aTimeScale) + 2400000.5;
-}
-
-Real Instant::getModifiedJulianDate(const Scale& aTimeScale) const
-{
-    using ostk::core::type::Uint64;
-
     if (aTimeScale == Scale::Undefined)
     {
         throw ostk::core::error::runtime::Undefined("Scale");
@@ -337,21 +315,22 @@ Real Instant::getModifiedJulianDate(const Scale& aTimeScale) const
         throw ostk::core::error::runtime::Undefined("Instant");
     }
 
-    // J2000 epoch (2000-01-01 12:00:00 in the target scale) is MJD 51544.5.
-    // The whole-day / remainder split keeps the conversion exact to the double
-    // resolution of the resulting MJD.
+    return this->getDateTime(aTimeScale).getJulianDate();
+}
 
-    const Instant::Count count = this->inScale(aTimeScale).count_;
+Real Instant::getModifiedJulianDate(const Scale& aTimeScale) const
+{
+    if (aTimeScale == Scale::Undefined)
+    {
+        throw ostk::core::error::runtime::Undefined("Scale");
+    }
 
-    static const Uint64 nanosecondsPerDay = 86400000000000ULL;
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("Instant");
+    }
 
-    const Uint64 wholeDays = count.countFromEpoch_ / nanosecondsPerDay;
-    const Uint64 remainderNanoseconds = count.countFromEpoch_ % nanosecondsPerDay;
-
-    const double dayOffset = static_cast<double>(wholeDays) +
-                             static_cast<double>(remainderNanoseconds) / static_cast<double>(nanosecondsPerDay);
-
-    return 51544.5 + (count.postEpoch_ ? dayOffset : -dayOffset);
+    return this->getDateTime(aTimeScale).getModifiedJulianDate();
 }
 
 Int64 Instant::getLeapSecondCount() const
@@ -445,6 +424,8 @@ Instant Instant::GPSEpoch()
 
 Instant Instant::DateTime(const time::DateTime& aDateTime, const Scale& aTimeScale)
 {
+    using ostk::core::type::Int32;
+
     if (!aDateTime.isDefined())
     {
         throw ostk::core::error::runtime::Wrong("DateTime");
@@ -463,27 +444,61 @@ Instant Instant::DateTime(const time::DateTime& aDateTime, const Scale& aTimeSca
         );
     }
 
-    // Days from 2000-01-01, then signed nanosecond offset from the J2000 epoch (2000-01-01 12:00:00)
+    // Epoch
 
-    const std::int64_t dayCount =
-        daysFromCivil(
-            aDateTime.accessDate().getYear(), aDateTime.accessDate().getMonth(), aDateTime.accessDate().getDay()
-        ) -
-        daysFromUnixEpochTo2000;
+    std::tm epochTime = {};  // J2000
 
-    const std::int64_t timeOfDay =
-        aDateTime.accessTime().getHour() * 3600000000000LL + aDateTime.accessTime().getMinute() * 60000000000LL +
-        aDateTime.accessTime().getSecond() * 1000000000LL + aDateTime.accessTime().getMillisecond() * 1000000LL +
-        aDateTime.accessTime().getMicrosecond() * 1000LL + aDateTime.accessTime().getNanosecond();
+    epochTime.tm_sec = 0;
+    epochTime.tm_min = 0;
+    epochTime.tm_hour = 12;
+    epochTime.tm_mday = 1;
+    epochTime.tm_mon = 0;
+    epochTime.tm_year = 100;
 
-    const __int128 offset = static_cast<__int128>(dayCount) * nanosecondsPerDay + timeOfDay - nanosecondsPerHalfDay;
+    const std::chrono::time_point<std::chrono::system_clock> epochTimePoint =
+        std::chrono::system_clock::from_time_t(std::mktime(&epochTime));
 
-    const bool postEpoch = offset >= 0;
-    const Uint64 nanosecondCount = static_cast<Uint64>(postEpoch ? offset : -offset);
+    // Date
+
+    std::tm dateTime = {};
+
+    dateTime.tm_sec = aDateTime.accessTime().getSecond();
+    dateTime.tm_min = aDateTime.accessTime().getMinute();
+    dateTime.tm_hour = aDateTime.accessTime().getHour();
+    dateTime.tm_mday = aDateTime.accessDate().getDay();
+    dateTime.tm_mon = aDateTime.accessDate().getMonth() - 1;
+    dateTime.tm_year = static_cast<Int32>(aDateTime.accessDate().getYear()) - 1900;
+
+    const std::chrono::time_point<std::chrono::system_clock> dateTimePoint =
+        std::chrono::system_clock::from_time_t(std::mktime(&dateTime));
+
+    // Difference
+
+    const auto nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(dateTimePoint - epochTimePoint);
+
+    Uint64 nanosecondCount = 0;
+    bool postEpoch = true;
+
+    if (nanoseconds.count() >= 0)
+    {
+        const Uint64 ns = nanoseconds.count();
+
+        nanosecondCount = ns + aDateTime.accessTime().getMillisecond() * 1000000 +
+                          aDateTime.accessTime().getMicrosecond() * 1000 + aDateTime.accessTime().getNanosecond();
+        postEpoch = true;
+    }
+    else
+    {
+        const Uint64 ns = std::abs(nanoseconds.count());
+
+        nanosecondCount = ns - aDateTime.accessTime().getMillisecond() * 1000000 -
+                          aDateTime.accessTime().getMicrosecond() * 1000 - aDateTime.accessTime().getNanosecond();
+        postEpoch = false;
+    }
 
     // Output
 
-    const Instant::Count count = {nanosecondCount, postEpoch};
+    const Instant::Count count = {nanosecondCount, postEpoch};  // [TBM] This cast in incorrect !!
 
     const Instant::Count count_TT = Instant::ConvertCountScale(count, aTimeScale, Scale::TT);
 

--- a/test/OpenSpaceToolkit/Physics/Coordinate/Position.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Coordinate/Position.test.cpp
@@ -211,7 +211,7 @@ TEST_F(OpenSpaceToolkit_Physics_Coordinate_Position, InFrame)
         const Position position_ITRF = position_GCRF.inFrame(Frame::ITRF(), Instant::J2000());
 
         EXPECT_TRUE(
-            position_ITRF.getCoordinates().isNear(Vector3d(254638.49423473, 7066495.80292154, 499796.263037414), 1e-3)
+            position_ITRF.getCoordinates().isNear(Vector3d(254638.493586864, 7066495.80294488, 499796.263037415), 1e-8)
         ) << position_ITRF;
         EXPECT_EQ(Position::Unit::Meter, position_ITRF.getUnit()) << position_ITRF;
         EXPECT_EQ(Frame::ITRF(), position_ITRF.accessFrame()) << position_ITRF;

--- a/test/OpenSpaceToolkit/Physics/Time/DateTime.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Time/DateTime.test.cpp
@@ -246,15 +246,6 @@ TEST(OpenSpaceToolkit_Physics_Time_DateTime, GetModifiedJulianDate)
     }
 
     {
-        // Sub-second resolution: the direct computation resolves ~0.6 us at current epochs
-        // (a JD - 2400000.5 detour would quantize to ~40 us)
-
-        EXPECT_EQ(59945.25, DateTime(2023, 1, 1, 6, 0, 0).getModifiedJulianDate());
-        EXPECT_NEAR(59945.0 + 1e-6 / 86400.0, DateTime(2023, 1, 1, 0, 0, 0, 0, 1, 0).getModifiedJulianDate(), 1e-12);
-        EXPECT_NEAR(59945.5 + 1.0 / 86400.0, DateTime(2023, 1, 1, 12, 0, 1).getModifiedJulianDate(), 1e-11);
-    }
-
-    {
         EXPECT_ANY_THROW(DateTime::Undefined().getModifiedJulianDate());
     }
 }

--- a/test/OpenSpaceToolkit/Physics/Time/Instant.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Time/Instant.test.cpp
@@ -1222,53 +1222,6 @@ TEST(OpenSpaceToolkit_Physics_Time_Instant, GetModifiedJulianDate)
     }
 }
 
-TEST(OpenSpaceToolkit_Physics_Time_Instant, GetModifiedJulianDate_ConsistencyWithDateTime)
-{
-    using ostk::physics::time::Duration;
-    using ostk::physics::time::Instant;
-    using ostk::physics::time::Scale;
-
-    // The arithmetic conversion must agree with the DateTime-based conversion to within
-    // the double resolution of a Julian date (the DateTime path quantizes at ~1e-9 day).
-
-    for (auto const& scale : scales)
-    {
-        for (int i = -200; i <= 200; i += 7)
-        {
-            const Instant instant = Instant::J2000() + Duration::Days(37.3 * i) + Duration::Nanoseconds(123456789);
-
-            EXPECT_NEAR(instant.getDateTime(scale).getModifiedJulianDate(), instant.getModifiedJulianDate(scale), 1e-8);
-            EXPECT_NEAR(instant.getDateTime(scale).getJulianDate(), instant.getJulianDate(scale), 1e-8);
-        }
-    }
-}
-
-TEST(OpenSpaceToolkit_Physics_Time_Instant, DateTime_RoundTrip)
-{
-    using ostk::physics::time::DateTime;
-    using ostk::physics::time::Instant;
-    using ostk::physics::time::Scale;
-
-    // Calendar round-trip at nanosecond resolution across the supported year range [1970, 2554]
-
-    for (auto const& scale : scales)
-    {
-        for (const auto& dateTime : {
-                 DateTime(1970, 1, 1, 0, 0, 0, 0, 0, 1),
-                 DateTime(1979, 3, 15, 3, 4, 5, 6, 7, 8),
-                 DateTime(1999, 12, 31, 23, 59, 59, 999, 999, 999),
-                 DateTime(2000, 1, 1, 12, 0, 0),
-                 DateTime(2000, 2, 29, 23, 59, 59, 1, 2, 3),
-                 DateTime(2023, 7, 1, 1, 2, 3, 4, 5, 6),
-                 DateTime(2100, 3, 1, 0, 0, 0, 500, 0, 0),
-                 DateTime(2554, 12, 31, 23, 59, 59, 999, 999, 999),
-             })
-        {
-            EXPECT_EQ(dateTime, Instant::DateTime(dateTime, scale).getDateTime(scale)) << dateTime.toString();
-        }
-    }
-}
-
 TEST(OpenSpaceToolkit_Physics_Time_Instant, GetLeapSecondCount)
 {
     using ostk::physics::time::DateTime;


### PR DESCRIPTION
https://github.com/open-space-collective/open-space-toolkit-physics/pull/378 has caused a regression in downstream ostk-astro: https://github.com/open-space-collective/open-space-toolkit-astrodynamics/actions/runs/30840395441/job/91943013904

The numerical difference in the position/velocity unit tests may be acceptable, but the BLS failures are not

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved date and time conversions between instants, calendar dates, Julian dates, and Modified Julian Dates.
  * Enhanced reliability when converting timestamps across time scales, including UTC and terrestrial time.
  * Improved precision of coordinate transformations involving Earth-fixed reference frames.

* **Tests**
  * Updated coordinate transformation validation to reflect more precise results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->