### PR TITLE
feat: add isPointMass to gravitational models

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Earth.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Earth.cpp
@@ -100,6 +100,17 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Earth(pybind11::
             )
 
             .def(
+                "is_point_mass",
+                &Earth::isPointMass,
+                R"doc(
+                    Check if the gravitational model is a point mass model.
+
+                    Returns:
+                        bool: True if the gravitational model is a point mass model.
+                )doc"
+            )
+
+            .def(
                 "get_type",
                 &Earth::getType,
                 R"doc(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Model.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Model.cpp
@@ -24,6 +24,17 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Model(pybind11::
 
             .def("get_parameters", &Model::getParameters)
 
+            .def(
+                "is_point_mass",
+                &Model::isPointMass,
+                R"doc(
+                    Check if the gravitational model is a point mass model.
+
+                    Returns:
+                        bool: True if the gravitational model is a point mass model.
+                )doc"
+            )
+
             ;
     }
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Moon.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Moon.cpp
@@ -61,6 +61,17 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Moon(pybind11::m
             )
 
             .def(
+                "is_point_mass",
+                &Moon::isPointMass,
+                R"doc(
+                    Check if the gravitational model is a point mass model.
+
+                    Returns:
+                        bool: True if the gravitational model is a point mass model.
+                )doc"
+            )
+
+            .def(
                 "get_type",
                 &Moon::getType,
                 R"doc(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Spherical.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Spherical.cpp
@@ -57,6 +57,17 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Spherical(pybind
                 Returns:
                     bool: True if the Spherical gravitational model is defined.
             )doc"
+        )
+
+        .def(
+            "is_point_mass",
+            &Spherical::isPointMass,
+            R"doc(
+                Check if the gravitational model is a point mass model.
+
+                Returns:
+                    bool: True if the gravitational model is a point mass model.
+            )doc"
         );
 
     ;

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Sun.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Sun.cpp
@@ -61,6 +61,17 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Sun(pybind11::mo
             )
 
             .def(
+                "is_point_mass",
+                &Sun::isPointMass,
+                R"doc(
+                    Check if the gravitational model is a point mass model.
+
+                    Returns:
+                        bool: True if the gravitational model is a point mass model.
+                )doc"
+            )
+
+            .def(
                 "get_type",
                 &Sun::getType,
                 R"doc(

--- a/bindings/python/test/environment/gravitational/test_earth.py
+++ b/bindings/python/test/environment/gravitational/test_earth.py
@@ -63,6 +63,25 @@ class TestEarth:
         assert isinstance(earth_gravitational_model, EarthGravitationalModel)
         assert isinstance(earth_gravitational_model, GravitationalModel)
 
+    def test_is_point_mass_success(
+        self, earth_gravitational_model: EarthGravitationalModel
+    ):
+        assert earth_gravitational_model.is_point_mass() is False
+
+        assert (
+            EarthGravitationalModel(
+                EarthGravitationalModel.Type.Spherical
+            ).is_point_mass()
+            is True
+        )
+
+        assert (
+            EarthGravitationalModel(
+                EarthGravitationalModel.Type.Undefined
+            ).is_point_mass()
+            is False
+        )
+
     def test_get_type_success(self, earth_gravitational_model: EarthGravitationalModel):
         assert (
             earth_gravitational_model.get_type() == EarthGravitationalModel.Type.EGM2008

--- a/bindings/python/test/environment/gravitational/test_moon.py
+++ b/bindings/python/test/environment/gravitational/test_moon.py
@@ -35,6 +35,16 @@ class TestMoon:
         assert isinstance(moon_gravitational_model, MoonGravitationalModel)
         assert isinstance(moon_gravitational_model, GravitationalModel)
 
+    def test_is_point_mass_success(
+        self, moon_gravitational_model: MoonGravitationalModel
+    ):
+        assert moon_gravitational_model.is_point_mass() is True
+
+        assert (
+            MoonGravitationalModel(MoonGravitationalModel.Type.Undefined).is_point_mass()
+            is False
+        )
+
     def test_get_type_success(self, moon_gravitational_model: MoonGravitationalModel):
         assert (
             moon_gravitational_model.get_type() == MoonGravitationalModel.Type.Spherical

--- a/bindings/python/test/environment/gravitational/test_spherical.py
+++ b/bindings/python/test/environment/gravitational/test_spherical.py
@@ -19,6 +19,13 @@ class TestSpherical:
         assert isinstance(spherical_gravitational_model, SphericalGravitationalModel)
         assert isinstance(spherical_gravitational_model, GravitationalModel)
 
+    def test_is_point_mass_success(self):
+        spherical_gravitational_model = SphericalGravitationalModel(
+            EarthGravitationalModel.spherical
+        )
+
+        assert spherical_gravitational_model.is_point_mass() is True
+
     def test_get_field_value_at_success(self):
         spherical_gravitational_model = SphericalGravitationalModel(
             EarthGravitationalModel.spherical

--- a/bindings/python/test/environment/gravitational/test_sun.py
+++ b/bindings/python/test/environment/gravitational/test_sun.py
@@ -35,6 +35,14 @@ class TestSun:
         assert isinstance(sun_gravitational_model, SunGravitationalModel)
         assert isinstance(sun_gravitational_model, GravitationalModel)
 
+    def test_is_point_mass_success(self, sun_gravitational_model: SunGravitationalModel):
+        assert sun_gravitational_model.is_point_mass() is True
+
+        assert (
+            SunGravitationalModel(SunGravitationalModel.Type.Undefined).is_point_mass()
+            is False
+        )
+
     def test_get_type_success(self, sun_gravitational_model: SunGravitationalModel):
         assert sun_gravitational_model.get_type() == SunGravitationalModel.Type.Spherical
 

--- a/include/OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.hpp
@@ -129,6 +129,15 @@ class Earth : public Model
     /// @return True if the Earth gravitational model is defined
     virtual bool isDefined() const override;
 
+    /// @brief Returns true if the gravitational model is a point mass model
+    ///
+    /// @code
+    ///     bool isPointMass = earthGrav.isPointMass();
+    /// @endcode
+    ///
+    /// @return true if the gravitational model is a point mass
+    virtual bool isPointMass() const override;
+
     /// @brief Get gravitational model type
     ///
     /// @code

--- a/include/OpenSpaceToolkit/Physics/Environment/Gravitational/Model.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Gravitational/Model.hpp
@@ -172,6 +172,15 @@ class Model
     /// @return True if the gravitational model is defined
     virtual bool isDefined() const = 0;
 
+    /// @brief Returns true if the gravitational model is a point mass model
+    ///
+    /// @code
+    ///     bool isPointMass = model.isPointMass();
+    /// @endcode
+    ///
+    /// @return true if the gravitational model is a point mass
+    virtual bool isPointMass() const;
+
     /// @brief Get the gravitational field value at a given position and instant (pure virtual)
     ///
     /// @param [in] aPosition A position, expressed in the gravitational object frame [m]

--- a/include/OpenSpaceToolkit/Physics/Environment/Gravitational/Moon.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Gravitational/Moon.hpp
@@ -98,6 +98,15 @@ class Moon : public Model
     /// @return True if the Moon gravitational model is defined
     virtual bool isDefined() const override;
 
+    /// @brief Returns true if the gravitational model is a point mass model
+    ///
+    /// @code
+    ///     bool isPointMass = moonGrav.isPointMass();
+    /// @endcode
+    ///
+    /// @return true if the gravitational model is a point mass
+    virtual bool isPointMass() const override;
+
     /// @brief Get gravitational model type
     ///
     /// @code

--- a/include/OpenSpaceToolkit/Physics/Environment/Gravitational/Spherical.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Gravitational/Spherical.hpp
@@ -55,6 +55,15 @@ class Spherical : public Model
     /// @return True if the spherical gravitational model is defined
     virtual bool isDefined() const override;
 
+    /// @brief Returns true if the gravitational model is a point mass model
+    ///
+    /// @code
+    ///     bool isPointMass = model.isPointMass();
+    /// @endcode
+    ///
+    /// @return true if the gravitational model is a point mass
+    virtual bool isPointMass() const override;
+
     /// @brief Get the gravitational field value at a given position and instant
     ///
     /// @code

--- a/include/OpenSpaceToolkit/Physics/Environment/Gravitational/Sun.hpp
+++ b/include/OpenSpaceToolkit/Physics/Environment/Gravitational/Sun.hpp
@@ -97,6 +97,15 @@ class Sun : public Model
     /// @return True if the Sun gravitational model is defined
     virtual bool isDefined() const override;
 
+    /// @brief Returns true if the gravitational model is a point mass model
+    ///
+    /// @code
+    ///     bool isPointMass = sunGrav.isPointMass();
+    /// @endcode
+    ///
+    /// @return true if the gravitational model is a point mass
+    virtual bool isPointMass() const override;
+
     /// @brief Get gravitational model type
     ///
     /// @code

--- a/src/OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.cpp
@@ -471,6 +471,11 @@ bool Earth::isDefined() const
     return implUPtr_ != nullptr;
 }
 
+bool Earth::isPointMass() const
+{
+    return this->isDefined() && (this->getType() == Earth::Type::Spherical);
+}
+
 Earth::Type Earth::getType() const
 {
     return implUPtr_->getType();

--- a/src/OpenSpaceToolkit/Physics/Environment/Gravitational/Model.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Gravitational/Model.cpp
@@ -157,12 +157,17 @@ Model::Model(const Parameters& aSetOfParameters)
 {
 }
 
+Model::~Model() {}
+
+bool Model::isPointMass() const
+{
+    return false;
+}
+
 Model::Parameters Model::getParameters() const
 {
     return parameters_;
 }
-
-Model::~Model() {}
 
 }  // namespace gravitational
 }  // namespace environment

--- a/src/OpenSpaceToolkit/Physics/Environment/Gravitational/Moon.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Gravitational/Moon.cpp
@@ -124,6 +124,11 @@ bool Moon::isDefined() const
     return implUPtr_ != nullptr;
 }
 
+bool Moon::isPointMass() const
+{
+    return this->isDefined() && (this->getType() == Moon::Type::Spherical);
+}
+
 Moon::Type Moon::getType() const
 {
     return implUPtr_->getType();

--- a/src/OpenSpaceToolkit/Physics/Environment/Gravitational/Spherical.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Gravitational/Spherical.cpp
@@ -39,6 +39,11 @@ bool Spherical::isDefined() const
     return gravitationalParameter_SI_.isDefined();
 }
 
+bool Spherical::isPointMass() const
+{
+    return true;
+}
+
 Vector3d Spherical::getFieldValueAt(const Vector3d& aPosition, const Instant& anInstant) const
 {
     (void)anInstant;  // Temporal invariance

--- a/src/OpenSpaceToolkit/Physics/Environment/Gravitational/Sun.cpp
+++ b/src/OpenSpaceToolkit/Physics/Environment/Gravitational/Sun.cpp
@@ -124,6 +124,11 @@ bool Sun::isDefined() const
     return implUPtr_ != nullptr;
 }
 
+bool Sun::isPointMass() const
+{
+    return this->isDefined() && (this->getType() == Sun::Type::Spherical);
+}
+
 Sun::Type Sun::getType() const
 {
     return implUPtr_->getType();

--- a/test/OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Gravitational/Earth.test.cpp
@@ -184,6 +184,24 @@ TEST(OpenSpaceToolkit_Physics_Environment_Gravitational_Earth, IsDefined)
     }
 }
 
+TEST(OpenSpaceToolkit_Physics_Environment_Gravitational_Earth, IsPointMass)
+{
+    {
+        EarthGravitationalModelManager::Get().setLocalRepository(
+            Directory::Path(Path::Parse("/app/test/OpenSpaceToolkit/Physics/Environment/Gravitational/Earth"))
+        );
+
+        EXPECT_FALSE(EarthGravitationalModel(EarthGravitationalModel::Type::Undefined).isPointMass());
+
+        EXPECT_TRUE(EarthGravitationalModel(EarthGravitationalModel::Type::Spherical).isPointMass());
+
+        EXPECT_FALSE(EarthGravitationalModel(EarthGravitationalModel::Type::WGS84).isPointMass());
+        EXPECT_FALSE(EarthGravitationalModel(EarthGravitationalModel::Type::EGM96).isPointMass());
+
+        EarthGravitationalModelManager::Get().reset();
+    }
+}
+
 TEST(OpenSpaceToolkit_Physics_Environment_Gravitational_Earth, ParametersFromType)
 {
     const Array<Tuple<EarthGravitationalModel::Type, EarthGravitationalModel::Parameters>> testCases = {

--- a/test/OpenSpaceToolkit/Physics/Environment/Gravitational/Moon.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Gravitational/Moon.test.cpp
@@ -43,6 +43,15 @@ TEST(OpenSpaceToolkit_Physics_Environment_Gravitational_Moon, IsDefined)
     }
 }
 
+TEST(OpenSpaceToolkit_Physics_Environment_Gravitational_Moon, IsPointMass)
+{
+    {
+        EXPECT_FALSE(MoonGravitationalModel(MoonGravitationalModel::Type::Undefined).isPointMass());
+
+        EXPECT_TRUE(MoonGravitationalModel(MoonGravitationalModel::Type::Spherical).isPointMass());
+    }
+}
+
 TEST(OpenSpaceToolkit_Physics_Environment_Gravitational_Moon, GetType)
 {
     {

--- a/test/OpenSpaceToolkit/Physics/Environment/Gravitational/Spherical.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Gravitational/Spherical.test.cpp
@@ -48,6 +48,20 @@ TEST(OpenSpaceToolkit_Physics_Environment_Gravitational_Spherical, Clone)
     }
 }
 
+TEST(OpenSpaceToolkit_Physics_Environment_Gravitational_Spherical, IsPointMass)
+{
+    {
+        const Derived gravitationalParameter = {
+            1.0, Derived::Unit::GravitationalParameter(Length::Unit::Meter, Time::Unit::Second)
+        };
+
+        const Model::Parameters parameterSet(gravitationalParameter, Length::Meters(1.0), 0.0, 0.0, 0.0);
+        const Spherical spherical = {parameterSet};
+
+        EXPECT_TRUE(spherical.isPointMass());
+    }
+}
+
 TEST(OpenSpaceToolkit_Physics_Environment_Gravitational_Spherical, GetFieldValueAt)
 {
     {

--- a/test/OpenSpaceToolkit/Physics/Environment/Gravitational/Sun.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Environment/Gravitational/Sun.test.cpp
@@ -43,6 +43,15 @@ TEST(OpenSpaceToolkit_Physics_Environment_Gravitational_Sun, IsDefined)
     }
 }
 
+TEST(OpenSpaceToolkit_Physics_Environment_Gravitational_Sun, IsPointMass)
+{
+    {
+        EXPECT_FALSE(SunGravitationalModel(SunGravitationalModel::Type::Undefined).isPointMass());
+
+        EXPECT_TRUE(SunGravitationalModel(SunGravitationalModel::Type::Spherical).isPointMass());
+    }
+}
+
 TEST(OpenSpaceToolkit_Physics_Environment_Gravitational_Sun, GetType)
 {
     {


### PR DESCRIPTION
Adds an `isPointMass` method to the gravitational model based on the model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `is_point_mass()` to Python gravitational models for Earth, Moon, Sun, and spherical models.
  * Added corresponding C++ APIs to identify whether a gravitational model represents a point mass.
  * Spherical models report `True`; unsupported, undefined, and non-spherical models report `False`.

* **Tests**
  * Added coverage for point-mass detection across Earth, Moon, Sun, and spherical gravitational models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->