### PR TITLE
feat: add Earth atmospheric model constructor

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth.cpp
@@ -112,14 +112,53 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth(pybind11::mo
 
                 Args:
                     type (Earth.Type): Earth atmospheric model type.
-                    input_data_type (Earth.InputDataType): Earth atmospheric model input data type.
-                    f107_constant_value (Real): F10.7 constant value.
-                    f107_average_constant_value (Real): F10.7a constant value.
-                    kp_constant_value (Real): Kp constant value.
+                    input_data_type (Earth.InputDataType, optional): Earth atmospheric model input data type. Defaults to Earth.InputDataType.Undefined.
+                    f107_constant_value (Real, optional): F10.7 constant value. Defaults to 150.0.
+                    f107_average_constant_value (Real, optional): F10.7a constant value. Defaults to 150.0.
+                    kp_constant_value (Real, optional): Kp constant value. Defaults to 3.0.
+                    earth_frame (Frame, optional): Earth frame. Defaults to Frame.ITRF().
+                    earth_radius (Length, optional): Earth radius [m]. Defaults to the WGS84 equatorial radius.
+                    earth_flattening (Real, optional): Earth flattening. Defaults to the WGS84 flattening.
+                    sun_celestial (Celestial, optional): Sun celestial object. Defaults to None.
+
+                Returns:
+                    Earth: Earth atmospheric model.
+                )doc"
+            )
+
+            .def(
+                init<
+                    const Earth::Type&,
+                    const Shared<const Frame>&,
+                    const Earth::InputDataType&,
+                    const Real&,
+                    const Real&,
+                    const Real&,
+                    const Length&,
+                    const Real&,
+                    const Shared<Celestial>&>(),
+                arg("type"),
+                arg("earth_frame"),
+                arg("input_data_type") = Earth::InputDataType::CSSISpaceWeatherFile,
+                arg("f107_constant_value") = Earth::defaultF107ConstantValue,
+                arg("f107_average_constant_value") = Earth::defaultF107AConstantValue,
+                arg("kp_constant_value") = Earth::defaultKpConstantValue,
+                arg_v("earth_radius", EarthGravityModel::WGS84.equatorialRadius_, "WGS84.equatorialRadius_"),
+                arg_v("earth_flattening", EarthGravityModel::WGS84.flattening_, "WGS84.flattening_"),
+                arg("sun_celestial") = nullptr,
+                R"doc(
+                    Constructor, with the Earth frame as second argument.
+
+                Args:
+                    type (Earth.Type): Earth atmospheric model type.
                     earth_frame (Frame): Earth frame.
-                    earth_radius (Length): Earth radius [m].
-                    earth_flattening (Real): Earth flattening.
-                    sun_celestial (Celestial): Sun celestial object.
+                    input_data_type (Earth.InputDataType, optional): Earth atmospheric model input data type. Defaults to Earth.InputDataType.CSSISpaceWeatherFile.
+                    f107_constant_value (Real, optional): F10.7 constant value. Defaults to 150.0.
+                    f107_average_constant_value (Real, optional): F10.7a constant value. Defaults to 150.0.
+                    kp_constant_value (Real, optional): Kp constant value. Defaults to 3.0.
+                    earth_radius (Length, optional): Earth radius [m]. Defaults to the WGS84 equatorial radius.
+                    earth_flattening (Real, optional): Earth flattening. Defaults to the WGS84 flattening.
+                    sun_celestial (Celestial, optional): Sun celestial object. Defaults to None.
 
                 Returns:
                     Earth: Earth atmospheric model.

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth/NRLMSISE00.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth/NRLMSISE00.cpp
@@ -70,14 +70,14 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth_NRLMSISE00(p
                 Constructor.
 
                 Args:
-                    input_data_type (NRLMSISE00.InputDataType): Input data source type.
-                    f107_constant_value (float): F10.7 constant value.
-                    f107_average_constant_value (float): F10.7a constant value.
-                    kp_constant_value (float): Kp constant value.
-                    earth_frame (Frame): Earth frame.
-                    earth_radius (Length): Earth radius [m].
-                    earth_flattening (float): Earth flattening.
-                    sun_celestial (Celestial): Sun celestial object. Defaults to None.
+                    input_data_type (NRLMSISE00.InputDataType, optional): Input data source type. Defaults to NRLMSISE00.InputDataType.CSSISpaceWeatherFile.
+                    f107_constant_value (float, optional): F10.7 constant value. Defaults to 150.0.
+                    f107_average_constant_value (float, optional): F10.7a constant value. Defaults to 150.0.
+                    kp_constant_value (float, optional): Kp constant value. Defaults to 3.0.
+                    earth_frame (Frame, optional): Earth frame. Defaults to Frame.ITRF().
+                    earth_radius (Length, optional): Earth radius [m]. Defaults to the WGS84 equatorial radius.
+                    earth_flattening (float, optional): Earth flattening. Defaults to the WGS84 flattening.
+                    sun_celestial (Celestial, optional): Sun celestial object. Defaults to None.
             )doc"
         )
 

--- a/bindings/python/test/environment/atmospheric/test_earth.py
+++ b/bindings/python/test/environment/atmospheric/test_earth.py
@@ -113,6 +113,59 @@ class TestEarth:
 
         assert isinstance(earth_atmospheric_model, EarthAtmosphericModel)
 
+    def test_constructor_success_with_earth_frame(self):
+        earth_atmospheric_model = EarthAtmosphericModel(
+            EarthAtmosphericModel.Type.Exponential,
+            Frame.ITRF(),
+        )
+
+        assert isinstance(earth_atmospheric_model, EarthAtmosphericModel)
+
+    def test_constructor_success_with_earth_frame_and_params(self):
+        earth_atmospheric_model = EarthAtmosphericModel(
+            EarthAtmosphericModel.Type.NRLMSISE00,
+            Frame.TEME(),
+            input_data_type=EarthAtmosphericModel.InputDataType.ConstantFluxAndGeoMag,
+            f107_constant_value=160.0,
+            f107_average_constant_value=160.0,
+            kp_constant_value=4.0,
+            earth_radius=EarthGravitationalModel.WGS84.equatorial_radius,
+            earth_flattening=EarthGravitationalModel.WGS84.flattening,
+            sun_celestial=Sun.default(),
+        )
+
+        assert isinstance(earth_atmospheric_model, EarthAtmosphericModel)
+        assert earth_atmospheric_model.is_defined()
+        assert earth_atmospheric_model.get_type() == EarthAtmosphericModel.Type.NRLMSISE00
+        assert (
+            earth_atmospheric_model.get_input_data_type()
+            == EarthAtmosphericModel.InputDataType.ConstantFluxAndGeoMag
+        )
+
+    def test_constructor_success_with_earth_frame_get_density_at(
+        self,
+        manager_with_cssi_space_weather: Manager,
+    ):
+        earth_atmospheric_model = EarthAtmosphericModel(
+            EarthAtmosphericModel.Type.NRLMSISE00,
+            Frame.ITRF(),
+        )
+
+        density = earth_atmospheric_model.get_density_at(
+            position=Position.meters(
+                coordinates=LLA(
+                    Angle.degrees(30.0), Angle.degrees(40.0), Length.kilometers(500.0)
+                ).to_cartesian(
+                    ellipsoid_equatorial_radius=EarthGravitationalModel.EGM2008.equatorial_radius,
+                    ellipsoid_flattening=EarthGravitationalModel.EGM2008.flattening,
+                ),
+                frame=Frame.ITRF(),
+            ),
+            instant=Instant.date_time(DateTime.parse("2021-01-01 00:00:00"), Scale.UTC),
+        )
+
+        assert density is not None
+
     def test_get_type_success(
         self, earth_atmospheric_model_exponential: EarthAtmosphericModel
     ):

--- a/include/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.hpp
@@ -65,14 +65,14 @@ class Earth : public Model
     /// @endcode
     ///
     /// @param [in] aType An atmospheric model type
-    /// @param [in] anInputDataType An input data source type
-    /// @param [in] aF107ConstantValue A constant value for F10.7 input parameter
-    /// @param [in] aF107AConstantValue A constant value for F10.7a input parameter
-    /// @param [in] aKpConstantValue A constant value for Kp input parameter
-    /// @param [in] anEarthFrameSPtr A shared pointer to the Earth frame
-    /// @param [in] anEarthRadius An Earth radius
-    /// @param [in] anEarthFlattening An Earth flattening
-    /// @param [in] aSunCelestialSPtr A shared pointer to the Sun celestial body
+    /// @param [in] anInputDataType An input data source type. Defaults to CSSISpaceWeatherFile
+    /// @param [in] aF107ConstantValue A constant value for F10.7 input parameter. Defaults to 150.0
+    /// @param [in] aF107AConstantValue A constant value for F10.7a input parameter. Defaults to 150.0
+    /// @param [in] aKpConstantValue A constant value for Kp input parameter. Defaults to 3.0
+    /// @param [in] anEarthFrameSPtr A shared pointer to the Earth frame. Defaults to Frame::ITRF()
+    /// @param [in] anEarthRadius An Earth radius. Defaults to WGS84 radius
+    /// @param [in] anEarthFlattening An Earth flattening. Defaults to WGS84 flattening
+    /// @param [in] aSunCelestialSPtr A shared pointer to the Sun celestial body. Defaults to nullptr
     Earth(
         const Earth::Type& aType,
         const Earth::InputDataType& anInputDataType = Earth::InputDataType::CSSISpaceWeatherFile,
@@ -80,6 +80,36 @@ class Earth : public Model
         const Real& aF107AConstantValue = defaultF107AConstantValue,
         const Real& aKpConstantValue = defaultKpConstantValue,
         const Shared<const Frame>& anEarthFrameSPtr = Frame::ITRF(),
+        const Length& anEarthRadius = EarthGravitationalModel::WGS84.equatorialRadius_,
+        const Real& anEarthFlattening = EarthGravitationalModel::WGS84.flattening_,
+        const Shared<Celestial>& aSunCelestialSPtr = nullptr
+    );
+
+    /// @brief Constructor, with the Earth frame as second argument
+    ///
+    /// This overload allows specifying the Earth frame without having to spell out the
+    /// input data type and the constant flux and geomagnetic index values.
+    ///
+    /// @code
+    ///     Earth earthAtmo(Earth::Type::Exponential, Frame::ITRF());
+    /// @endcode
+    ///
+    /// @param [in] aType An atmospheric model type
+    /// @param [in] anEarthFrameSPtr A shared pointer to the Earth frame
+    /// @param [in] anInputDataType An input data source type. Defaults to CSSISpaceWeatherFile
+    /// @param [in] aF107ConstantValue A constant value for F10.7 input parameter. Defaults to 150.0
+    /// @param [in] aF107AConstantValue A constant value for F10.7a input parameter. Defaults to 150.0
+    /// @param [in] aKpConstantValue A constant value for Kp input parameter. Defaults to 3.0
+    /// @param [in] anEarthRadius An Earth radius. Defaults to WGS84 radius
+    /// @param [in] anEarthFlattening An Earth flattening. Defaults to WGS84 flattening
+    /// @param [in] aSunCelestialSPtr A shared pointer to the Sun celestial body. Defaults to nullptr
+    Earth(
+        const Earth::Type& aType,
+        const Shared<const Frame>& anEarthFrameSPtr,
+        const Earth::InputDataType& anInputDataType = Earth::InputDataType::CSSISpaceWeatherFile,
+        const Real& aF107ConstantValue = defaultF107ConstantValue,
+        const Real& aF107AConstantValue = defaultF107AConstantValue,
+        const Real& aKpConstantValue = defaultKpConstantValue,
         const Length& anEarthRadius = EarthGravitationalModel::WGS84.equatorialRadius_,
         const Real& anEarthFlattening = EarthGravitationalModel::WGS84.flattening_,
         const Shared<Celestial>& aSunCelestialSPtr = nullptr

--- a/src/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.cpp
@@ -238,6 +238,32 @@ Earth::Earth(
 {
 }
 
+Earth::Earth(
+    const Earth::Type& aType,
+    const Shared<const Frame>& anEarthFrameSPtr,
+    const Earth::InputDataType& anInputDataType,
+    const Real& aF107ConstantValue,
+    const Real& aF107AConstantValue,
+    const Real& aKpConstantValue,
+    const Length& anEarthRadius,
+    const Real& anEarthFlattening,
+    const Shared<Celestial>& aSunCelestialSPtr
+)
+    : Model(),
+      implUPtr_(Earth::ImplFromType(
+          aType,
+          anInputDataType,
+          aF107ConstantValue,
+          aF107AConstantValue,
+          aKpConstantValue,
+          anEarthFrameSPtr,
+          anEarthRadius,
+          anEarthFlattening,
+          aSunCelestialSPtr
+      ))
+{
+}
+
 Earth::Earth(const Earth& anEarthAtmosphericModel)
     : Model(anEarthAtmosphericModel),
       implUPtr_((anEarthAtmosphericModel.implUPtr_ != nullptr) ? anEarthAtmosphericModel.implUPtr_->clone() : nullptr)

--- a/test/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth.test.cpp
@@ -116,6 +116,184 @@ TEST_F(OpenSpaceToolkit_Physics_Environment_Atmospheric_Earth, Constructor)
     }
 }
 
+TEST_F(OpenSpaceToolkit_Physics_Environment_Atmospheric_Earth, Constructor_EarthFrame)
+{
+    {
+        EXPECT_NO_THROW(
+            EarthAtmosphericModel earthAtmosphericModel(EarthAtmosphericModel::Type::Exponential, Frame::ITRF())
+        );
+    }
+
+    {
+        EXPECT_NO_THROW(
+            EarthAtmosphericModel earthAtmosphericModel(EarthAtmosphericModel::Type::NRLMSISE00, Frame::TEME())
+        );
+    }
+
+    {
+        EXPECT_NO_THROW(EarthAtmosphericModel earthAtmosphericModel(
+            EarthAtmosphericModel::Type::NRLMSISE00,
+            Frame::ITRF(),
+            EarthAtmosphericModel::InputDataType::CSSISpaceWeatherFile
+        ));
+    }
+
+    {
+        EXPECT_NO_THROW(EarthAtmosphericModel earthAtmosphericModel(
+            EarthAtmosphericModel::Type::NRLMSISE00,
+            Frame::ITRF(),
+            EarthAtmosphericModel::InputDataType::ConstantFluxAndGeoMag,
+            150.0,
+            150.0,
+            3.0,
+            EarthGravitationalModel::EGM2008.equatorialRadius_,
+            EarthGravitationalModel::EGM2008.flattening_,
+            std::make_shared<Sun>(Sun::Default())
+        ));
+    }
+
+    {
+        EXPECT_THROW(
+            EarthAtmosphericModel earthAtmosphericModel(
+                EarthAtmosphericModel::Type::NRLMSISE00,
+                Frame::ITRF(),
+                EarthAtmosphericModel::InputDataType::ConstantFluxAndGeoMag,
+                Real::Undefined(),
+                150.0,
+                3.0
+            ),
+            ostk::core::error::runtime::Undefined
+        );
+    }
+
+    {
+        const EarthAtmosphericModel earthAtmosphericModel = {EarthAtmosphericModel::Type::Undefined, Frame::ITRF()};
+
+        EXPECT_FALSE(earthAtmosphericModel.isDefined());
+    }
+
+    {
+        const EarthAtmosphericModel earthAtmosphericModel = {
+            EarthAtmosphericModel::Type::NRLMSISE00, Frame::ITRF(), EarthAtmosphericModel::InputDataType::Undefined
+        };
+
+        EXPECT_TRUE(earthAtmosphericModel.isDefined());
+        EXPECT_EQ(EarthAtmosphericModel::Type::NRLMSISE00, earthAtmosphericModel.getType());
+        EXPECT_EQ(EarthAtmosphericModel::InputDataType::Undefined, earthAtmosphericModel.getInputDataType());
+    }
+
+    // The Earth frame defaults to CSSISpaceWeatherFile as input data type
+    {
+        const EarthAtmosphericModel earthAtmosphericModel = {EarthAtmosphericModel::Type::NRLMSISE00, Frame::ITRF()};
+
+        EXPECT_EQ(EarthAtmosphericModel::InputDataType::CSSISpaceWeatherFile, earthAtmosphericModel.getInputDataType());
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Physics_Environment_Atmospheric_Earth, Constructor_EarthFrame_Consistency)
+{
+    // The frame-first constructor must be equivalent to the fully-specified constructor
+    {
+        static const Array<Tuple<EarthAtmosphericModel::Type, EarthAtmosphericModel::InputDataType, LLA, Instant>>
+            testCases = {
+                {EarthAtmosphericModel::Type::Exponential,
+                 EarthAtmosphericModel::InputDataType::Undefined,
+                 LLA(Angle::Degrees(35.076832), Angle::Degrees(-92.546296), Length::Kilometers(500.0)),
+                 Instant::J2000()},
+                {EarthAtmosphericModel::Type::NRLMSISE00,
+                 EarthAtmosphericModel::InputDataType::CSSISpaceWeatherFile,
+                 LLA(Angle::Degrees(0.0), Angle::Degrees(0.0), Length::Kilometers(500.0)),
+                 Instant::DateTime(DateTime::Parse("2021-01-01 00:00:00"), Scale::UTC)}
+            };
+
+        for (const auto& testCase : testCases)
+        {
+            const EarthAtmosphericModel::Type type = std::get<0>(testCase);
+            const EarthAtmosphericModel::InputDataType inputDataType = std::get<1>(testCase);
+            const LLA lla = std::get<2>(testCase);
+            const Instant instant = std::get<3>(testCase);
+
+            const Position position = {
+                lla.toCartesian(
+                    EarthGravitationalModel::EGM2008.equatorialRadius_, EarthGravitationalModel::EGM2008.flattening_
+                ),
+                Position::Unit::Meter,
+                Frame::ITRF()
+            };
+
+            const EarthAtmosphericModel referenceModel = {
+                type,
+                inputDataType,
+                150.0,
+                150.0,
+                3.0,
+                Frame::TEME(),
+                EarthGravitationalModel::EGM2008.equatorialRadius_,
+                EarthGravitationalModel::EGM2008.flattening_
+            };
+
+            const EarthAtmosphericModel frameFirstModel = {
+                type,
+                Frame::TEME(),
+                inputDataType,
+                150.0,
+                150.0,
+                3.0,
+                EarthGravitationalModel::EGM2008.equatorialRadius_,
+                EarthGravitationalModel::EGM2008.flattening_
+            };
+
+            EXPECT_EQ(referenceModel.getType(), frameFirstModel.getType());
+            EXPECT_EQ(referenceModel.getInputDataType(), frameFirstModel.getInputDataType());
+            EXPECT_EQ(referenceModel.getDensityAt(position, instant), frameFirstModel.getDensityAt(position, instant));
+        }
+    }
+
+    // The Sun celestial body is forwarded by the frame-first constructor
+    {
+        const LLA lla = LLA(Angle::Degrees(35.076832), Angle::Degrees(-92.546296), Length::Kilometers(350.0));
+        const Instant instant = Instant::DateTime(DateTime::Parse("2021-01-01 00:00:00"), Scale::UTC);
+
+        const Position position = {
+            lla.toCartesian(
+                EarthGravitationalModel::EGM2008.equatorialRadius_, EarthGravitationalModel::EGM2008.flattening_
+            ),
+            Position::Unit::Meter,
+            Frame::ITRF()
+        };
+
+        const EarthAtmosphericModel earthAtmosphericModelSun = {
+            EarthAtmosphericModel::Type::NRLMSISE00,
+            Frame::ITRF(),
+            EarthAtmosphericModel::InputDataType::CSSISpaceWeatherFile,
+            Real::Undefined(),
+            Real::Undefined(),
+            Real::Undefined(),
+            EarthGravitationalModel::EGM2008.equatorialRadius_,
+            EarthGravitationalModel::EGM2008.flattening_,
+            std::make_shared<Sun>(Sun::Default())
+        };
+
+        const EarthAtmosphericModel earthAtmosphericModelNoSun = {
+            EarthAtmosphericModel::Type::NRLMSISE00,
+            Frame::ITRF(),
+            EarthAtmosphericModel::InputDataType::CSSISpaceWeatherFile,
+            Real::Undefined(),
+            Real::Undefined(),
+            Real::Undefined(),
+            EarthGravitationalModel::EGM2008.equatorialRadius_,
+            EarthGravitationalModel::EGM2008.flattening_
+        };
+
+        const Real densitySun = earthAtmosphericModelSun.getDensityAt(position, instant);
+        const Real densityNoSun = earthAtmosphericModelNoSun.getDensityAt(position, instant);
+
+        EXPECT_FALSE(densitySun.isNear(densityNoSun, 1e-15)) << String::Format(
+            "{} ≈ {} Δ {} [T]", densitySun.toString(), densityNoSun.toString(), (densitySun - densityNoSun)
+        );
+    }
+}
+
 TEST_F(OpenSpaceToolkit_Physics_Environment_Atmospheric_Earth, Clone)
 {
     {


### PR DESCRIPTION
Constructing an Earth atmospheric model with a non-default Earth frame previously required spelling out the input data type and the three constant flux/geomagnetic index values first, since the frame sits in the sixth position. Add an overload taking the frame as the second argument so the remaining parameters can keep their defaults.


This makes it easy to create an earth atmospheric model that uses a Spice based frame (with the other sensible defaults):
```
EarthAtmosphericModel(
    type=EarthAtmosphericModel.Type.NRLMSISE00,
    earth_frame=ephemeris.access_frame(),
)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Earth atmospheric model constructor that accepts an Earth reference frame.
  * Optional atmospheric model parameters now include documented default values.
  * CSSI space-weather data is used by default when no input type is specified.

* **Bug Fixes**
  * Improved support for configuring atmospheric models with Earth-frame data.

* **Tests**
  * Added coverage for new constructor options, default settings, invalid inputs, and density calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->