### PR TITLE
fix: spice test isolation

### DIFF
--- a/test/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE.test.cpp
@@ -300,10 +300,6 @@ TEST_F(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE, ManualMode)
 TEST_F(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE, AutomaticMode)
 {
     {
-        // Automatic mode fetches missing kernels into the local repository, so it must run against
-        // the default repository rather than the committed test kernels: pointing it at the latter
-        // makes the run overwrite files tracked in git.
-
         manager_.setMode(Manager::Mode::Automatic);
 
         engine_.reset();

--- a/test/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE.test.cpp
@@ -59,11 +59,30 @@ class OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE : public ::testing::T
     {
     }
 
+    void SetUp() override
+    {
+        // The Manager is a process-wide singleton, so whatever this suite leaves configured is
+        // inherited by every suite that runs after it. Remember the incoming configuration here
+        // and put it back in TearDown, so nothing leaks out of this suite.
+
+        localRepository_ = manager_.getLocalRepository();
+        mode_ = manager_.getMode();
+    }
+
     void TearDown() override
     {
+        // Restore the repository before resetting the Engine: reset() reloads the default kernels
+        // against whatever repository is configured at that moment, and in Automatic mode a
+        // missing kernel is fetched into it.
+
+        manager_.setLocalRepository(localRepository_);
+        manager_.setMode(mode_);
+
         engine_.reset();
-        manager_.setMode(Manager::Mode::Automatic);
     }
+
+    Directory localRepository_ = Directory::Undefined();
+    Manager::Mode mode_ = Manager::Mode::Automatic;
 };
 
 TEST_F(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE, Constructor)
@@ -281,9 +300,11 @@ TEST_F(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE, ManualMode)
 TEST_F(OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE, AutomaticMode)
 {
     {
-        Manager::Get().setLocalRepository(
-            Directory::Path(Path::Parse("/app/test/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE"))
-        );
+        // Automatic mode fetches missing kernels into the local repository, so it must run against
+        // the default repository rather than the committed test kernels: pointing it at the latter
+        // makes the run overwrite files tracked in git.
+
+        manager_.setMode(Manager::Mode::Automatic);
 
         engine_.reset();
 

--- a/test/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Manager.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Manager.test.cpp
@@ -37,8 +37,12 @@ class OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Manager : public ::te
    protected:
     void SetUp() override
     {
+        // Never point the Manager at the committed test kernels: it is the directory kernels are
+        // fetched into, so any test that fetches would overwrite files tracked in git. Each test
+        // below narrows this to its own subdirectory.
+
         manager_.setLocalRepository(
-            Directory::Path(Path::Parse("test/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/"))
+            Directory::Path(Path::Parse("/app/.open-space-toolkit/physics/environment/ephemeris/spice/"))
         );
 
         // cache current directory environment variables

--- a/test/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Manager.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Manager.test.cpp
@@ -37,10 +37,6 @@ class OpenSpaceToolkit_Physics_Environment_Ephemeris_SPICE_Manager : public ::te
    protected:
     void SetUp() override
     {
-        // Never point the Manager at the committed test kernels: it is the directory kernels are
-        // fetched into, so any test that fetches would overwrite files tracked in git. Each test
-        // below narrows this to its own subdirectory.
-
         manager_.setLocalRepository(
             Directory::Path(Path::Parse("/app/.open-space-toolkit/physics/environment/ephemeris/spice/"))
         );


### PR DESCRIPTION
There were unit tests that were overwriting committed files as they weren't pointing at the correct directories or properly using the setup/teardown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by restoring SPICE manager settings after each test.
  * Updated automatic-mode coverage to avoid unnecessary repository changes.
  * Standardized the test repository location for SPICE manager tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->