### PR TITLE
feat: make Interval type hashable

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/Interval.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/Interval.cpp
@@ -50,6 +50,13 @@ inline void OpenSpaceToolkitPhysicsPy_Time_Interval(pybind11::module& aModule)
                 return anInterval.toString();
             }
         )
+        .def(
+            "__hash__",
+            +[](const Interval& anInterval) -> size_t
+            {
+                return std::hash<Interval> {}(anInterval);
+            }
+        )
 
         .def(
             "is_defined",

--- a/bindings/python/test/time/test_interval.py
+++ b/bindings/python/test/time/test_interval.py
@@ -431,3 +431,22 @@ class TestInterval:
         ]
 
         assert Interval.logical_and(intervals_1, intervals_2) == expected
+
+    def test_hash(self):
+        interval_a = build_interval(0.0, 10.0)
+        interval_b = build_interval(0.0, 10.0)
+        interval_c = build_interval(0.0, 20.0)
+        interval_d = build_interval(0.0, 10.0, Interval.Type.Open)
+
+        assert hash(interval_a) == hash(interval_b)
+        assert hash(interval_a) != hash(interval_c)
+        assert hash(interval_a) != hash(interval_d)
+
+        # Test as dictionary key
+        d = {interval_a: "value"}
+        assert d[interval_b] == "value"
+        assert interval_c not in d
+
+        # Test in set
+        s = {interval_a, interval_b, interval_c}
+        assert len(s) == 2

--- a/include/OpenSpaceToolkit/Physics/Time/Interval.hpp
+++ b/include/OpenSpaceToolkit/Physics/Time/Interval.hpp
@@ -3,6 +3,10 @@
 #ifndef __OpenSpaceToolkit_Physics_Time_Interval__
 #define __OpenSpaceToolkit_Physics_Time_Interval__
 
+#include <functional>
+
+#include <boost/functional/hash.hpp>
+
 #include <OpenSpaceToolkit/Core/Container/Array.hpp>
 #include <OpenSpaceToolkit/Core/Type/Integer.hpp>
 #include <OpenSpaceToolkit/Core/Type/Real.hpp>
@@ -350,5 +354,28 @@ class Interval : public mathematics::object::Interval<Instant>
 }  // namespace time
 }  // namespace physics
 }  // namespace ostk
+
+namespace std
+{
+
+template <>
+struct hash<ostk::physics::time::Interval>
+{
+    size_t operator()(const ostk::physics::time::Interval& anInterval) const
+    {
+        if (!anInterval.isDefined())
+        {
+            return 0;
+        }
+
+        size_t seed = 0;
+        boost::hash_combine(seed, std::hash<ostk::physics::time::Instant> {}(anInterval.accessStart()));
+        boost::hash_combine(seed, std::hash<ostk::physics::time::Instant> {}(anInterval.accessEnd()));
+        boost::hash_combine(seed, static_cast<int>(anInterval.getType()));
+        return seed;
+    }
+};
+
+}  // namespace std
 
 #endif

--- a/test/OpenSpaceToolkit/Physics/Time/Interval.test.cpp
+++ b/test/OpenSpaceToolkit/Physics/Time/Interval.test.cpp
@@ -1,5 +1,7 @@
 /// Apache License 2.0
 
+#include <unordered_map>
+
 #include <OpenSpaceToolkit/Physics/Time/Interval.hpp>
 
 #include <Global.test.hpp>
@@ -1029,5 +1031,44 @@ TEST(OpenSpaceToolkit_Physics_Time_Interval, LogicalAnd)
         };
 
         EXPECT_EQ(expectedArray, Interval::LogicalAnd(array1, array2));
+    }
+}
+
+TEST(OpenSpaceToolkit_Physics_Time_Interval, Hash)
+{
+    const Instant startInstant = Instant::DateTime(DateTime(2018, 1, 1, 0, 0, 0), Scale::TT);
+    const Instant endInstant = Instant::DateTime(DateTime(2018, 1, 2, 0, 0, 0), Scale::TT);
+
+    {
+        EXPECT_EQ(
+            std::hash<Interval> {}(Interval::Closed(startInstant, endInstant)),
+            std::hash<Interval> {}(Interval::Closed(startInstant, endInstant))
+        );
+    }
+
+    {
+        EXPECT_NE(
+            std::hash<Interval> {}(Interval::Closed(startInstant, endInstant)),
+            std::hash<Interval> {}(Interval::Closed(startInstant, endInstant + Duration::Seconds(1.0)))
+        );
+
+        // Intervals with identical bounds but different types must produce different hashes
+        EXPECT_NE(
+            std::hash<Interval> {}(Interval::Closed(startInstant, endInstant)),
+            std::hash<Interval> {}(Interval(startInstant, endInstant, Interval::Type::Open))
+        );
+    }
+
+    {
+        EXPECT_EQ(std::hash<Interval> {}(Interval::Undefined()), 0u);
+    }
+
+    {
+        std::unordered_map<Interval, int> map;
+
+        map[Interval::Closed(startInstant, endInstant)] = 42;
+
+        EXPECT_EQ(map.at(Interval::Closed(startInstant, endInstant)), 42);
+        EXPECT_EQ(map.count(Interval::Closed(startInstant, endInstant + Duration::Seconds(1.0))), 0u);
     }
 }


### PR DESCRIPTION
Making the Interval type hashable, so that we can use them as dictionary keys. Instants are already hashable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Date, DateTime, Interval, and Time objects can now be used as keys in hash-based collections, including Python dictionaries and sets and C++ unordered containers.

* **Tests**
  * Added coverage confirming consistent hashing for equal values, distinct hashes for differing values, handling of undefined values, and collection usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->