### PR TITLE
fix: only use instant's date in space weather lookup

### DIFF
--- a/src/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/CSSISpaceWeather.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/CSSISpaceWeather.cpp
@@ -251,9 +251,13 @@ const CSSISpaceWeather::Reading& CSSISpaceWeather::accessObservationAt(const Ins
         );
     }
 
-    const Real instantMjd = anInstant.getModifiedJulianDate(Scale::UTC);
+    // Construct the MJD by only using the date component of the Instant, because an Instant just before
+    // the end of the observationInterval (within some nanoseconds) can have an MJD in the next day
+    // due to floating-point rounding error.
+    const Date date = anInstant.getDateTime(Scale::UTC).getDate();
+    const Integer mjd = DateTime(date, Time::Midnight()).getModifiedJulianDate().floor();
 
-    const auto observationIt = observations_.find(instantMjd.floor());
+    const auto observationIt = observations_.find(mjd);
 
     if (observationIt != observations_.end())
     {
@@ -295,9 +299,13 @@ const CSSISpaceWeather::Reading& CSSISpaceWeather::accessDailyPredictionAt(const
         );
     }
 
-    const Real instantMjd = anInstant.getModifiedJulianDate(Scale::UTC);
+    // Construct the MJD by only using the date component of the Instant, because an Instant just before
+    // the end of the dailyPredictionInterval (within some nanoseconds) can have an MJD in the next day
+    // due to floating-point rounding error.
+    const Date date = anInstant.getDateTime(Scale::UTC).getDate();
+    const Integer mjd = DateTime(date, Time::Midnight()).getModifiedJulianDate().floor();
 
-    const auto predictionIt = dailyPredictions_.find(instantMjd.floor());
+    const auto predictionIt = dailyPredictions_.find(mjd);
 
     if (predictionIt != dailyPredictions_.end())
     {

--- a/test/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/CSSISpaceWeather.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/CSSISpaceWeather.test.cpp
@@ -99,6 +99,17 @@ TEST_F(OpenSpaceToolkit_Physics_Environment_Atmospheric_Earth_CSSISpaceWeather, 
     }
 
     {
+        // access observation 1 nanosecond before end of interval
+        // Regression test for #393
+        const Instant instantNearEnd =
+            CSSISpaceWeather_.accessObservationInterval().accessEnd() - Duration::Nanoseconds(1.0);
+
+        const CSSISpaceWeather::Reading& observation = CSSISpaceWeather_.accessObservationAt(instantNearEnd);
+
+        EXPECT_EQ(CSSISpaceWeather_.accessLastObservationDate(), observation.date);
+    }
+
+    {
         // calling Undefined Space Weather
         EXPECT_THROW(
             CSSISpaceWeather::Undefined().accessObservationAt(
@@ -169,6 +180,17 @@ TEST_F(OpenSpaceToolkit_Physics_Environment_Atmospheric_Earth_CSSISpaceWeather, 
 
         EXPECT_NEAR(164.6, firstDailyPrediction.F107Obs, 1e-15);
         EXPECT_NEAR(160.2, firstDailyPrediction.F107ObsCenter81, 1e-15);
+    }
+
+    {
+        // access daily prediction 1 nanosecond before end of interval
+        // Regression test for #393
+        const Instant instantNearEnd =
+            CSSISpaceWeather_.accessDailyPredictionInterval().accessEnd() - Duration::Nanoseconds(1.0);
+
+        const CSSISpaceWeather::Reading& prediction = CSSISpaceWeather_.accessDailyPredictionAt(instantNearEnd);
+
+        EXPECT_EQ(Date::Parse("2023-08-03", Date::Format::Standard), prediction.date);
     }
 
     {


### PR DESCRIPTION
Fixes https://github.com/open-space-collective/open-space-toolkit-physics/issues/393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved atmospheric space-weather data lookups near date boundaries.
  * Lookups now return the correct final reading when requested immediately before an interval ends.

* **Tests**
  * Added regression coverage for observation and daily-prediction data accessed at interval endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->