### PR TITLE
feat: add getNorm to Position

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Position.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Position.cpp
@@ -113,13 +113,13 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Position(pybind11::module& aMod
             )doc"
         )
         .def(
-            "get_distance",
-            &Position::getDistance,
+            "get_norm",
+            &Position::getNorm,
             R"doc(
-                Get the distance from the frame origin.
+                Get the Position norm.
 
                 Returns:
-                    Length: Distance from the frame origin in the Position unit.
+                    Length: Position norm in the Position unit.
             )doc"
         )
         .def(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Position.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Position.cpp
@@ -116,10 +116,10 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Position(pybind11::module& aMod
             "get_norm",
             &Position::getNorm,
             R"doc(
-                Get the Position norm.
+                Get the distance to the Position Frame origin.
 
                 Returns:
-                    Length: Position norm in the Position unit.
+                    Length: Distance to the Position Frame origin.
             )doc"
         )
         .def(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Position.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Position.cpp
@@ -113,6 +113,16 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Position(pybind11::module& aMod
             )doc"
         )
         .def(
+            "get_distance",
+            &Position::getDistance,
+            R"doc(
+                Get the distance from the frame origin.
+
+                Returns:
+                    Length: Distance from the frame origin in the Position unit.
+            )doc"
+        )
+        .def(
             "get_unit",
             &Position::getUnit,
             R"doc(

--- a/bindings/python/test/coordinate/test_position.py
+++ b/bindings/python/test/coordinate/test_position.py
@@ -131,6 +131,17 @@ class TestPosition:
         assert isinstance(coordinates, np.ndarray)
         assert np.array_equal(coordinates, vector)
 
+    def test_get_distance(self, unit: Length.Unit, frame: Frame):
+        position: Position = Position([3.0, -4.0, 12.0], unit, frame)
+
+        distance: Length = position.get_distance()
+
+        assert isinstance(distance, Length)
+        assert distance == Length.meters(13.0)
+
+        with pytest.raises(RuntimeError):
+            Position.undefined().get_distance()
+
     def test_get_unit(self, unit: Length.Unit, frame: Frame):
         vector = [1000.0, 0.0, 0.0]
 

--- a/bindings/python/test/coordinate/test_position.py
+++ b/bindings/python/test/coordinate/test_position.py
@@ -131,16 +131,16 @@ class TestPosition:
         assert isinstance(coordinates, np.ndarray)
         assert np.array_equal(coordinates, vector)
 
-    def test_get_distance(self, unit: Length.Unit, frame: Frame):
+    def test_get_norm(self, unit: Length.Unit, frame: Frame):
         position: Position = Position([3.0, -4.0, 12.0], unit, frame)
 
-        distance: Length = position.get_distance()
+        norm: Length = position.get_norm()
 
-        assert isinstance(distance, Length)
-        assert distance == Length.meters(13.0)
+        assert isinstance(norm, Length)
+        assert norm == Length.meters(13.0)
 
         with pytest.raises(RuntimeError):
-            Position.undefined().get_distance()
+            Position.undefined().get_norm()
 
     def test_get_unit(self, unit: Length.Unit, frame: Frame):
         vector = [1000.0, 0.0, 0.0]

--- a/include/OpenSpaceToolkit/Physics/Coordinate/Position.hpp
+++ b/include/OpenSpaceToolkit/Physics/Coordinate/Position.hpp
@@ -166,14 +166,14 @@ class Position
     /// @return Coordinates
     Vector3d getCoordinates() const;
 
-    /// @brief Get distance from the frame origin
+    /// @brief Get position norm
     ///
     /// @code
-    ///     position.getDistance();
+    ///     position.getNorm();
     /// @endcode
     ///
-    /// @return Distance from the frame origin in the position unit
-    Length getDistance() const;
+    /// @return Position norm in the position unit
+    Length getNorm() const;
 
     /// @brief Get unit
     ///

--- a/include/OpenSpaceToolkit/Physics/Coordinate/Position.hpp
+++ b/include/OpenSpaceToolkit/Physics/Coordinate/Position.hpp
@@ -166,13 +166,13 @@ class Position
     /// @return Coordinates
     Vector3d getCoordinates() const;
 
-    /// @brief Get position norm
+    /// @brief Get the distance to the Position Frame origin.
     ///
     /// @code
     ///     position.getNorm();
     /// @endcode
     ///
-    /// @return Position norm in the position unit
+    /// @return Distance to the Position Frame origin
     Length getNorm() const;
 
     /// @brief Get unit

--- a/include/OpenSpaceToolkit/Physics/Coordinate/Position.hpp
+++ b/include/OpenSpaceToolkit/Physics/Coordinate/Position.hpp
@@ -166,6 +166,15 @@ class Position
     /// @return Coordinates
     Vector3d getCoordinates() const;
 
+    /// @brief Get distance from the frame origin
+    ///
+    /// @code
+    ///     position.getDistance();
+    /// @endcode
+    ///
+    /// @return Distance from the frame origin in the position unit
+    Length getDistance() const;
+
     /// @brief Get unit
     ///
     /// @code

--- a/src/OpenSpaceToolkit/Physics/Coordinate/Position.cpp
+++ b/src/OpenSpaceToolkit/Physics/Coordinate/Position.cpp
@@ -149,7 +149,7 @@ Vector3d Position::getCoordinates() const
     return coordinates_;
 }
 
-Length Position::getDistance() const
+Length Position::getNorm() const
 {
     if (!this->isDefined())
     {

--- a/src/OpenSpaceToolkit/Physics/Coordinate/Position.cpp
+++ b/src/OpenSpaceToolkit/Physics/Coordinate/Position.cpp
@@ -149,6 +149,16 @@ Vector3d Position::getCoordinates() const
     return coordinates_;
 }
 
+Length Position::getDistance() const
+{
+    if (!this->isDefined())
+    {
+        throw ostk::core::error::runtime::Undefined("Position");
+    }
+
+    return {coordinates_.norm(), unit_};
+}
+
 Position::Unit Position::getUnit() const
 {
     if (!this->isDefined())

--- a/test/OpenSpaceToolkit/Physics/Coordinate/Position.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Coordinate/Position.test.cpp
@@ -156,28 +156,28 @@ TEST_F(OpenSpaceToolkit_Physics_Coordinate_Position, GetCoordinates)
     }
 }
 
-TEST_F(OpenSpaceToolkit_Physics_Coordinate_Position, GetDistance)
+TEST_F(OpenSpaceToolkit_Physics_Coordinate_Position, GetNorm)
 {
     {
         const Position position = {{3.0, -4.0, 12.0}, Position::Unit::Meter, Frame::GCRF()};
 
-        EXPECT_EQ(Length::Meters(13.0), position.getDistance());
+        EXPECT_EQ(Length::Meters(13.0), position.getNorm());
     }
 
     {
         const Position position = {{3.0, -4.0, 12.0}, Position::Unit::Foot, Frame::GCRF()};
 
-        EXPECT_EQ(Length(13.0, Length::Unit::Foot), position.getDistance());
+        EXPECT_EQ(Length(13.0, Length::Unit::Foot), position.getNorm());
     }
 
     {
         const Position position = {{0.0, 0.0, 0.0}, Position::Unit::Meter, Frame::GCRF()};
 
-        EXPECT_EQ(Length(0.0, Length::Unit::Meter), position.getDistance());
+        EXPECT_EQ(Length(0.0, Length::Unit::Meter), position.getNorm());
     }
 
     {
-        EXPECT_ANY_THROW(Position::Undefined().getDistance());
+        EXPECT_ANY_THROW(Position::Undefined().getNorm());
     }
 }
 

--- a/test/OpenSpaceToolkit/Physics/Coordinate/Position.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Coordinate/Position.test.cpp
@@ -156,6 +156,31 @@ TEST_F(OpenSpaceToolkit_Physics_Coordinate_Position, GetCoordinates)
     }
 }
 
+TEST_F(OpenSpaceToolkit_Physics_Coordinate_Position, GetDistance)
+{
+    {
+        const Position position = {{3.0, -4.0, 12.0}, Position::Unit::Meter, Frame::GCRF()};
+
+        EXPECT_EQ(Length::Meters(13.0), position.getDistance());
+    }
+
+    {
+        const Position position = {{3.0, -4.0, 12.0}, Position::Unit::Foot, Frame::GCRF()};
+
+        EXPECT_EQ(Length(13.0, Length::Unit::Foot), position.getDistance());
+    }
+
+    {
+        const Position position = {{0.0, 0.0, 0.0}, Position::Unit::Meter, Frame::GCRF()};
+
+        EXPECT_EQ(Length(0.0, Length::Unit::Meter), position.getDistance());
+    }
+
+    {
+        EXPECT_ANY_THROW(Position::Undefined().getDistance());
+    }
+}
+
 TEST_F(OpenSpaceToolkit_Physics_Coordinate_Position, GetUnit)
 {
     {


### PR DESCRIPTION
## New Features

  * Added `ostk.physics.coordinate.Position.get_norm` method returning a `Length`, computed as the Euclidean magnitude in the position’s unit.