### PR TITLE
build: migrate python bindings from pybind11 to nanobind

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -95,6 +95,9 @@ FUNCTION (NB_ADD_LIBRARY version)
     TARGET_COMPILE_FEATURES (${target} PUBLIC cxx_std_17)
     # Python's C API type-puns heavily.
     TARGET_COMPILE_OPTIONS (${target} PRIVATE "-fno-strict-aliasing")
+    # Trade nanobind's verbose assertion messages for a smaller binary. The macro is only read by
+    # nanobind's own sources, so this is the target that actually needs it.
+    TARGET_COMPILE_DEFINITIONS (${target} PRIVATE $<$<NOT:$<CONFIG:Debug>>:NB_COMPACT_ASSERTIONS>)
     SET_TARGET_PROPERTIES (${target} PROPERTIES
                           POSITION_INDEPENDENT_CODE ON
                           C_VISIBILITY_PRESET hidden
@@ -207,7 +210,7 @@ FUNCTION (PY_ADD_PACKAGE_DIRECTORY NAME)
                             COMMAND cp "${CMAKE_SOURCE_DIR}/lib/${LIBRARY_TARGET}.*${EXTENSION}*.so" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_PATH}/"
                             COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/README.md" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/README.md"
                             COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" && uv sync --python ${PYTHON_VERSION} --all-extras
-                            COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}" && uv run --project "${NAME}" python -m nanobind.stubgen -m "${PROJECT_GROUP}.${PROJECT_SUBGROUP}" -r -M "${NAME}/${PROJECT_PATH}/py.typed" -O "${NAME}" # generate stubs in same dir as binaries
+                            COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}" && uv run --project "${NAME}" python -m nanobind.stubgen -m "${PROJECT_GROUP}.${PROJECT_SUBGROUP}" -r -M "${NAME}/${PROJECT_PATH}/py.typed" -O "${NAME}/${PROJECT_PATH}" # generate stubs in same dir as binaries
                             COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" && env _PYTHON_HOST_PLATFORM="${PLATFORM}" uv build
                             COMMAND mkdir -p "${CMAKE_CURRENT_BINARY_DIR}/dist"
                             COMMAND cp "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/dist/*" "${CMAKE_CURRENT_BINARY_DIR}/dist"

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -27,6 +27,7 @@ SET (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake")
 ### Policies
 
 CMAKE_POLICY (SET "CMP0048" NEW)
+CMAKE_POLICY (SET "CMP0063" NEW)  # honour visibility properties on static libraries
 
 ### Options
 
@@ -68,6 +69,39 @@ MACRO (FIND_PYTHON version)
     ENDIF ()
 ENDMACRO ()
 
+### Function stripping a built python module
+
+# Replaces pybind11's `pybind11_strip`, which nanobind has no equivalent of.
+
+FUNCTION (PY_STRIP name)
+    IF (CMAKE_STRIP)
+        ADD_CUSTOM_COMMAND (TARGET ${name} POST_BUILD COMMAND ${CMAKE_STRIP} $<TARGET_FILE:${name}>)
+    ENDIF ()
+ENDFUNCTION ()
+
+### Function building the nanobind runtime library for one python version
+
+FUNCTION (NB_ADD_LIBRARY version)
+    SET (target "nanobind-static-${version}")
+
+    IF (TARGET ${target})
+        RETURN ()
+    ENDIF ()
+
+    ADD_LIBRARY (${target} STATIC EXCLUDE_FROM_ALL ${NANOBIND_SOURCES})
+    TARGET_INCLUDE_DIRECTORIES (${target} SYSTEM PUBLIC "${nanobind_SOURCE_DIR}/include")
+    TARGET_INCLUDE_DIRECTORIES (${target} PRIVATE "${nanobind_SOURCE_DIR}/ext/robin_map/include")
+    TARGET_LINK_LIBRARIES (${target} PUBLIC python${version}::headers)
+    TARGET_COMPILE_FEATURES (${target} PUBLIC cxx_std_17)
+    # Python's C API type-puns heavily.
+    TARGET_COMPILE_OPTIONS (${target} PRIVATE "-fno-strict-aliasing")
+    SET_TARGET_PROPERTIES (${target} PROPERTIES
+                          POSITION_INDEPENDENT_CODE ON
+                          C_VISIBILITY_PRESET hidden
+                          CXX_VISIBILITY_PRESET hidden
+    )
+ENDFUNCTION ()
+
 ### Function to grab python extension and use for target
 
 FUNCTION (PY_EXTENSION name version)
@@ -87,8 +121,10 @@ FUNCTION (PY_ADD_MODULE NAME)
     CMAKE_PARSE_ARGUMENTS (PARSE "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
     SET (PYTHON_VERSION ${PARSE_PYTHON_VERSION})
 
+    NB_ADD_LIBRARY (${PYTHON_VERSION})
+
     ADD_LIBRARY (${NAME} MODULE ${PARSE_UNPARSED_ARGUMENTS})
-    PYBIND11_STRIP (${NAME})
+    PY_STRIP (${NAME})
     PY_EXTENSION (${NAME} ${PYTHON_VERSION})
 
     # External Libraries
@@ -103,7 +139,10 @@ FUNCTION (PY_ADD_MODULE NAME)
     TARGET_INCLUDE_DIRECTORIES (${NAME} PUBLIC "${PROJECT_SOURCE_DIR}/src")
 
     # Pybind11/Python Link
-    TARGET_LINK_LIBRARIES (${NAME} PRIVATE pybind11::module pybind11::lto python${PYTHON_VERSION}::headers)
+    TARGET_LINK_LIBRARIES (${NAME} PRIVATE "nanobind-static-${PYTHON_VERSION}" python${PYTHON_VERSION}::headers)
+    TARGET_COMPILE_OPTIONS (${NAME} PRIVATE "-fno-strict-aliasing")
+    # Trade nanobind's verbose assertion messages for a smaller binary.
+    TARGET_COMPILE_DEFINITIONS (${NAME} PRIVATE $<$<NOT:$<CONFIG:Debug>>:NB_COMPACT_ASSERTIONS>)
     TARGET_LINK_LIBRARIES (${NAME} PRIVATE ${SHARED_LIBRARY_TARGET})
 
     # Previous Boost Linking
@@ -168,8 +207,7 @@ FUNCTION (PY_ADD_PACKAGE_DIRECTORY NAME)
                             COMMAND cp "${CMAKE_SOURCE_DIR}/lib/${LIBRARY_TARGET}.*${EXTENSION}*.so" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_PATH}/"
                             COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/README.md" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/README.md"
                             COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" && uv sync --python ${PYTHON_VERSION} --all-extras
-                            COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" && uv run pybind11-stubgen -o . "${PROJECT_GROUP}.${PROJECT_SUBGROUP}" # generate stubs in same dir as binaries
-                            COMMAND find "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_GROUP}" -type f -name "*.pyi" -exec sed -i "s/: \\\\.\\\\.\\\\./: typing.Any/g" {} + # crudely fix broken stubs; need to escape \\
+                            COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}" && uv run --project "${NAME}" python -m nanobind.stubgen -m "${PROJECT_GROUP}.${PROJECT_SUBGROUP}" -r -M "${NAME}/${PROJECT_PATH}/py.typed" -O "${NAME}" # generate stubs in same dir as binaries
                             COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" && env _PYTHON_HOST_PLATFORM="${PLATFORM}" uv build
                             COMMAND mkdir -p "${CMAKE_CURRENT_BINARY_DIR}/dist"
                             COMMAND cp "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/dist/*" "${CMAKE_CURRENT_BINARY_DIR}/dist"
@@ -194,10 +232,28 @@ ENDFUNCTION ()
 
 ## Dependencies
 
-### Pybind11
+### Nanobind
 
-SET (PYBIND11_NOPYTHON ON)
-FIND_PACKAGE (pybind11 2.12.0 REQUIRED)
+INCLUDE (FetchContent)
+
+FetchContent_Declare (
+    nanobind
+    GIT_REPOSITORY https://github.com/wjakob/nanobind.git
+    GIT_TAG v2.9.2
+    GIT_SHALLOW TRUE
+)
+
+# Only nanobind's sources are needed. Its own CMake project resolves a single
+# interpreter, whereas the bindings are built once per supported python version,
+# so the runtime library is assembled per version by NB_ADD_LIBRARY below.
+FetchContent_GetProperties (nanobind)
+IF (NOT nanobind_POPULATED)
+    FetchContent_Populate (nanobind)
+ENDIF ()
+
+# `nb_combined.cpp` is nanobind's officially supported single-translation-unit
+# amalgamation, which keeps this list correct across nanobind upgrades.
+SET (NANOBIND_SOURCES "${nanobind_SOURCE_DIR}/src/nb_combined.cpp")
 
 ### Python
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy.cxx
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy.cxx
@@ -2,12 +2,12 @@
 
 #include <OpenSpaceToolkitPhysicsPy/Utility/ArrayCasting.hpp>
 #include <OpenSpaceToolkitPhysicsPy/Utility/DateTimeCasting.hpp>
+#include <OpenSpaceToolkitPhysicsPy/Utility/EigenSequenceCasting.hpp>
 #include <OpenSpaceToolkitPhysicsPy/Utility/ShiftToString.hpp>
-#include <pybind11/chrono.h>
-#include <pybind11/eigen.h>
-#include <pybind11/numpy.h>
-#include <pybind11/operators.h>
-#include <pybind11/pybind11.h>
+#include <nanobind/eigen/dense.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/chrono.h>
 
 #include <OpenSpaceToolkitPhysicsPy/Coordinate.cpp>
 #include <OpenSpaceToolkitPhysicsPy/Data.cpp>
@@ -16,7 +16,7 @@
 #include <OpenSpaceToolkitPhysicsPy/Time.cpp>
 #include <OpenSpaceToolkitPhysicsPy/Unit.cpp>
 
-PYBIND11_MODULE(OpenSpaceToolkitPhysicsPy, m)
+NB_MODULE(OpenSpaceToolkitPhysicsPy, m)
 {
     // Add optional docstring for package OpenSpaceToolkitPhysicsPy
     m.doc() = "Physical units, time, reference frames, environment modeling for OpenSpaceToolkit";

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate.cpp
@@ -7,7 +7,7 @@
 #include <OpenSpaceToolkitPhysicsPy/Coordinate/Transform.cpp>
 #include <OpenSpaceToolkitPhysicsPy/Coordinate/Velocity.cpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Coordinate(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Coordinate(nanobind::module_& aModule)
 {
     // Create "coordinate" python submodule
     auto coordinate = aModule.def_submodule("coordinate");

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Axes.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Axes.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Axes.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Coordinate_Axes(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Coordinate_Axes(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Shared;
 
@@ -41,7 +41,12 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Axes(pybind11::module& aModule)
         )
 
         .def(
-            self == self,
+            "__eq__",
+            [](const Axes& self, const Axes& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator(),
             R"doc(
                 Equality operator.
 
@@ -53,7 +58,12 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Axes(pybind11::module& aModule)
             )doc"
         )
         .def(
-            self != self,
+            "__ne__",
+            [](const Axes& self, const Axes& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator(),
             R"doc(
                 Inequality operator.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Frame.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Frame.cpp
@@ -5,9 +5,9 @@
 #include <OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Manager.cpp>
 #include <OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider.cpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Shared;
     using ostk::core::type::String;
@@ -15,7 +15,7 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame(pybind11::module& aModule
     using ostk::physics::coordinate::Frame;
     using ostk::physics::coordinate::frame::Provider;
 
-    class_<Frame, Shared<Frame>>(
+    class_<Frame>(
         aModule,
         "Frame",
         R"doc(
@@ -29,7 +29,12 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame(pybind11::module& aModule
     )
 
         .def(
-            self == self,
+            "__eq__",
+            [](const Frame& self, const Frame& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator(),
             R"doc(
                 Equality operator.
 
@@ -41,7 +46,12 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame(pybind11::module& aModule
             )doc"
         )
         .def(
-            self != self,
+            "__ne__",
+            [](const Frame& self, const Frame& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator(),
             R"doc(
                 Inequality operator.
 
@@ -349,7 +359,7 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame(pybind11::module& aModule
             arg("is_quasi_inertial"),
             arg("parent_frame"),
             arg("provider"),
-            arg_v("overwrite", false, "false"),
+            arg("overwrite").sig("false") = false,
             R"doc(
                 Construct a frame.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Manager.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Manager.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Frame/Manager.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Manager(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Manager(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Shared;
     using ostk::core::type::String;
@@ -139,7 +139,7 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Manager(pybind11::module&
         .def_static(
             "get",
             &Manager::Get,
-            return_value_policy::reference,
+            rv_policy::reference,
             R"doc(
                 Get manager singleton.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider.cpp
@@ -7,15 +7,15 @@
 #include <OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider/IERS.cpp>
 #include <OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider/Static.cpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Shared;
 
     using ostk::physics::coordinate::frame::Provider;
 
-    class_<Provider, Shared<Provider>>(
+    class_<Provider>(
         aModule,
         "Provider",
         R"doc(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider/Dynamic.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider/Dynamic.cpp
@@ -4,9 +4,9 @@
 #include <OpenSpaceToolkit/Physics/Coordinate/Transform.hpp>
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider_Dynamic(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider_Dynamic(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Shared;
 
@@ -15,7 +15,7 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider_Dynamic(pybind11
     using ostk::physics::coordinate::Transform;
     using ostk::physics::time::Instant;
 
-    class_<Dynamic, Shared<Dynamic>, Provider>(
+    class_<Dynamic, Provider>(
         aModule,
         "Dynamic",
         R"doc(
@@ -27,11 +27,11 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider_Dynamic(pybind11
         // Custom Constructor for Dynamic
         .def(
             "__init__",
-            (+[](Dynamic& aDynamicFrameProvider, const pybind11::object& aGeneratorObject)
+            (+[](Dynamic& aDynamicFrameProvider, const nanobind::object& aGeneratorObject)
              {
                  const auto generatorProxy = [aGeneratorObject](const Instant& anInstant) -> Transform
                  {
-                     return pybind11::cast<Transform>(aGeneratorObject(anInstant));
+                     return nanobind::cast<Transform>(aGeneratorObject(anInstant));
                  };
 
                  // might need to add return type to the function (Shared<Dynamic>)

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider/IAU.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider/IAU.cpp
@@ -2,7 +2,7 @@
 
 #include <OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider/IAU/Theory.cpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider_IAU(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider_IAU(nanobind::module_& aModule)
 {
     // Create "IAU" python submodule
     auto IAU = aModule.def_submodule("iau");

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider/IAU/Theory.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider/IAU/Theory.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Frame/Provider/IAU/Theory.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider_IAU_Theory(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider_IAU_Theory(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::physics::coordinate::frame::provider::iau::Theory;
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider/IERS.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider/IERS.cpp
@@ -4,7 +4,7 @@
 #include <OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider/IERS/Finals2000A.cpp>
 #include <OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider/IERS/Manager.cpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider_IERS(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider_IERS(nanobind::module_& aModule)
 {
     // Create "iers" python submodule
     auto iers = aModule.def_submodule("iers");

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider/IERS/BulletinA.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider/IERS/BulletinA.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Frame/Provider/IERS/BulletinA.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider_IERS_BulletinA(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider_IERS_BulletinA(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Shared;
 
@@ -215,70 +215,70 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider_IERS_BulletinA(p
 
     class_<BulletinA::Observation>(bulletinA, "Observation")
 
-        .def_readonly(
+        .def_ro(
             "year",
             &BulletinA::Observation::year,
             R"doc(
                 Year (to get true calendar year, add 1900 for MJD <= 51543 or add 2000 for MJD >= 51544).
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "month",
             &BulletinA::Observation::month,
             R"doc(
                 Month number.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "day",
             &BulletinA::Observation::day,
             R"doc(
                 Day of month.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "mjd",
             &BulletinA::Observation::mjd,
             R"doc(
                 Modified Julian Day.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "x",
             &BulletinA::Observation::x,
             R"doc(
                 PM-x [asec].
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "x_error",
             &BulletinA::Observation::xError,
             R"doc(
                 PM-x error [asec].
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "y",
             &BulletinA::Observation::y,
             R"doc(
                 PM-y [asec].
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "y_error",
             &BulletinA::Observation::yError,
             R"doc(
                 PM-y error [asec].
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "ut1_minus_utc",
             &BulletinA::Observation::ut1MinusUtc,
             R"doc(
                 UT1-UTC [s].
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "ut1_minus_utc_error",
             &BulletinA::Observation::ut1MinusUtcError,
             R"doc(
@@ -290,49 +290,49 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider_IERS_BulletinA(p
 
     class_<BulletinA::Prediction>(bulletinA, "Prediction")
 
-        .def_readonly(
+        .def_ro(
             "year",
             &BulletinA::Prediction::year,
             R"doc(
                 Year (to get true calendar year, add 1900 for MJD <= 51543 or add 2000 for MJD >= 51544).
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "month",
             &BulletinA::Prediction::month,
             R"doc(
                 Month number.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "day",
             &BulletinA::Prediction::day,
             R"doc(
                 Day of month.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "mjd",
             &BulletinA::Prediction::mjd,
             R"doc(
                 Modified Julian Day.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "x",
             &BulletinA::Prediction::x,
             R"doc(
                 PM-x [asec].
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "y",
             &BulletinA::Prediction::y,
             R"doc(
                 PM-y [asec].
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "ut1_minus_utc",
             &BulletinA::Prediction::ut1MinusUtc,
             R"doc(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider/IERS/Finals2000A.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider/IERS/Finals2000A.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Frame/Provider/IERS/Finals2000A.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider_IERS_Finals2000A(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider_IERS_Finals2000A(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Shared;
 
@@ -137,168 +137,168 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider_IERS_Finals2000A
 
     class_<Finals2000A::Data>(finals2000A, "Data")
 
-        .def_readonly(
+        .def_ro(
             "year",
             &Finals2000A::Data::year,
             R"doc(
                 Year (to get true calendar year, add 1900 for MJD <= 51543 or add 2000 for MJD >= 51544).
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "month",
             &Finals2000A::Data::month,
             R"doc(
                 Month number.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "day",
             &Finals2000A::Data::day,
             R"doc(
                 Day of month.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "mjd",
             &Finals2000A::Data::mjd,
             R"doc(
                 Modified Julian Date.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "polar_motionflag",
             &Finals2000A::Data::polarMotionflag,
             R"doc(
                 IERS (I) or Prediction (P) flag for Bulletin A polar motion values.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "x_a",
             &Finals2000A::Data::x_A,
             R"doc(
                 Bulletin A PM-x [asec].
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "x_error_a",
             &Finals2000A::Data::xError_A,
             R"doc(
                 Error in PM-x [asec].
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "y_a",
             &Finals2000A::Data::y_A,
             R"doc(
                 Bulletin A PM-y [asec].
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "y_error_a",
             &Finals2000A::Data::yError_A,
             R"doc(
                 Error in PM-y [asec].
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "ut1_minus_utc_flag",
             &Finals2000A::Data::ut1MinusUtcFlag,
             R"doc(
                 IERS (I) or Prediction (P) flag for Bulletin A UT1-UTC values.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "ut1_minus_utc_a",
             &Finals2000A::Data::ut1MinusUtc_A,
             R"doc(
                 Bulletin A UT1-UTC [s].
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "ut1_minus_utc_error_a",
             &Finals2000A::Data::ut1MinusUtcError_A,
             R"doc(
                 Error in UT1-UTC [s].
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "lod_a",
             &Finals2000A::Data::lod_A,
             R"doc(
                 Bulletin A LOD (not always filled) [ms].
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "lod_error_a",
             &Finals2000A::Data::lodError_A,
             R"doc(
                 Error in LOD (not always filled) [ms].
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "nutation_flag",
             &Finals2000A::Data::nutationFlag,
             R"doc(
                 IERS (I) or Prediction (P) flag for Bulletin A nutation values.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "dx_a",
             &Finals2000A::Data::dx_A,
             R"doc(
                 Bulletin A dX wrt IAU2000A Nutation, Free Core Nutation NOT Removed [amsec].
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "dx_error_a",
             &Finals2000A::Data::dxError_A,
             R"doc(
                 Error in dX [amsec].
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "dy_a",
             &Finals2000A::Data::dy_A,
             R"doc(
                 Bulletin A dY wrt IAU2000A Nutation, Free Core Nutation NOT Removed [amsec].
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "dy_error_a",
             &Finals2000A::Data::dyError_A,
             R"doc(
                 Error in dY [amsec].
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "x_b",
             &Finals2000A::Data::x_B,
             R"doc(
                 Bulletin B PM-x [asec].
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "y_b",
             &Finals2000A::Data::y_B,
             R"doc(
                 Bulletin B PM-y [asec].
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "ut1_minus_utc_b",
             &Finals2000A::Data::ut1MinusUtc_B,
             R"doc(
                 Bulletin B UT1-UTC [s].
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "dx_b",
             &Finals2000A::Data::dx_B,
             R"doc(
                 Bulletin B dX wrt IAU2000A Nutation [amsec].
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "dy_b",
             &Finals2000A::Data::dy_B,
             R"doc(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider/IERS/Manager.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider/IERS/Manager.cpp
@@ -4,9 +4,9 @@
 
 #include <OpenSpaceToolkit/Physics/Manager.cpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider_IERS_Manager(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider_IERS_Manager(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Shared;
 
@@ -165,7 +165,7 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider_IERS_Manager(pyb
         .def_static(
             "get",
             &Manager::Get,
-            return_value_policy::reference,
+            rv_policy::reference,
             R"doc(
                 Get manager singleton.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider/Static.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Frame/Provider/Static.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Frame/Provider/Static.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider_Static(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider_Static(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Shared;
 
@@ -12,7 +12,7 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Frame_Provider_Static(pybind11:
     using ostk::physics::coordinate::frame::provider::Static;
     using ostk::physics::coordinate::Transform;
 
-    class_<Static, Shared<Static>, Provider>(
+    class_<Static, Provider>(
         aModule,
         "Static",
         R"doc(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Position.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Position.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Position.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Coordinate_Position(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Coordinate_Position(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Integer;
     using ostk::core::type::Shared;
@@ -38,7 +38,12 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Position(pybind11::module& aMod
         )
 
         .def(
-            self == self,
+            "__eq__",
+            [](const Position& self, const Position& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator(),
             R"doc(
                 Equality operator.
 
@@ -50,7 +55,12 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Position(pybind11::module& aMod
             )doc"
         )
         .def(
-            self != self,
+            "__ne__",
+            [](const Position& self, const Position& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator(),
             R"doc(
                 Inequality operator.
 
@@ -171,7 +181,7 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Position(pybind11::module& aMod
         .def(
             "to_string",
             &Position::toString,
-            arg_v("precision", DEFAULT_PRECISION, "Integer.Undefined()"),
+            arg("precision").sig("Integer.Undefined()") = DEFAULT_PRECISION,
             R"doc(
                 Create a string representation.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Spherical.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Spherical.cpp
@@ -3,7 +3,7 @@
 #include <OpenSpaceToolkitPhysicsPy/Coordinate/Spherical/AER.cpp>
 #include <OpenSpaceToolkitPhysicsPy/Coordinate/Spherical/LLA.cpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical(nanobind::module_& aModule)
 {
     // Create "spherical" python submodule
     auto spherical = aModule.def_submodule("spherical");

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Spherical/AER.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Spherical/AER.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Spherical/AER.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_AER(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_AER(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::physics::coordinate::Position;
     using ostk::physics::coordinate::spherical::AER;
@@ -35,7 +35,12 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_AER(pybind11::module&
         )
 
         .def(
-            self == self,
+            "__eq__",
+            [](const AER& self, const AER& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator(),
             R"doc(
                 Equality operator.
 
@@ -47,7 +52,12 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_AER(pybind11::module&
             )doc"
         )
         .def(
-            self != self,
+            "__ne__",
+            [](const AER& self, const AER& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator(),
             R"doc(
                 Inequality operator.
 
@@ -153,7 +163,7 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_AER(pybind11::module&
             &AER::FromPositionToPosition,
             arg("from_position"),
             arg("to_position"),
-            arg_v("is_z_negative", DEFAULT_IS_Z_NEGATIVE, "True"),
+            arg("is_z_negative").sig("True") = DEFAULT_IS_Z_NEGATIVE,
             R"doc(
                 Construct AER from position to position.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Spherical/LLA.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Spherical/LLA.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Spherical/LLA.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Real;
 
@@ -39,7 +39,12 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
         )
 
         .def(
-            self == self,
+            "__eq__",
+            [](const LLA& self, const LLA& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator(),
             R"doc(
                 Equality operator.
 
@@ -51,7 +56,12 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
             )doc"
         )
         .def(
-            self != self,
+            "__ne__",
+            [](const LLA& self, const LLA& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator(),
             R"doc(
                 Inequality operator.
 
@@ -135,8 +145,8 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
                     Length: Distance.
             )doc",
             arg("lla"),
-            arg_v("ellipsoid_equatorial_radius", Length::Undefined(), "Length.Undefined()"),
-            arg_v("ellipsoid_flattening", Real::Undefined(), "Real.Undefined()")
+            arg("ellipsoid_equatorial_radius").sig("Length.Undefined()") = Length::Undefined(),
+            arg("ellipsoid_flattening").sig("Real.Undefined()") = Real::Undefined()
         )
         .def(
             "calculate_azimuth_to",
@@ -155,8 +165,8 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
 
                 )doc",
             arg("lla"),
-            arg_v("ellipsoid_equatorial_radius", Length::Undefined(), "Length.Undefined()"),
-            arg_v("ellipsoid_flattening", Real::Undefined(), "Real.Undefined()")
+            arg("ellipsoid_equatorial_radius").sig("Length.Undefined()") = Length::Undefined(),
+            arg("ellipsoid_flattening").sig("Real.Undefined()") = Real::Undefined()
         )
         .def(
             "calculate_intermediate_to",
@@ -177,8 +187,8 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
             )doc",
             arg("lla"),
             arg("ratio"),
-            arg_v("ellipsoid_equatorial_radius", Length::Undefined(), "Length.Undefined()"),
-            arg_v("ellipsoid_flattening", Real::Undefined(), "Real.Undefined()")
+            arg("ellipsoid_equatorial_radius").sig("Length.Undefined()") = Length::Undefined(),
+            arg("ellipsoid_flattening").sig("Real.Undefined()") = Real::Undefined()
         )
         .def(
             "calculate_forward",
@@ -199,8 +209,8 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
             )doc",
             arg("azimuth"),
             arg("distance"),
-            arg_v("ellipsoid_equatorial_radius", Length::Undefined(), "Length.Undefined()"),
-            arg_v("ellipsoid_flattening", Real::Undefined(), "Real.Undefined()")
+            arg("ellipsoid_equatorial_radius").sig("Length.Undefined()") = Length::Undefined(),
+            arg("ellipsoid_flattening").sig("Real.Undefined()") = Real::Undefined()
         )
         .def(
             "calculate_linspace_to",
@@ -221,8 +231,8 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
             )doc",
             arg("lla"),
             arg("number_of_points"),
-            arg_v("ellipsoid_equatorial_radius", Length::Undefined(), "Length.Undefined()"),
-            arg_v("ellipsoid_flattening", Real::Undefined(), "Real.Undefined()")
+            arg("ellipsoid_equatorial_radius").sig("Length.Undefined()") = Length::Undefined(),
+            arg("ellipsoid_flattening").sig("Real.Undefined()") = Real::Undefined()
         )
 
         .def(
@@ -249,8 +259,8 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
                 Returns:
                     np.ndarray: Cartesian.
             )doc",
-            arg_v("ellipsoid_equatorial_radius", Length::Undefined(), "Length.Undefined()"),
-            arg_v("ellipsoid_flattening", Real::Undefined(), "Real.Undefined()")
+            arg("ellipsoid_equatorial_radius").sig("Length.Undefined()") = Length::Undefined(),
+            arg("ellipsoid_flattening").sig("Real.Undefined()") = Real::Undefined()
         )
         .def(
             "to_string",
@@ -303,8 +313,8 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
                     LLA: LLA.
             )doc",
             arg("cartesian_coordinates"),
-            arg_v("ellipsoid_equatorial_radius", Length::Undefined(), "Length.Undefined()"),
-            arg_v("ellipsoid_flattening", Real::Undefined(), "Real.Undefined()")
+            arg("ellipsoid_equatorial_radius").sig("Length.Undefined()") = Length::Undefined(),
+            arg("ellipsoid_flattening").sig("Real.Undefined()") = Real::Undefined()
         )
         .def_static(
             "distance_between",
@@ -324,8 +334,8 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
             )doc",
             arg("lla_1"),
             arg("lla_2"),
-            arg_v("ellipsoid_equatorial_radius", Length::Undefined(), "Length.Undefined()"),
-            arg_v("ellipsoid_flattening", Real::Undefined(), "Real.Undefined()")
+            arg("ellipsoid_equatorial_radius").sig("Length.Undefined()") = Length::Undefined(),
+            arg("ellipsoid_flattening").sig("Real.Undefined()") = Real::Undefined()
         )
         .def_static(
             "azimuth_between",
@@ -345,8 +355,8 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
             )doc",
             arg("lla_1"),
             arg("lla_2"),
-            arg_v("ellipsoid_equatorial_radius", Length::Undefined(), "Length.Undefined()"),
-            arg_v("ellipsoid_flattening", Real::Undefined(), "Real.Undefined()")
+            arg("ellipsoid_equatorial_radius").sig("Length.Undefined()") = Length::Undefined(),
+            arg("ellipsoid_flattening").sig("Real.Undefined()") = Real::Undefined()
         )
         .def_static(
             "intermediate_between",
@@ -369,8 +379,8 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
             arg("lla_1"),
             arg("lla_2"),
             arg("ratio"),
-            arg_v("ellipsoid_equatorial_radius", Length::Undefined(), "Length.Undefined()"),
-            arg_v("ellipsoid_flattening", Real::Undefined(), "Real.Undefined()")
+            arg("ellipsoid_equatorial_radius").sig("Length.Undefined()") = Length::Undefined(),
+            arg("ellipsoid_flattening").sig("Real.Undefined()") = Real::Undefined()
         )
         .def_static(
             "forward",
@@ -393,8 +403,8 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
             arg("lla"),
             arg("azimuth"),
             arg("distance"),
-            arg_v("ellipsoid_equatorial_radius", Length::Undefined(), "Length.Undefined()"),
-            arg_v("ellipsoid_flattening", Real::Undefined(), "Real.Undefined()")
+            arg("ellipsoid_equatorial_radius").sig("Length.Undefined()") = Length::Undefined(),
+            arg("ellipsoid_flattening").sig("Real.Undefined()") = Real::Undefined()
         )
         .def_static(
             "linspace",
@@ -417,8 +427,8 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
             arg("lla_1"),
             arg("lla_2"),
             arg("number_of_points"),
-            arg_v("ellipsoid_equatorial_radius", Length::Undefined(), "Length.Undefined()"),
-            arg_v("ellipsoid_flattening", Real::Undefined(), "Real.Undefined()")
+            arg("ellipsoid_equatorial_radius").sig("Length.Undefined()") = Length::Undefined(),
+            arg("ellipsoid_flattening").sig("Real.Undefined()") = Real::Undefined()
         )
         .def_static(
             "from_position",
@@ -434,7 +444,7 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Spherical_LLA(pybind11::module&
                     LLA: LLA.
             )doc",
             arg("position"),
-            arg_v("celestial", nullptr, "None")
+            arg("celestial").sig("None") = nullptr
         )
 
         ;

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Transform.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Transform.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Transform.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Coordinate_Transform(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Coordinate_Transform(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Real;
 
@@ -51,7 +51,12 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Transform(pybind11::module& aMo
         )
 
         .def(
-            self == self,
+            "__eq__",
+            [](const Transform& self, const Transform& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator(),
             R"doc(
                 Equality operator.
 
@@ -63,7 +68,12 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Transform(pybind11::module& aMo
             )doc"
         )
         .def(
-            self != self,
+            "__ne__",
+            [](const Transform& self, const Transform& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator(),
             R"doc(
                 Inequality operator.
 
@@ -76,7 +86,12 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Transform(pybind11::module& aMo
         )
 
         .def(
-            self * self,
+            "__mul__",
+            [](const Transform& self, const Transform& other)
+            {
+                return self * other;
+            },
+            nanobind::is_operator(),
             R"doc(
                 Multiplication operator.
 
@@ -89,7 +104,14 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Transform(pybind11::module& aMo
         )
 
         .def(
-            self *= self,
+            "__imul__",
+            [](Transform& self, const Transform& other) -> Transform&
+            {
+                self *= other;
+                return self;
+            },
+            nanobind::rv_policy::none,
+            nanobind::is_operator(),
             R"doc(
                 Multiplication assignment operator.
 
@@ -128,7 +150,7 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Transform(pybind11::module& aMo
         .def(
             "access_instant",
             &Transform::accessInstant,
-            return_value_policy::reference,
+            rv_policy::reference,
             R"doc(
                 Access the instant.
 
@@ -139,7 +161,7 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Transform(pybind11::module& aMo
         .def(
             "access_translation",
             &Transform::accessTranslation,
-            return_value_policy::reference,
+            rv_policy::reference,
             R"doc(
                 Access the translation.
 
@@ -150,7 +172,7 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Transform(pybind11::module& aMo
         .def(
             "access_velocity",
             &Transform::accessVelocity,
-            return_value_policy::reference,
+            rv_policy::reference,
             R"doc(
                 Access the velocity.
 
@@ -161,7 +183,7 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Transform(pybind11::module& aMo
         .def(
             "access_orientation",
             &Transform::accessOrientation,
-            return_value_policy::reference,
+            rv_policy::reference,
             R"doc(
                 Access the orientation.
 
@@ -172,7 +194,7 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Transform(pybind11::module& aMo
         .def(
             "access_angular_velocity",
             &Transform::accessAngularVelocity,
-            return_value_policy::reference,
+            rv_policy::reference,
             R"doc(
                 Access the angular velocity.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Velocity.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Coordinate/Velocity.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Coordinate/Velocity.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Coordinate_Velocity(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Coordinate_Velocity(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Integer;
     using ostk::core::type::Shared;
@@ -40,7 +40,12 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Velocity(pybind11::module& aMod
         )
 
         .def(
-            self == self,
+            "__eq__",
+            [](const Velocity& self, const Velocity& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator(),
             R"doc(
                 Equality operator.
 
@@ -52,7 +57,12 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Velocity(pybind11::module& aMod
             )doc"
         )
         .def(
-            self != self,
+            "__ne__",
+            [](const Velocity& self, const Velocity& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator(),
             R"doc(
                 Inequality operator.
 
@@ -144,7 +154,7 @@ inline void OpenSpaceToolkitPhysicsPy_Coordinate_Velocity(pybind11::module& aMod
         .def(
             "to_string",
             &Velocity::toString,
-            arg_v("precision", DEFAULT_PRECISION, "Integer.Undefined()"),
+            arg("precision").sig("Integer.Undefined()") = DEFAULT_PRECISION,
             R"doc(
                 Convert to string.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Data.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Data.cpp
@@ -7,9 +7,9 @@
 #include <OpenSpaceToolkitPhysicsPy/Data/Scalar.cpp>
 #include <OpenSpaceToolkitPhysicsPy/Data/Vector.cpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Data(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Data(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     // Create "data" python submodule
     auto data = aModule.def_submodule("data");

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Data/Direction.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Data/Direction.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Data/Direction.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Data_Direction(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Data_Direction(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Shared;
 
@@ -39,7 +39,12 @@ inline void OpenSpaceToolkitPhysicsPy_Data_Direction(pybind11::module& aModule)
         )
 
         .def(
-            self == self,
+            "__eq__",
+            [](const Direction& self, const Direction& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator(),
             R"doc(
                 Equality operator.
 
@@ -51,7 +56,12 @@ inline void OpenSpaceToolkitPhysicsPy_Data_Direction(pybind11::module& aModule)
             )doc"
         )
         .def(
-            self != self,
+            "__ne__",
+            [](const Direction& self, const Direction& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator(),
             R"doc(
                 Inequality operator.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Data/Manager.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Data/Manager.cpp
@@ -3,9 +3,9 @@
 #include <OpenSpaceToolkit/Physics/Data/Manager.hpp>
 #include <OpenSpaceToolkit/Physics/Manager.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Data_Manager(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Data_Manager(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::physics::data::Manager;
     using BaseManager = ostk::physics::Manager;
@@ -131,7 +131,7 @@ inline void OpenSpaceToolkitPhysicsPy_Data_Manager(pybind11::module& aModule)
         .def_static(
             "get",
             &Manager::Get,
-            return_value_policy::reference,
+            rv_policy::reference,
             R"doc(
                 Get manager singleton.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Data/Manifest.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Data/Manifest.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Data/Manifest.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Data_Manifest(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Data_Manifest(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::physics::data::Manifest;
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Data/Provider.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Data/Provider.cpp
@@ -1,12 +1,12 @@
 /// Apache License 2.0
 
-#include <pybind11/pybind11.h>
+#include <nanobind/nanobind.h>
 
 #include <OpenSpaceToolkitPhysicsPy/Data/Provider/Nadir.cpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Data_Provider(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Data_Provider(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     // Create "provider" python submodule
     auto provider = aModule.def_submodule("provider");

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Data/Provider/Nadir.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Data/Provider/Nadir.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Data/Provider/Nadir.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Data_Provider_Nadir(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Data_Provider_Nadir(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::physics::coordinate::Frame;
     using ostk::physics::data::provider::Nadir;

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Data/Scalar.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Data/Scalar.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Data/Scalar.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Data_Scalar(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Data_Scalar(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Integer;
     using ostk::core::type::Real;
@@ -40,7 +40,12 @@ inline void OpenSpaceToolkitPhysicsPy_Data_Scalar(pybind11::module& aModule)
         )
 
         .def(
-            self == self,
+            "__eq__",
+            [](const Scalar& self, const Scalar& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator(),
             R"doc(
                 Equality operator.
 
@@ -52,7 +57,12 @@ inline void OpenSpaceToolkitPhysicsPy_Data_Scalar(pybind11::module& aModule)
             )doc"
         )
         .def(
-            self != self,
+            "__ne__",
+            [](const Scalar& self, const Scalar& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator(),
             R"doc(
                 Inequality operator.
 
@@ -114,7 +124,7 @@ inline void OpenSpaceToolkitPhysicsPy_Data_Scalar(pybind11::module& aModule)
         .def(
             "to_string",
             &Scalar::toString,
-            arg_v("precision", Integer::Undefined(), "Integer.Undefined()"),
+            arg("precision").sig("Integer.Undefined()") = Integer::Undefined(),
             R"doc(
                 Convert to string.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Data/Vector.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Data/Vector.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Data/Vector.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Data_Vector(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Data_Vector(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Shared;
 
@@ -39,7 +39,12 @@ inline void OpenSpaceToolkitPhysicsPy_Data_Vector(pybind11::module& aModule)
         )
 
         .def(
-            self == self,
+            "__eq__",
+            [](const Vector& self, const Vector& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator(),
             R"doc(
                 Equality operator.
 
@@ -51,7 +56,12 @@ inline void OpenSpaceToolkitPhysicsPy_Data_Vector(pybind11::module& aModule)
             )doc"
         )
         .def(
-            self != self,
+            "__ne__",
+            [](const Vector& self, const Vector& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator(),
             R"doc(
                 Inequality operator.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment.cpp
@@ -9,9 +9,9 @@
 #include <OpenSpaceToolkitPhysicsPy/Environment/Object.cpp>
 #include <OpenSpaceToolkitPhysicsPy/Environment/Utility.cpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::container::Array;
     using ostk::core::type::Shared;
@@ -20,7 +20,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment(pybind11::module& aModule)
     using ostk::physics::environment::Object;
     using ostk::physics::time::Instant;
 
-    class_<Environment, Shared<Environment>>(
+    class_<Environment>(
         aModule,
         "Environment",
         R"doc(
@@ -106,7 +106,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment(pybind11::module& aModule)
             "intersects",
             &Environment::intersects,
             arg("geometry"),
-            arg_v("objects_to_ignore", Array<Shared<const Object>>::Empty(), "[]"),
+            arg("objects_to_ignore").sig("[]") = Array<Shared<const Object>>::Empty(),
             R"doc(
                 Returns true if a given geometry intersects any of the environment objects.
 
@@ -122,7 +122,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment(pybind11::module& aModule)
         .def(
             "access_objects",
             &Environment::accessObjects,
-            return_value_policy::reference,
+            rv_policy::reference,
             R"doc(
                 Access the objects in the environment.
 
@@ -134,7 +134,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment(pybind11::module& aModule)
             "access_object_with_name",
             &Environment::accessObjectWithName,
             arg("name"),
-            return_value_policy::reference,
+            rv_policy::reference,
             R"doc(
                 Access an object with a given name.
 
@@ -149,7 +149,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment(pybind11::module& aModule)
             "access_celestial_object_with_name",
             &Environment::accessCelestialObjectWithName,
             arg("name"),
-            return_value_policy::reference,
+            rv_policy::reference,
             R"doc(
                 Access celestial object with a given name.
 
@@ -163,7 +163,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment(pybind11::module& aModule)
         .def(
             "access_central_celestial_object",
             &Environment::accessCentralCelestialObject,
-            return_value_policy::reference,
+            rv_policy::reference,
             R"doc(
                 Access the central celestial object.
 
@@ -256,7 +256,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment(pybind11::module& aModule)
         .def_static(
             "access_global_instance",
             &Environment::AccessGlobalInstance,
-            return_value_policy::reference,
+            rv_policy::reference,
             R"doc(
                 Access the global environment instance.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric.cpp
@@ -2,7 +2,7 @@
 
 #include <OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth.cpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric(nanobind::module_& aModule)
 {
     // Create "atmospheric" python submodule
     auto atmospheric = aModule.def_submodule("atmospheric");

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth.cpp
@@ -10,9 +10,9 @@
 #include <OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth/Manager.cpp>
 #include <OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth/NRLMSISE00.cpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Real;
     using ostk::core::type::Shared;
@@ -28,7 +28,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth(pybind11::mo
     using ostk::physics::unit::Length;
 
     {
-        class_<Earth, Shared<Earth>> earth_class(
+        class_<Earth> earth_class(
             aModule,
             "Earth",
             R"doc(
@@ -103,9 +103,9 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth(pybind11::mo
                 arg("f107_constant_value") = Earth::defaultF107ConstantValue,
                 arg("f107_average_constant_value") = Earth::defaultF107AConstantValue,
                 arg("kp_constant_value") = Earth::defaultKpConstantValue,
-                arg_v("earth_frame", Frame::ITRF(), "Frame.ITRF()"),
-                arg_v("earth_radius", EarthGravityModel::WGS84.equatorialRadius_, "WGS84.equatorialRadius_"),
-                arg_v("earth_flattening", EarthGravityModel::WGS84.flattening_, "WGS84.flattening_"),
+                arg("earth_frame").sig("Frame.ITRF()") = Frame::ITRF(),
+                arg("earth_radius").sig("WGS84.equatorialRadius_") = EarthGravityModel::WGS84.equatorialRadius_,
+                arg("earth_flattening").sig("WGS84.flattening_") = EarthGravityModel::WGS84.flattening_,
                 arg("sun_celestial") = nullptr,
                 R"doc(
                     Constructor.
@@ -143,8 +143,8 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth(pybind11::mo
                 arg("f107_constant_value") = Earth::defaultF107ConstantValue,
                 arg("f107_average_constant_value") = Earth::defaultF107AConstantValue,
                 arg("kp_constant_value") = Earth::defaultKpConstantValue,
-                arg_v("earth_radius", EarthGravityModel::WGS84.equatorialRadius_, "WGS84.equatorialRadius_"),
-                arg_v("earth_flattening", EarthGravityModel::WGS84.flattening_, "WGS84.flattening_"),
+                arg("earth_radius").sig("WGS84.equatorialRadius_") = EarthGravityModel::WGS84.equatorialRadius_,
+                arg("earth_flattening").sig("WGS84.flattening_") = EarthGravityModel::WGS84.flattening_,
                 arg("sun_celestial") = nullptr,
                 R"doc(
                     Constructor, with the Earth frame as second argument.
@@ -200,7 +200,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth(pybind11::mo
 
             .def(
                 "get_density_at",
-                pybind11::overload_cast<const Position&, const Instant&>(&Earth::getDensityAt, pybind11::const_),
+                nanobind::overload_cast<const Position&, const Instant&>(&Earth::getDensityAt, nanobind::const_),
                 arg("position"),
                 arg("instant"),
                 R"doc(
@@ -217,7 +217,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth(pybind11::mo
 
             .def(
                 "get_density_at",
-                pybind11::overload_cast<const LLA&, const Instant&>(&Earth::getDensityAt, pybind11::const_),
+                nanobind::overload_cast<const LLA&, const Instant&>(&Earth::getDensityAt, nanobind::const_),
                 arg("lla"),
                 arg("instant"),
                 R"doc(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth/CSSISpaceWeather.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth/CSSISpaceWeather.cpp
@@ -1,12 +1,12 @@
 /// Apache License 2.0
 
-#include <pybind11/functional.h>
+#include <nanobind/stl/function.h>
 
 #include <OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/CSSISpaceWeather.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth_CSSISpaceWeather(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth_CSSISpaceWeather(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Shared;
 
@@ -206,7 +206,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth_CSSISpaceWea
         )doc"
     )
 
-        .def_readonly(
+        .def_ro(
             "date",
             &CSSISpaceWeather::Reading::date,
             R"doc(
@@ -214,7 +214,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth_CSSISpaceWea
 
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "bsrn",
             &CSSISpaceWeather::Reading::BSRN,
             R"doc(
@@ -222,7 +222,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth_CSSISpaceWea
 
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "nd",
             &CSSISpaceWeather::Reading::ND,
             R"doc(
@@ -230,7 +230,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth_CSSISpaceWea
 
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "kp_1",
             &CSSISpaceWeather::Reading::Kp1,
             R"doc(
@@ -238,14 +238,14 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth_CSSISpaceWea
                 
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "kp_2",
             &CSSISpaceWeather::Reading::Kp2,
             R"doc(
                 Planetary 3-hour Range Index (Kp) for 0300-0600 UT.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "kp_3",
             &CSSISpaceWeather::Reading::Kp3,
             R"doc(
@@ -253,147 +253,147 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth_CSSISpaceWea
 
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "kp_4",
             &CSSISpaceWeather::Reading::Kp4,
             R"doc(
                 Planetary 3-hour Range Index (Kp) for 0900-1200 UT.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "kp_5",
             &CSSISpaceWeather::Reading::Kp5,
             R"doc(
                 Planetary 3-hour Range Index (Kp) for 1200-1500 UT.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "kp_6",
             &CSSISpaceWeather::Reading::Kp6,
             R"doc(
                 Planetary 3-hour Range Index (Kp) for 1500-1800 UT.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "kp_7",
             &CSSISpaceWeather::Reading::Kp7,
             R"doc(
                 Planetary 3-hour Range Index (Kp) for 1800-2100 UT.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "kp_8",
             &CSSISpaceWeather::Reading::Kp8,
             R"doc(
                 Planetary 3-hour Range Index (Kp) for 2100-0000 UT.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "kp_sum",
             &CSSISpaceWeather::Reading::KpSum,
             R"doc(
                 Sum of the 8 Kp indices for the day.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "ap_1",
             &CSSISpaceWeather::Reading::Ap1,
             R"doc(
                 Planetary Equivalent Amplitude (Ap) for 0000-0300 UT.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "ap_2",
             &CSSISpaceWeather::Reading::Ap2,
             R"doc(
                 Planetary Equivalent Amplitude (Ap) for 0300-0600 UT.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "ap_3",
             &CSSISpaceWeather::Reading::Ap3,
             R"doc(
                 Planetary Equivalent Amplitude (Ap) for 0600-0900 UT.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "ap_4",
             &CSSISpaceWeather::Reading::Ap4,
             R"doc(
                 Planetary Equivalent Amplitude (Ap) for 0900-1200 UT.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "ap_5",
             &CSSISpaceWeather::Reading::Ap5,
             R"doc(
                 Planetary Equivalent Amplitude (Ap) for 1200-1500 UT.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "ap_6",
             &CSSISpaceWeather::Reading::Ap6,
             R"doc(
                 Planetary Equivalent Amplitude (Ap) for 1500-1800 UT.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "ap_7",
             &CSSISpaceWeather::Reading::Ap7,
             R"doc(
                 Planetary Equivalent Amplitude (Ap) for 1800-2100 UT.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "ap_8",
             &CSSISpaceWeather::Reading::Ap8,
             R"doc(
                 Planetary Equivalent Amplitude (Ap) for 2100-0000 UT.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "ap_avg",
             &CSSISpaceWeather::Reading::ApAvg,
             R"doc(
                 Arithmetic average of the 8 Ap indices for the day.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "cp",
             &CSSISpaceWeather::Reading::Cp,
             R"doc(
                 Cp or Planetary Daily Character Figure. A qualitative estimate of overall level of magnetic activity for the day determined from the sum of the 8 Ap indices. Cp ranges, in steps of one-tenth, from 0 (quiet) to 2.5 (highly disturbed).
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "c9",
             &CSSISpaceWeather::Reading::C9,
             R"doc(
                 C9. A conversion of the 0-to-2.5 range of the Cp index to one digit between 0 and 9.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "isn",
             &CSSISpaceWeather::Reading::ISN,
             R"doc(
                 International Sunspot Number. Records contain the Zurich number through 1980 Dec 31 and the International Brussels number thereafter.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "f107_obs",
             &CSSISpaceWeather::Reading::F107Obs,
             R"doc(
                 Observed 10.7-cm Solar Radio Flux (F10.7). Measured at Ottawa at 1700 UT daily from 1947 Feb 14 until 1991 May 31 and measured at Penticton at 2000 UT from 1991 Jun 01 on. Expressed in units of 10-22 W/m2/Hz.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "f107_adj",
             &CSSISpaceWeather::Reading::F107Adj,
             R"doc(
                 10.7-cm Solar Radio Flux (F10.7) adjusted to 1 AU.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "f107_data_type",
             &CSSISpaceWeather::Reading::F107DataType,
             R"doc(
@@ -404,28 +404,28 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth_CSSISpaceWea
                 - PRM: Monthly predicted flux.
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "f107_obs_center_81",
             &CSSISpaceWeather::Reading::F107ObsCenter81,
             R"doc(
                 Centered 81-day arithmetic average of F107 (observed).
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "f107_obs_last_81",
             &CSSISpaceWeather::Reading::F107ObsLast81,
             R"doc(
                 Last 81-day arithmetic average of F107 (observed).
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "f107_adj_center_81",
             &CSSISpaceWeather::Reading::F107AdjCenter81,
             R"doc(
                 Centered 81-day arithmetic average of F10.7 (adjusted).
             )doc"
         )
-        .def_readonly(
+        .def_ro(
             "f107_adj_last_81",
             &CSSISpaceWeather::Reading::F107AdjLast81,
             R"doc(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth/Exponential.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth/Exponential.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/Exponential.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth_Exponential(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth_Exponential(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Shared;
 
@@ -13,7 +13,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth_Exponential(
     using ostk::physics::environment::atmospheric::earth::Exponential;
     using ostk::physics::time::Instant;
 
-    class_<Exponential, Shared<Exponential>>(
+    class_<Exponential>(
         aModule,
         "Exponential",
         R"doc(
@@ -37,7 +37,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth_Exponential(
 
         .def(
             "get_density_at",
-            pybind11::overload_cast<const LLA&, const Instant&>(&Exponential::getDensityAt, pybind11::const_),
+            nanobind::overload_cast<const LLA&, const Instant&>(&Exponential::getDensityAt, nanobind::const_),
             arg("lla"),
             arg("instant"),
             R"doc(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth/Manager.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth/Manager.cpp
@@ -3,9 +3,9 @@
 #include <OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/Manager.hpp>
 #include <OpenSpaceToolkit/Physics/Manager.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth_Manager(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth_Manager(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::physics::environment::atmospheric::earth::Manager;
     using BaseManager = ostk::physics::Manager;
@@ -159,7 +159,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth_Manager(pybi
         .def_static(
             "get",
             &Manager::Get,
-            return_value_policy::reference,
+            rv_policy::reference,
             R"doc(
                 Get manager singleton.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth/NRLMSISE00.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Atmospheric/Earth/NRLMSISE00.cpp
@@ -4,9 +4,9 @@
 #include <OpenSpaceToolkit/Physics/Environment/Atmospheric/Earth/NRLMSISE00.hpp>
 #include <OpenSpaceToolkit/Physics/Environment/Object/Celestial.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth_NRLMSISE00(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth_NRLMSISE00(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Real;
     using ostk::core::type::Shared;
@@ -20,7 +20,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth_NRLMSISE00(p
     using EarthAtmosphericModel = ostk::physics::environment::atmospheric::Earth;
     using ostk::physics::environment::atmospheric::earth::NRLMSISE00;
 
-    class_<NRLMSISE00, Shared<NRLMSISE00>> nrlmsise(
+    class_<NRLMSISE00> nrlmsise(
         aModule,
         "NRLMSISE00",
         R"doc(
@@ -62,9 +62,9 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Atmospheric_Earth_NRLMSISE00(p
             arg("f107_constant_value") = EarthAtmosphericModel::defaultF107ConstantValue,
             arg("f107_average_constant_value") = EarthAtmosphericModel::defaultF107AConstantValue,
             arg("kp_constant_value") = EarthAtmosphericModel::defaultKpConstantValue,
-            arg_v("earth_frame", Frame::ITRF(), "Frame.ITRF()"),
-            arg_v("earth_radius", EarthGravityModel::WGS84.equatorialRadius_, "WGS84.equatorialRadius_"),
-            arg_v("earth_flattening", EarthGravityModel::WGS84.flattening_, "WGS84.flattening_"),
+            arg("earth_frame").sig("Frame.ITRF()") = Frame::ITRF(),
+            arg("earth_radius").sig("WGS84.equatorialRadius_") = EarthGravityModel::WGS84.equatorialRadius_,
+            arg("earth_flattening").sig("WGS84.flattening_") = EarthGravityModel::WGS84.flattening_,
             arg("sun_celestial") = nullptr,
             R"doc(
                 Constructor.

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Ephemeris.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Ephemeris.cpp
@@ -1,11 +1,13 @@
 /// Apache License 2.0
 
+#include <nanobind/trampoline.h>
+
 #include <OpenSpaceToolkit/Physics/Environment/Ephemeris.hpp>
 
 #include <OpenSpaceToolkitPhysicsPy/Environment/Ephemeris/Analytical.cpp>
 #include <OpenSpaceToolkitPhysicsPy/Environment/Ephemeris/SPICE.cpp>
 
-using namespace pybind11;
+using namespace nanobind;
 
 using ostk::core::type::Shared;
 
@@ -15,29 +17,29 @@ using ostk::physics::environment::Ephemeris;
 class PyEphemeris : public Ephemeris
 {
    public:
-    using Ephemeris::Ephemeris;
+    NB_TRAMPOLINE(Ephemeris, 3);
 
     // Trampoline (need one for each virtual function)
 
     Ephemeris* clone() const override
     {
-        PYBIND11_OVERRIDE_PURE_NAME(Ephemeris*, Ephemeris, "clone", clone);
+        NB_OVERRIDE_PURE_NAME("clone", clone);
     }
 
     bool isDefined() const override
     {
-        PYBIND11_OVERRIDE_PURE_NAME(bool, Ephemeris, "is_defined", isDefined);
+        NB_OVERRIDE_PURE_NAME("is_defined", isDefined);
     }
 
     Shared<const Frame> accessFrame() const override
     {
-        PYBIND11_OVERRIDE_PURE_NAME(Shared<const Frame>, Ephemeris, "access_frame", accessFrame);
+        NB_OVERRIDE_PURE_NAME("access_frame", accessFrame);
     }
 };
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Ephemeris(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Ephemeris(nanobind::module_& aModule)
 {
-    class_<Ephemeris, PyEphemeris, Shared<Ephemeris>>(
+    class_<Ephemeris, PyEphemeris>(
         aModule,
         "Ephemeris",
         R"doc(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Ephemeris/Analytical.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Ephemeris/Analytical.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Environment/Ephemeris/Analytical.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Ephemeris_Analytical(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Ephemeris_Analytical(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Shared;
 
@@ -12,7 +12,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Ephemeris_Analytical(pybind11:
     using ostk::physics::environment::Ephemeris;
     using ostk::physics::environment::ephemeris::Analytical;
 
-    class_<Analytical, Shared<Analytical>, Ephemeris>(
+    class_<Analytical, Ephemeris>(
         aModule,
         "Analytical",
         R"doc(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Ephemeris/SPICE.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Ephemeris/SPICE.cpp
@@ -6,9 +6,9 @@
 #include <OpenSpaceToolkitPhysicsPy/Environment/Ephemeris/SPICE/Kernel.cpp>
 #include <OpenSpaceToolkitPhysicsPy/Environment/Ephemeris/SPICE/Manager.cpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Ephemeris_SPICE(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Ephemeris_SPICE(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Shared;
 
@@ -16,7 +16,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Ephemeris_SPICE(pybind11::modu
     using ostk::physics::environment::Ephemeris;
     using ostk::physics::environment::ephemeris::SPICE;
 
-    class_<SPICE, Shared<SPICE>, Ephemeris> spice_class(
+    class_<SPICE, Ephemeris> spice_class(
         aModule,
         "SPICE",
         R"doc(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Ephemeris/SPICE/Engine.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Ephemeris/SPICE/Engine.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Engine.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Ephemeris_SPICE_Engine(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Ephemeris_SPICE_Engine(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::container::Array;
     using ostk::core::type::Shared;
@@ -134,7 +134,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Ephemeris_SPICE_Engine(pybind1
         .def_static(
             "get",
             &Engine::Get,
-            return_value_policy::reference,
+            rv_policy::reference,
             R"doc(
                 Get the engine singleton.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Ephemeris/SPICE/Kernel.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Ephemeris/SPICE/Kernel.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Kernel.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Ephemeris_SPICE_Kernel(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Ephemeris_SPICE_Kernel(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::filesystem::File;
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Ephemeris/SPICE/Manager.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Ephemeris/SPICE/Manager.cpp
@@ -3,9 +3,9 @@
 #include <OpenSpaceToolkit/Physics/Environment/Ephemeris/SPICE/Manager.hpp>
 #include <OpenSpaceToolkit/Physics/Manager.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Ephemeris_SPICE_Manager(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Ephemeris_SPICE_Manager(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::container::Array;
     using ostk::core::filesystem::Path;
@@ -97,7 +97,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Ephemeris_SPICE_Manager(pybind
         .def_static(
             "get",
             &Manager::Get,
-            return_value_policy::reference,
+            rv_policy::reference,
             R"doc(
                 Get the manager singleton.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational.cpp
@@ -6,7 +6,7 @@
 #include <OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Spherical.cpp>
 #include <OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Sun.cpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational(nanobind::module_& aModule)
 {
     // Create "gravitational" python submodule
     auto gravitational = aModule.def_submodule("gravitational");

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Earth.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Earth.cpp
@@ -4,9 +4,9 @@
 
 #include <OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Earth/Manager.cpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Earth(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Earth(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::filesystem::Directory;
     using ostk::core::type::Integer;
@@ -17,7 +17,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Earth(pybind11::
     using ostk::physics::environment::gravitational::Model;
 
     {
-        class_<Earth, Model, Shared<Earth>> earth_class(
+        class_<Earth, Model> earth_class(
             aModule,
             "Earth",
             R"doc(
@@ -159,28 +159,28 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Earth(pybind11::
                 )doc"
             )
 
-            .def_readonly_static(
+            .def_ro_static(
                 "EGM2008",
                 &Earth::EGM2008,
                 R"doc(
                     The Earth Gravity Model 2008, which includes terms up to degree 2190.
                 )doc"
             )
-            .def_readonly_static(
+            .def_ro_static(
                 "EGM96",
                 &Earth::EGM96,
                 R"doc(
                     The Earth Gravity Model 1996, which includes terms up to degree 360.
                 )doc"
             )
-            .def_readonly_static(
+            .def_ro_static(
                 "EGM84",
                 &Earth::EGM84,
                 R"doc(
                     The Earth Gravity Model 1984, which includes terms up to degree 180.
                 )doc"
             )
-            .def_readonly_static(
+            .def_ro_static(
                 "WGS84_EGM96",
                 &Earth::WGS84_EGM96,
                 R"doc(
@@ -188,21 +188,21 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Earth(pybind11::
                     which includes terms up to degree 360.
                 )doc"
             )
-            .def_readonly_static(
+            .def_ro_static(
                 "WGS84",
                 &Earth::WGS84,
                 R"doc(
                     The normal gravitational field for the reference ellipsoid. This includes the zonal coefficients up to order 20.
                 )doc"
             )
-            .def_readonly_static(
+            .def_ro_static(
                 "spherical",
                 &Earth::Spherical,
                 R"doc(
                     The spherical gravity originating from a point source at the center of the Earth.
                 )doc"
             )
-            .def_readonly_static(
+            .def_ro_static(
                 "gravity_constant",
                 &Earth::gravityConstant,
                 R"doc(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Earth/Manager.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Earth/Manager.cpp
@@ -3,9 +3,9 @@
 #include <OpenSpaceToolkit/Physics/Environment/Gravitational/Earth/Manager.hpp>
 #include <OpenSpaceToolkit/Physics/Manager.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Earth_Manager(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Earth_Manager(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::physics::environment::gravitational::earth::Manager;
     using BaseManager = ostk::physics::Manager;
@@ -70,7 +70,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Earth_Manager(py
         .def_static(
             "get",
             &Manager::Get,
-            return_value_policy::reference,
+            rv_policy::reference,
             R"doc(
                 Get manager singleton.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Model.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Model.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Environment/Gravitational/Model.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Model(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Model(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Real;
     using ostk::core::type::Shared;
@@ -14,7 +14,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Model(pybind11::
     using ostk::physics::unit::Length;
 
     {
-        class_<Model, Shared<Model>>(
+        class_<Model>(
             aModule,
             "Model",
             R"doc(
@@ -89,7 +89,12 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Model(pybind11::
             )
 
             .def(
-                self == self,
+                "__eq__",
+                [](const Model::Parameters& self, const Model::Parameters& other)
+                {
+                    return self == other;
+                },
+                nanobind::is_operator(),
                 R"doc(
                     Equal to operator
                     
@@ -101,7 +106,12 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Model(pybind11::
                 )doc"
             )
             .def(
-                self != self,
+                "__ne__",
+                [](const Model::Parameters& self, const Model::Parameters& other)
+                {
+                    return self != other;
+                },
+                nanobind::is_operator(),
                 R"doc(
                     Not equal to operator
                     
@@ -142,63 +152,63 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Model(pybind11::
                 )doc"
             )
 
-            .def_readwrite(
+            .def_rw(
                 "gravitational_parameter",
                 &Model::Parameters::gravitationalParameter_,
                 R"doc(
                     Gravitational parameter [m^3/s^2].
                 )doc"
             )
-            .def_readwrite(
+            .def_rw(
                 "equatorial_radius",
                 &Model::Parameters::equatorialRadius_,
                 R"doc(
                     Equatorial radius [m].
                 )doc"
             )
-            .def_readwrite(
+            .def_rw(
                 "flattening",
                 &Model::Parameters::flattening_,
                 R"doc(
                     Flattening.
                 )doc"
             )
-            .def_readwrite(
+            .def_rw(
                 "J2",
                 &Model::Parameters::J2_,
                 R"doc(
                     J2.
                 )doc"
             )
-            .def_readwrite(
+            .def_rw(
                 "J3",
                 &Model::Parameters::J3_,
                 R"doc(
                     J3.
                 )doc"
             )
-            .def_readwrite(
+            .def_rw(
                 "J4",
                 &Model::Parameters::J4_,
                 R"doc(
                     J4.
                 )doc"
             )
-            .def_readwrite(
+            .def_rw(
                 "C20",
                 &Model::Parameters::C20_,
                 R"doc(
                     C20.
                 )doc"
             )
-            .def_readwrite(
+            .def_rw(
                 "C30",
                 &Model::Parameters::C30_,
                 R"doc(
                     C30.
                 )doc"
             )
-            .def_readwrite(
+            .def_rw(
                 "C40",
                 &Model::Parameters::C40_,
                 R"doc(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Moon.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Moon.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Environment/Gravitational/Moon.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Moon(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Moon(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::filesystem::Directory;
     using ostk::core::type::Shared;
@@ -13,7 +13,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Moon(pybind11::m
     using ostk::physics::environment::gravitational::Moon;
 
     {
-        class_<Moon, Shared<Moon>, Model> moon_class(
+        class_<Moon, Model> moon_class(
             aModule,
             "Moon",
             R"doc(
@@ -99,7 +99,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Moon(pybind11::m
                 )doc"
             )
 
-            .def_readonly_static(
+            .def_ro_static(
                 "spherical",
                 &Moon::Spherical,
                 R"doc(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Spherical.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Spherical.cpp
@@ -2,16 +2,16 @@
 
 #include <OpenSpaceToolkit/Physics/Environment/Gravitational/Spherical.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Spherical(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Spherical(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Shared;
 
     using ostk::physics::environment::gravitational::Model;
     using ostk::physics::environment::gravitational::Spherical;
 
-    class_<Spherical, Model, Shared<Spherical>>(
+    class_<Spherical, Model>(
         aModule,
         "Spherical",
         R"doc(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Sun.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Gravitational/Sun.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Environment/Gravitational/Sun.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Sun(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Sun(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::filesystem::Directory;
     using ostk::core::type::Shared;
@@ -13,7 +13,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Sun(pybind11::mo
     using ostk::physics::environment::gravitational::Sun;
 
     {
-        class_<Sun, Model, Shared<Sun>> sun_class(
+        class_<Sun, Model> sun_class(
             aModule,
             "Sun",
             R"doc(
@@ -92,7 +92,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Gravitational_Sun(pybind11::mo
                 )doc"
             )
 
-            .def_readonly_static(
+            .def_ro_static(
                 "spherical",
                 &Sun::Spherical,
                 R"doc(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Magnetic.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Magnetic.cpp
@@ -3,7 +3,7 @@
 #include <OpenSpaceToolkitPhysicsPy/Environment/Magnetic/Dipole.cpp>
 #include <OpenSpaceToolkitPhysicsPy/Environment/Magnetic/Earth.cpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Magnetic(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Magnetic(nanobind::module_& aModule)
 {
     // Create "magnetic" python submodule
     auto magnetic = aModule.def_submodule("magnetic");

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Magnetic/Dipole.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Magnetic/Dipole.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Environment/Magnetic/Dipole.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Magnetic_Dipole(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Magnetic_Dipole(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::mathematics::object::Vector3d;
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Magnetic/Earth.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Magnetic/Earth.cpp
@@ -5,9 +5,9 @@
 
 #include <OpenSpaceToolkitPhysicsPy/Environment/Magnetic/Earth/Manager.cpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Magnetic_Earth(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Magnetic_Earth(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::filesystem::Directory;
     using ostk::core::type::Shared;
@@ -16,7 +16,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Magnetic_Earth(pybind11::modul
     using ostk::physics::environment::magnetic::earth::Manager;
     using ostk::physics::unit::Derived;
 
-    class_<Earth, Shared<Earth>> earth_magnetic_class(
+    class_<Earth> earth_magnetic_class(
         aModule,
         "Earth",
         R"doc(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Magnetic/Earth/Manager.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Magnetic/Earth/Manager.cpp
@@ -3,9 +3,9 @@
 #include <OpenSpaceToolkit/Physics/Environment/Magnetic/Earth/Manager.hpp>
 #include <OpenSpaceToolkit/Physics/Manager.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Magnetic_Earth_Manager(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Magnetic_Earth_Manager(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::physics::environment::magnetic::earth::Manager;
     using BaseManager = ostk::physics::Manager;
@@ -70,7 +70,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Magnetic_Earth_Manager(pybind1
         .def_static(
             "get",
             &Manager::Get,
-            return_value_policy::reference,
+            rv_policy::reference,
             R"doc(
                 Get manager singleton
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Object.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Object.cpp
@@ -5,9 +5,9 @@
 #include <OpenSpaceToolkitPhysicsPy/Environment/Object/Celestial.cpp>
 #include <OpenSpaceToolkitPhysicsPy/Environment/Object/Geometry.cpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Object(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Object(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Shared;
     using ostk::core::type::String;
@@ -16,7 +16,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Object(pybind11::module& aModu
     using ostk::physics::time::Instant;
 
     // Binding class "Object"
-    class_<Object, Shared<Object>>(
+    class_<Object>(
         aModule,
         "Object",
         R"doc(
@@ -51,7 +51,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Object(pybind11::module& aModu
         .def(
             "access_name",
             &Object::accessName,
-            return_value_policy::reference,
+            rv_policy::reference,
             R"doc(
                 Accesses the name of the Object.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Object/Celestial.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Object/Celestial.cpp
@@ -6,9 +6,9 @@
 #include <OpenSpaceToolkitPhysicsPy/Environment/Object/Celestial/Moon.cpp>
 #include <OpenSpaceToolkitPhysicsPy/Environment/Object/Celestial/Sun.cpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Celestial(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Celestial(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Real;
     using ostk::core::type::Shared;
@@ -24,7 +24,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Celestial(pybind11::mod
     using MagneticModel = ostk::physics::environment::magnetic::Model;
     using AtmosphericModel = ostk::physics::environment::atmospheric::Model;
 
-    class_<Celestial, Shared<Celestial>, Object> celestial_class(
+    class_<Celestial, Object> celestial_class(
         aModule,
         "Celestial",
         R"doc(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Object/Celestial/Earth.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Object/Celestial/Earth.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Environment/Object/Celestial/Earth.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Celestial_Earth(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Celestial_Earth(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Integer;
     using ostk::core::type::Real;
@@ -23,7 +23,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Celestial_Earth(pybind1
     using EarthAtmosphericModel = ostk::physics::environment::atmospheric::Earth;
 
     {
-        class_<Earth, Celestial, Shared<Earth>>(
+        class_<Earth, Celestial>(
             aModule,
             "Earth",
             R"doc(
@@ -75,9 +75,9 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Celestial_Earth(pybind1
                     const Shared<EarthMagneticModel>&,
                     const Shared<EarthAtmosphericModel>&>(),
                 arg("ephemeris"),
-                arg("gravitational_model") = pybind11::none(),
-                arg("magnetic_model") = pybind11::none(),
-                arg("atmospheric_model") = pybind11::none(),
+                arg("gravitational_model") = nanobind::none(),
+                arg("magnetic_model") = nanobind::none(),
+                arg("atmospheric_model") = nanobind::none(),
                 R"doc(
                     Constructor
 
@@ -106,8 +106,8 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Celestial_Earth(pybind1
             .def_static(
                 "EGM2008",
                 &Earth::EGM2008,
-                arg_v("degree", Integer::Undefined(), "Integer.undefined()"),
-                arg_v("order", Integer::Undefined(), "Integer.undefined()"),
+                arg("degree").sig("Integer.undefined()") = Integer::Undefined(),
+                arg("order").sig("Integer.undefined()") = Integer::Undefined(),
                 R"doc(
                     Earth Gravity Model 2008 model (EGM2008).
 
@@ -123,8 +123,8 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Celestial_Earth(pybind1
             .def_static(
                 "WGS84_EGM96",
                 &Earth::WGS84_EGM96,
-                arg_v("degree", Integer::Undefined(), "Integer.undefined()"),
-                arg_v("order", Integer::Undefined(), "Integer.undefined()"),
+                arg("degree").sig("Integer.undefined()") = Integer::Undefined(),
+                arg("order").sig("Integer.undefined()") = Integer::Undefined(),
                 R"doc(
                     World Geodetic System 1984 (WGS84) + Earth Gravity Model 1996 (EGM96).
 
@@ -144,8 +144,8 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Celestial_Earth(pybind1
             .def_static(
                 "EGM96",
                 &Earth::EGM96,
-                arg_v("degree", Integer::Undefined(), "Integer.undefined()"),
-                arg_v("order", Integer::Undefined(), "Integer.undefined()"),
+                arg("degree").sig("Integer.undefined()") = Integer::Undefined(),
+                arg("order").sig("Integer.undefined()") = Integer::Undefined(),
                 R"doc(
                     Earth Gravity Model 1996 (EGM96).
 
@@ -160,8 +160,8 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Celestial_Earth(pybind1
             .def_static(
                 "EGM84",
                 &Earth::EGM84,
-                arg_v("degree", Integer::Undefined(), "Integer.undefined()"),
-                arg_v("order", Integer::Undefined(), "Integer.undefined()"),
+                arg("degree").sig("Integer.undefined()") = Integer::Undefined(),
+                arg("order").sig("Integer.undefined()") = Integer::Undefined(),
                 R"doc(
                     Earth Gravity Model 1984 (EGM84).
 
@@ -176,8 +176,8 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Celestial_Earth(pybind1
             .def_static(
                 "WGS84",
                 &Earth::WGS84,
-                arg_v("degree", Integer::Undefined(), "Integer.undefined()"),
-                arg_v("order", Integer::Undefined(), "Integer.undefined()"),
+                arg("degree").sig("Integer.undefined()") = Integer::Undefined(),
+                arg("order").sig("Integer.undefined()") = Integer::Undefined(),
                 R"doc(
                     World Geodetic System 1984 (WGS84).
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Object/Celestial/Moon.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Object/Celestial/Moon.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Environment/Object/Celestial/Moon.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Celestial_Moon(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Celestial_Moon(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Shared;
 
@@ -15,7 +15,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Celestial_Moon(pybind11
     using MoonGravitationalModel = ostk::physics::environment::gravitational::Moon;
 
     {
-        class_<Moon, Shared<Moon>, Celestial>(
+        class_<Moon, Celestial>(
             aModule,
             "Moon",
             R"doc(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Object/Celestial/Sun.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Object/Celestial/Sun.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Environment/Object/Celestial/Sun.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Celestial_Sun(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Celestial_Sun(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Shared;
 
@@ -15,7 +15,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Celestial_Sun(pybind11:
     using SunGravitationalModel = ostk::physics::environment::gravitational::Sun;
 
     {
-        class_<Sun, Shared<Sun>, Celestial>(
+        class_<Sun, Celestial>(
             aModule,
             "Sun",
             R"doc(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Object/Geometry.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Object/Geometry.cpp
@@ -14,9 +14,9 @@
 
 #include <OpenSpaceToolkit/Physics/Environment/Object/Geometry.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Geometry(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Geometry(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Shared;
     using ostk::core::type::Unique;
@@ -50,8 +50,22 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Geometry(pybind11::modu
         .def(init<const Composite&, const Shared<const Frame>&>())
         .def(init<const Geometry::Object&, const Shared<const Frame>&>())
 
-        .def(self == self)
-        .def(self != self)
+        .def(
+            "__eq__",
+            [](const Geometry& self, const Geometry& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__ne__",
+            [](const Geometry& self, const Geometry& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator()
+        )
 
         .def("__str__", &(shiftToString<Geometry>))
         .def("__repr__", &(shiftToString<Geometry>))
@@ -97,7 +111,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Object_Geometry(pybind11::modu
         .def(
             "access_composite",
             &Geometry::accessComposite,
-            return_value_policy::reference,
+            rv_policy::reference,
             R"doc(
                 Access composite.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Utility.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Utility.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkitPhysicsPy/Environment/Utility/Eclipse.cpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Utility(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Utility(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     // Create "utility" python submodule
     auto utility = aModule.def_submodule("utility");

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Utility/Eclipse.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Environment/Utility/Eclipse.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Environment/Utility/Eclipse.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Environment_Utility_Eclipse(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Environment_Utility_Eclipse(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::container::Array;
     using ostk::core::type::Real;
@@ -55,7 +55,12 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Utility_Eclipse(pybind11::modu
         )
 
         .def(
-            self == self,
+            "__eq__",
+            [](const EclipsePhase& self, const EclipsePhase& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator(),
             R"doc(
                 Equality operator.
 
@@ -67,7 +72,12 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Utility_Eclipse(pybind11::modu
             )doc"
         )
         .def(
-            self != self,
+            "__ne__",
+            [](const EclipsePhase& self, const EclipsePhase& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator(),
             R"doc(
                 Inequality operator.
 
@@ -85,7 +95,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Utility_Eclipse(pybind11::modu
         .def(
             "get_region",
             &EclipsePhase::getRegion,
-            return_value_policy::reference_internal,
+            rv_policy::reference_internal,
             R"doc(
                 The region of the eclipse phase (Umbra or Penumbra).
             )doc"
@@ -94,7 +104,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Utility_Eclipse(pybind11::modu
         .def(
             "get_interval",
             &EclipsePhase::getInterval,
-            return_value_policy::reference_internal,
+            rv_policy::reference_internal,
             R"doc(
                 The time interval of the phase.
             )doc"
@@ -146,7 +156,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Utility_Eclipse(pybind11::modu
         .def(
             "get_occulted_celestial_object",
             &Eclipse::accessOccultedCelestialObject,
-            return_value_policy::reference_internal,
+            rv_policy::reference_internal,
             R"doc(
                 Get the occulted celestial object.
 
@@ -158,7 +168,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Utility_Eclipse(pybind11::modu
         .def(
             "get_occulting_celestial_object",
             &Eclipse::accessOccultingCelestialObject,
-            return_value_policy::reference_internal,
+            rv_policy::reference_internal,
             R"doc(
                 Get the occulting celestial object.
 
@@ -170,7 +180,7 @@ inline void OpenSpaceToolkitPhysicsPy_Environment_Utility_Eclipse(pybind11::modu
         .def(
             "get_phases",
             &Eclipse::getPhases,
-            return_value_policy::reference_internal,
+            rv_policy::reference_internal,
             R"doc(
                 Get the phases of the eclipse.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Manager.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Manager.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Manager.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Manager(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Manager(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::physics::Manager;
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time.cpp
@@ -8,7 +8,7 @@
 #include <OpenSpaceToolkitPhysicsPy/Time/Scale.cpp>
 #include <OpenSpaceToolkitPhysicsPy/Time/Time.cpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Time(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Time(nanobind::module_& aModule)
 {
     // Create "time" python submodule
     auto time = aModule.def_submodule("time");

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/Date.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/Date.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Time/Date.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Time_Date(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Time_Date(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::String;
 
@@ -21,8 +21,22 @@ inline void OpenSpaceToolkitPhysicsPy_Time_Date(pybind11::module& aModule)
     date_class
         .def(init<int, int, int>())
 
-        .def(self == self)
-        .def(self != self)
+        .def(
+            "__eq__",
+            [](const Date& self, const Date& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__ne__",
+            [](const Date& self, const Date& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator()
+        )
 
         .def("__str__", &(shiftToString<Date>))
         .def(
@@ -192,7 +206,7 @@ inline void OpenSpaceToolkitPhysicsPy_Time_Date(pybind11::module& aModule)
 
         );
 
-    enum_<Date::Format>(date_class, "Format", pybind11::module_local())
+    enum_<Date::Format>(date_class, "Format")
 
         .value(
             "Undefined",
@@ -218,5 +232,5 @@ inline void OpenSpaceToolkitPhysicsPy_Time_Date(pybind11::module& aModule)
 
         ;
 
-    date_class.def_static("parse", &Date::Parse, "aString"_a, "aFormat"_a = Date::Format::Undefined);
+    date_class.def_static("parse", &Date::Parse, arg("aString"), arg("aFormat") = Date::Format::Undefined);
 }

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/DateTime.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/DateTime.cpp
@@ -4,9 +4,9 @@
 
 #include <OpenSpaceToolkit/Physics/Time/DateTime.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Time_DateTime(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Time_DateTime(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::String;
 
@@ -64,8 +64,22 @@ inline void OpenSpaceToolkitPhysicsPy_Time_DateTime(pybind11::module& aModule)
             )doc"
         )
 
-        .def(self == self)
-        .def(self != self)
+        .def(
+            "__eq__",
+            [](const DateTime& self, const DateTime& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__ne__",
+            [](const DateTime& self, const DateTime& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator()
+        )
 
         .def("__str__", &(shiftToString<DateTime>))
         .def(
@@ -259,7 +273,7 @@ inline void OpenSpaceToolkitPhysicsPy_Time_DateTime(pybind11::module& aModule)
 
         ;
 
-    // https://pybind11.readthedocs.io/en/stable/advanced/functions.html#default-arguments-revisited
+    // https://nanobind.readthedocs.io/en/stable/advanced/functions.html#default-arguments-revisited
     // "default arguments are converted to Python objects right at declaration time"
     // The following parsing function requires DateTime::Format to be binded for proper declaration
     datetime_class.def_static("parse", &DateTime::Parse, arg("string"), arg("format") = DateTime::Format::Undefined);

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/Duration.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/Duration.cpp
@@ -4,9 +4,9 @@
 
 #include <OpenSpaceToolkit/Physics/Time/Duration.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Time_Duration(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Time_Duration(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::String;
 
@@ -22,13 +22,13 @@ inline void OpenSpaceToolkitPhysicsPy_Time_Duration(pybind11::module& aModule)
 
     duration_class
 
+        // nanobind has no `init(factory)`; a placement-new `__init__` is the equivalent.
         .def(
-            init(
-                [](const std::chrono::microseconds& aCount)
-                {
-                    return new Duration(aCount.count() * 1000);
-                }
-            ),
+            "__init__",
+            [](Duration* aDurationPtr, const std::chrono::microseconds& aCount)
+            {
+                new (aDurationPtr) Duration(aCount.count() * 1000);
+            },
             R"doc(
                 Constructor.
                 Args:
@@ -46,24 +46,137 @@ inline void OpenSpaceToolkitPhysicsPy_Time_Duration(pybind11::module& aModule)
             )doc"
         )
 
-        .def(self == self)
-        .def(self != self)
+        .def(
+            "__eq__",
+            [](const Duration& self, const Duration& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__ne__",
+            [](const Duration& self, const Duration& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator()
+        )
 
-        .def(self < self)
-        .def(self <= self)
-        .def(self > self)
-        .def(self >= self)
+        .def(
+            "__lt__",
+            [](const Duration& self, const Duration& other)
+            {
+                return self < other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__le__",
+            [](const Duration& self, const Duration& other)
+            {
+                return self <= other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__gt__",
+            [](const Duration& self, const Duration& other)
+            {
+                return self > other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__ge__",
+            [](const Duration& self, const Duration& other)
+            {
+                return self >= other;
+            },
+            nanobind::is_operator()
+        )
 
-        .def(self + self)
-        .def(self - self)
-        .def(self * double())
-        .def(self / double())
-        .def(double() * self)
+        .def(
+            "__add__",
+            [](const Duration& self, const Duration& other)
+            {
+                return self + other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__sub__",
+            [](const Duration& self, const Duration& other)
+            {
+                return self - other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__mul__",
+            [](const Duration& self, const double& other)
+            {
+                return self * other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__truediv__",
+            [](const Duration& self, const double& other)
+            {
+                return self / other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__rmul__",
+            [](const Duration& self, const double& other)
+            {
+                return other * self;
+            },
+            nanobind::is_operator()
+        )
 
-        .def(self += self)
-        .def(self -= self)
-        .def(self *= double())
-        .def(self /= double())
+        .def(
+            "__iadd__",
+            [](Duration& self, const Duration& other) -> Duration&
+            {
+                self += other;
+                return self;
+            },
+            nanobind::rv_policy::none,
+            nanobind::is_operator()
+        )
+        .def(
+            "__isub__",
+            [](Duration& self, const Duration& other) -> Duration&
+            {
+                self -= other;
+                return self;
+            },
+            nanobind::rv_policy::none,
+            nanobind::is_operator()
+        )
+        .def(
+            "__imul__",
+            [](Duration& self, const double& other) -> Duration&
+            {
+                self *= other;
+                return self;
+            },
+            nanobind::rv_policy::none,
+            nanobind::is_operator()
+        )
+        .def(
+            "__itruediv__",
+            [](Duration& self, const double& other) -> Duration&
+            {
+                self /= other;
+                return self;
+            },
+            nanobind::rv_policy::none,
+            nanobind::is_operator()
+        )
 
         .def("__str__", &(shiftToString<Duration>))
         .def(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/Instant.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/Instant.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Time/Instant.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Time_Instant(pybind11::module &aModule)
+inline void OpenSpaceToolkitPhysicsPy_Time_Instant(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::String;
 
@@ -21,23 +21,72 @@ inline void OpenSpaceToolkitPhysicsPy_Time_Instant(pybind11::module &aModule)
         )doc"
     )
 
-        .def(self == self)
-        .def(self != self)
+        .def(
+            "__eq__",
+            [](const Instant& self, const Instant& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__ne__",
+            [](const Instant& self, const Instant& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator()
+        )
 
-        .def(self < self)
-        .def(self <= self)
-        .def(self > self)
-        .def(self >= self)
+        .def(
+            "__lt__",
+            [](const Instant& self, const Instant& other)
+            {
+                return self < other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__le__",
+            [](const Instant& self, const Instant& other)
+            {
+                return self <= other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__gt__",
+            [](const Instant& self, const Instant& other)
+            {
+                return self > other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__ge__",
+            [](const Instant& self, const Instant& other)
+            {
+                return self >= other;
+            },
+            nanobind::is_operator()
+        )
 
         // Duration() is private in this context
         // .def(self + Duration())
         // .def(self - Duration())
         // .def(self += Duration())
         // .def(self -= Duration())
-        .def(self - self)
+        .def(
+            "__sub__",
+            [](const Instant& self, const Instant& other)
+            {
+                return self - other;
+            },
+            nanobind::is_operator()
+        )
         .def(
             "__add__",
-            [](const Instant &anInstant, Duration aDuration)
+            [](const Instant& anInstant, Duration aDuration)
             {
                 return anInstant + aDuration;
             },
@@ -45,7 +94,7 @@ inline void OpenSpaceToolkitPhysicsPy_Time_Instant(pybind11::module &aModule)
         )
         .def(
             "__sub__",
-            [](const Instant &anInstant, Duration aDuration)
+            [](const Instant& anInstant, Duration aDuration)
             {
                 return anInstant - aDuration;
             },
@@ -53,7 +102,7 @@ inline void OpenSpaceToolkitPhysicsPy_Time_Instant(pybind11::module &aModule)
         )
         .def(
             "__iadd__",
-            [](const Instant &anInstant, Duration aDuration)
+            [](const Instant& anInstant, Duration aDuration)
             {
                 return anInstant + aDuration;
             },
@@ -61,7 +110,7 @@ inline void OpenSpaceToolkitPhysicsPy_Time_Instant(pybind11::module &aModule)
         )
         .def(
             "__isub__",
-            [](const Instant &anInstant, Duration aDuration)
+            [](const Instant& anInstant, Duration aDuration)
             {
                 return anInstant - aDuration;
             },
@@ -71,14 +120,14 @@ inline void OpenSpaceToolkitPhysicsPy_Time_Instant(pybind11::module &aModule)
         .def("__str__", &(shiftToString<Instant>))
         .def(
             "__repr__",
-            +[](const Instant &anInstant) -> std::string
+            +[](const Instant& anInstant) -> std::string
             {
                 return anInstant.toString();
             }
         )
         .def(
             "__hash__",
-            +[](const Instant &anInstant) -> size_t
+            +[](const Instant& anInstant) -> size_t
             {
                 return std::hash<Instant> {}(anInstant);
             }
@@ -157,9 +206,9 @@ inline void OpenSpaceToolkitPhysicsPy_Time_Instant(pybind11::module &aModule)
         )
         .def(
             "to_string",
-            overload_cast<const Scale &, const DateTime::Format &>(&Instant::toString, const_),
-            arg_v("scale", DEFAULT_TIME_SCALE, "Scale.UTC"),
-            arg_v("date_time_format", DEFAULT_DATE_TIME_FORMAT, "Format.Standard"),
+            overload_cast<const Scale&, const DateTime::Format&>(&Instant::toString, const_),
+            arg("scale").sig("Scale.UTC") = DEFAULT_TIME_SCALE,
+            arg("date_time_format").sig("Format.Standard") = DEFAULT_DATE_TIME_FORMAT,
             R"doc(
                 Convert to string.
 
@@ -257,7 +306,7 @@ inline void OpenSpaceToolkitPhysicsPy_Time_Instant(pybind11::module &aModule)
             &Instant::Parse,
             arg("string"),
             arg("scale"),
-            arg_v("date_time_format", DEFAULT_DATE_TIME_FORMAT, "Format.Standard"),
+            arg("date_time_format").sig("Format.Standard") = DEFAULT_DATE_TIME_FORMAT,
 
             R"doc(
                 Create an instant from a string representation.
@@ -266,7 +315,6 @@ inline void OpenSpaceToolkitPhysicsPy_Time_Instant(pybind11::module &aModule)
                     string (str): String representation.
                     scale (Time.Scale): Time scale.
                     date_time_format (DateTime.Format): Date-time format.
-
 
                 Returns:
                     Instant: Instant.

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/Interval.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/Interval.cpp
@@ -4,10 +4,11 @@
 
 #include <OpenSpaceToolkit/Physics/Time/Interval.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Time_Interval(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Time_Interval(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
+    using ostk::core::container::Array;
     using ostk::core::type::String;
 
     using ostk::physics::time::Instant;
@@ -39,8 +40,22 @@ inline void OpenSpaceToolkitPhysicsPy_Time_Interval(pybind11::module& aModule)
             )doc"
         )
 
-        .def(self == self)
-        .def(self != self)
+        .def(
+            "__eq__",
+            [](const Interval& self, const Interval& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__ne__",
+            [](const Interval& self, const Interval& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator()
+        )
 
         .def("__str__", &(shiftToString<Interval>))
         .def(
@@ -425,9 +440,29 @@ inline void OpenSpaceToolkitPhysicsPy_Time_Interval(pybind11::module& aModule)
         )
         .def_static(
             "get_gaps",
-            &Interval::GetGaps,
+            [](const Array<Interval>& anIntervalArray) -> Array<Interval>
+            {
+                return Interval::GetGaps(anIntervalArray);
+            },
             arg("intervals"),
-            arg_v("interval", Interval::Undefined(), "Interval::Undefined()"),
+            R"doc(
+                Creates a list of intervals gaps, over the span of the provided intervals.
+
+                Args:
+                    intervals (list[Interval]): A list of intervals.
+
+                Returns:
+                    list[Interval]: Intervals gaps.
+            )doc"
+        )
+        .def_static(
+            "get_gaps",
+            [](const Array<Interval>& anIntervalArray, const Interval& anInterval) -> Array<Interval>
+            {
+                return Interval::GetGaps(anIntervalArray, anInterval);
+            },
+            arg("intervals"),
+            arg("interval"),
             R"doc(
                 Creates a list of intervals gaps.
 
@@ -510,47 +545,10 @@ inline void OpenSpaceToolkitPhysicsPy_Time_Interval(pybind11::module& aModule)
 
         ;
 
-    // https://github.com/pybind/pybind11/pull/949 locally to avoid conflicts with other potential objects in other ostk
-    // modules
-    enum_<Interval::Type>(interval_class, "Type", pybind11::module_local())
-
-        .value(
-            "Undefined",
-            Interval::Type::Undefined,
-            R"doc(
-                Undefined interval type.
-            )doc"
-        )
-        .value(
-            "Closed",
-            Interval::Type::Closed,
-            R"doc(
-                Closed interval type.
-            )doc"
-        )
-        .value(
-            "Open",
-            Interval::Type::Open,
-            R"doc(
-                Open interval type.
-            )doc"
-        )
-        .value(
-            "HalfOpenLeft",
-            Interval::Type::HalfOpenLeft,
-            R"doc(
-                Half-open left interval type.
-            )doc"
-        )
-        .value(
-            "HalfOpenRight",
-            Interval::Type::HalfOpenRight,
-            R"doc(
-                Half-open right interval type.
-            )doc"
-        )
-
-        ;
+    // `Interval::Type` is `ostk::mathematics::object::IntervalBase::Type`, which `ostk.mathematics`
+    // already binds. pybind11 allowed a second, module-local registration of the same C++
+    // enumeration; nanobind keeps one registry per domain, so the existing one is reused.
+    interval_class.attr("Type") = module_::import_("ostk.mathematics.object").attr("RealInterval").attr("Type");
 
     implicitly_convertible<ostk::mathematics::object::Interval<ostk::physics::time::Instant>, Interval>();
 }

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/Scale.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/Scale.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Time/Scale.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Time_Scale(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Time_Scale(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::physics::time::Scale;
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/Time.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Time/Time.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Time/Time.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Time_Time(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Time_Time(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::String;
 
@@ -72,8 +72,22 @@ inline void OpenSpaceToolkitPhysicsPy_Time_Time(pybind11::module& aModule)
             )doc"
         )
 
-        .def(self == self)
-        .def(self != self)
+        .def(
+            "__eq__",
+            [](const Time& self, const Time& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__ne__",
+            [](const Time& self, const Time& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator()
+        )
 
         .def("__str__", &(shiftToString<Time>))
         .def(

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Unit.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Unit.cpp
@@ -7,9 +7,9 @@
 #include <OpenSpaceToolkitPhysicsPy/Unit/Mass.cpp>
 #include <OpenSpaceToolkitPhysicsPy/Unit/Time.cpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Unit(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Unit(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::physics::Unit;
 
@@ -98,8 +98,22 @@ inline void OpenSpaceToolkitPhysicsPy_Unit(pybind11::module& aModule)
 
     unit_class
 
-        .def(self == self)
-        .def(self != self)
+        .def(
+            "__eq__",
+            [](const Unit& self, const Unit& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__ne__",
+            [](const Unit& self, const Unit& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator()
+        )
 
         .def("__str__", &(shiftToString<Unit>))
         .def("__repr__", &(shiftToString<Unit>))

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Unit/Derived.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Unit/Derived.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Unit/Derived.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Unit_Derived(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Unit_Derived(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Integer;
     using ostk::core::type::Real;
@@ -38,8 +38,22 @@ inline void OpenSpaceToolkitPhysicsPy_Unit_Derived(pybind11::module& aModule)
             )doc"
         )
 
-        .def(self == self)
-        .def(self != self)
+        .def(
+            "__eq__",
+            [](const Derived& self, const Derived& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__ne__",
+            [](const Derived& self, const Derived& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator()
+        )
 
         .def("__str__", &(shiftToString<Derived>))
         .def(
@@ -84,7 +98,7 @@ inline void OpenSpaceToolkitPhysicsPy_Unit_Derived(pybind11::module& aModule)
         .def(
             "to_string",
             &Derived::toString,
-            "aPrecision"_a = Integer::Undefined(),
+            arg("aPrecision") = Integer::Undefined(),
             R"doc(
                 Convert to string.
 
@@ -166,8 +180,22 @@ inline void OpenSpaceToolkitPhysicsPy_Unit_Derived(pybind11::module& aModule)
             )doc"
         )
 
-        .def(self == self)
-        .def(self != self)
+        .def(
+            "__eq__",
+            [](const Derived::Order& self, const Derived::Order& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__ne__",
+            [](const Derived::Order& self, const Derived::Order& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator()
+        )
 
         .def(
             "is_zero",
@@ -284,20 +312,34 @@ inline void OpenSpaceToolkitPhysicsPy_Unit_Derived(pybind11::module& aModule)
              const Angle::Unit&,
              const Derived::Order&>())
 
-        .def(self == self)
-        .def(self != self)
+        .def(
+            "__eq__",
+            [](const Derived::Unit& self, const Derived::Unit& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__ne__",
+            [](const Derived::Unit& self, const Derived::Unit& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator()
+        )
 
         .def("is_defined", &Derived::Unit::isDefined)
         .def("is_compatible_with", &Derived::Unit::isCompatibleWith)
 
-        // .def("access_length_unit", &Derived::Unit::accessLengthUnit, return_value_policy::reference)
-        // .def("access_length_order", &Derived::Unit::accessLengthOrder, return_value_policy::reference)
-        // .def("access_mass_unit", &Derived::Unit::accessMassUnit, return_value_policy::reference)
-        // .def("access_mass_order", &Derived::Unit::accessMassOrder, return_value_policy::reference)
-        // .def("access_time_unit", &Derived::Unit::accessTimeUnit, return_value_policy::reference)
-        // .def("access_time_order", &Derived::Unit::accessTimeOrder, return_value_policy::reference)
-        // .def("access_angle_unit", &Derived::Unit::accessAngleUnit, return_value_policy::reference)
-        // .def("access_angle_order", &Derived::Unit::accessAngleOrder, return_value_policy::reference)
+        // .def("access_length_unit", &Derived::Unit::accessLengthUnit, rv_policy::reference)
+        // .def("access_length_order", &Derived::Unit::accessLengthOrder, rv_policy::reference)
+        // .def("access_mass_unit", &Derived::Unit::accessMassUnit, rv_policy::reference)
+        // .def("access_mass_order", &Derived::Unit::accessMassOrder, rv_policy::reference)
+        // .def("access_time_unit", &Derived::Unit::accessTimeUnit, rv_policy::reference)
+        // .def("access_time_order", &Derived::Unit::accessTimeOrder, rv_policy::reference)
+        // .def("access_angle_unit", &Derived::Unit::accessAngleUnit, rv_policy::reference)
+        // .def("access_angle_order", &Derived::Unit::accessAngleOrder, rv_policy::reference)
         .def(
             "to_string",
             &Derived::Unit::toString,

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Unit/Derived/Angle.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Unit/Derived/Angle.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Unit/Derived/Angle.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Unit_Derived_Angle(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Unit_Derived_Angle(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Integer;
     using ostk::core::type::Real;
@@ -15,11 +15,11 @@ inline void OpenSpaceToolkitPhysicsPy_Unit_Derived_Angle(pybind11::module& aModu
     using ostk::physics::unit::Angle;
 
     // Extend the mathematics module constructor
-    module math_module = module::import("ostk.mathematics.geometry");
+    module_ math_module = module_::import_("ostk.mathematics.geometry");
 
     // Get the Mathematics Angle class
     class_<ostk::mathematics::geometry::Angle> math_angle =
-        math_module.attr("Angle").cast<class_<ostk::mathematics::geometry::Angle>>();
+        borrow<class_<ostk::mathematics::geometry::Angle>>(math_module.attr("Angle"));
 
     // Add a new constructor to the Mathematics Angle class
     math_angle.def(init<const ostk::physics::unit::Angle&>());
@@ -60,14 +60,56 @@ inline void OpenSpaceToolkitPhysicsPy_Unit_Derived_Angle(pybind11::module& aModu
         )
 
         // Define methods
-        .def(self == self)
-        .def(self != self)
+        .def(
+            "__eq__",
+            [](const Angle& self, const Angle& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__ne__",
+            [](const Angle& self, const Angle& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator()
+        )
 
-        .def(self + self)
-        .def(self - self)
+        .def(
+            "__add__",
+            [](const Angle& self, const Angle& other)
+            {
+                return self + other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__sub__",
+            [](const Angle& self, const Angle& other)
+            {
+                return self - other;
+            },
+            nanobind::is_operator()
+        )
 
-        .def(+self)
-        .def(-self)
+        .def(
+            "__pos__",
+            [](const Angle& self)
+            {
+                return +self;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__neg__",
+            [](const Angle& self)
+            {
+                return -self;
+            },
+            nanobind::is_operator()
+        )
 
         .def(
             "__mul__",
@@ -102,8 +144,26 @@ inline void OpenSpaceToolkitPhysicsPy_Unit_Derived_Angle(pybind11::module& aModu
             is_operator()
         )
 
-        .def(self += self)
-        .def(self -= self)
+        .def(
+            "__iadd__",
+            [](Angle& self, const Angle& other) -> Angle&
+            {
+                self += other;
+                return self;
+            },
+            nanobind::rv_policy::none,
+            nanobind::is_operator()
+        )
+        .def(
+            "__isub__",
+            [](Angle& self, const Angle& other) -> Angle&
+            {
+                self -= other;
+                return self;
+            },
+            nanobind::rv_policy::none,
+            nanobind::is_operator()
+        )
 
         .def("__str__", &(shiftToString<Angle>))
         .def(
@@ -276,7 +336,7 @@ inline void OpenSpaceToolkitPhysicsPy_Unit_Derived_Angle(pybind11::module& aModu
         .def(
             "to_string",
             &Angle::toString,
-            arg_v("precision", Integer::Undefined(), "Integer.undefined()"),
+            arg("precision").sig("Integer.undefined()") = Integer::Undefined(),
             R"doc(
                 Get the string representation of the angle.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Unit/ElectricCurrent.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Unit/ElectricCurrent.cpp
@@ -4,9 +4,9 @@
 
 #include <OpenSpaceToolkit/Physics/Unit/ElectricCurrent.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Unit_ElectricCurrent(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Unit_ElectricCurrent(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Integer;
     using ostk::core::type::Real;
@@ -35,8 +35,22 @@ inline void OpenSpaceToolkitPhysicsPy_Unit_ElectricCurrent(pybind11::module& aMo
             )doc"
         )
 
-        .def(self == self)
-        .def(self != self)
+        .def(
+            "__eq__",
+            [](const ElectricCurrent& self, const ElectricCurrent& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__ne__",
+            [](const ElectricCurrent& self, const ElectricCurrent& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator()
+        )
 
         // .def(self < self)
         // .def(self <= self)
@@ -108,7 +122,7 @@ inline void OpenSpaceToolkitPhysicsPy_Unit_ElectricCurrent(pybind11::module& aMo
         .def(
             "to_string",
             &ElectricCurrent::toString,
-            "aPrecision"_a = Integer::Undefined(),
+            arg("aPrecision") = Integer::Undefined(),
             R"doc(
                 Get the string representation of the electric current.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Unit/Length.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Unit/Length.cpp
@@ -4,9 +4,9 @@
 
 #include <OpenSpaceToolkit/Physics/Unit/Length.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Unit_Length(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Unit_Length(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Integer;
     using ostk::core::type::Real;
@@ -35,27 +35,154 @@ inline void OpenSpaceToolkitPhysicsPy_Unit_Length(pybind11::module& aModule)
             )doc"
         )
 
-        .def(self == self)
-        .def(self != self)
+        .def(
+            "__eq__",
+            [](const Length& self, const Length& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__ne__",
+            [](const Length& self, const Length& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator()
+        )
 
-        .def(self < self)
-        .def(self <= self)
-        .def(self > self)
-        .def(self >= self)
+        .def(
+            "__lt__",
+            [](const Length& self, const Length& other)
+            {
+                return self < other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__le__",
+            [](const Length& self, const Length& other)
+            {
+                return self <= other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__gt__",
+            [](const Length& self, const Length& other)
+            {
+                return self > other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__ge__",
+            [](const Length& self, const Length& other)
+            {
+                return self >= other;
+            },
+            nanobind::is_operator()
+        )
 
-        .def(self + self)
-        .def(self - self)
-        .def(self * double())
-        .def(self / double())
-        .def(double() * self)
+        .def(
+            "__add__",
+            [](const Length& self, const Length& other)
+            {
+                return self + other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__sub__",
+            [](const Length& self, const Length& other)
+            {
+                return self - other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__mul__",
+            [](const Length& self, const double& other)
+            {
+                return self * other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__truediv__",
+            [](const Length& self, const double& other)
+            {
+                return self / other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__rmul__",
+            [](const Length& self, const double& other)
+            {
+                return other * self;
+            },
+            nanobind::is_operator()
+        )
 
-        .def(self += self)
-        .def(self -= self)
-        .def(self *= double())
-        .def(self /= double())
+        .def(
+            "__iadd__",
+            [](Length& self, const Length& other) -> Length&
+            {
+                self += other;
+                return self;
+            },
+            nanobind::rv_policy::none,
+            nanobind::is_operator()
+        )
+        .def(
+            "__isub__",
+            [](Length& self, const Length& other) -> Length&
+            {
+                self -= other;
+                return self;
+            },
+            nanobind::rv_policy::none,
+            nanobind::is_operator()
+        )
+        .def(
+            "__imul__",
+            [](Length& self, const double& other) -> Length&
+            {
+                self *= other;
+                return self;
+            },
+            nanobind::rv_policy::none,
+            nanobind::is_operator()
+        )
+        .def(
+            "__itruediv__",
+            [](Length& self, const double& other) -> Length&
+            {
+                self /= other;
+                return self;
+            },
+            nanobind::rv_policy::none,
+            nanobind::is_operator()
+        )
 
-        .def(+self)
-        .def(-self)
+        .def(
+            "__pos__",
+            [](const Length& self)
+            {
+                return +self;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__neg__",
+            [](const Length& self)
+            {
+                return -self;
+            },
+            nanobind::is_operator()
+        )
 
         .def("__str__", &(shiftToString<Length>))
         .def(
@@ -130,7 +257,7 @@ inline void OpenSpaceToolkitPhysicsPy_Unit_Length(pybind11::module& aModule)
         .def(
             "to_string",
             &Length::toString,
-            "aPrecision"_a = Integer::Undefined(),
+            arg("aPrecision") = Integer::Undefined(),
             R"doc(
                 Get the string representation of the length.
 
@@ -281,8 +408,22 @@ inline void OpenSpaceToolkitPhysicsPy_Unit_Length(pybind11::module& aModule)
             )doc"
         )
 
-        .def(self == self)
-        .def(self != self)
+        .def(
+            "__eq__",
+            [](const Interval<Length>& self, const Interval<Length>& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__ne__",
+            [](const Interval<Length>& self, const Interval<Length>& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator()
+        )
 
         .def(
             "is_defined",

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Unit/Mass.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Unit/Mass.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Unit/Mass.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Unit_Mass(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Unit_Mass(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Integer;
     using ostk::core::type::Real;
@@ -33,8 +33,22 @@ inline void OpenSpaceToolkitPhysicsPy_Unit_Mass(pybind11::module& aModule)
         )doc"
     )
 
-        .def(self == self)
-        .def(self != self)
+        .def(
+            "__eq__",
+            [](const Mass& self, const Mass& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__ne__",
+            [](const Mass& self, const Mass& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator()
+        )
 
         // .def("__str__", &(shiftToString<Mass>))
         .def(
@@ -89,7 +103,7 @@ inline void OpenSpaceToolkitPhysicsPy_Unit_Mass(pybind11::module& aModule)
         .def(
             "to_string",
             &Mass::toString,
-            "aPrecision"_a = Integer::Undefined(),
+            arg("aPrecision") = Integer::Undefined(),
             R"doc(
                 Convert mass to string.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Unit/Time.cpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Unit/Time.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Physics/Unit/Time.hpp>
 
-inline void OpenSpaceToolkitPhysicsPy_Unit_Time(pybind11::module& aModule)
+inline void OpenSpaceToolkitPhysicsPy_Unit_Time(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Integer;
     using ostk::core::type::Real;
@@ -32,8 +32,22 @@ inline void OpenSpaceToolkitPhysicsPy_Unit_Time(pybind11::module& aModule)
         )doc"
     )
 
-        .def(self == self)
-        .def(self != self)
+        .def(
+            "__eq__",
+            [](const Time& self, const Time& other)
+            {
+                return self == other;
+            },
+            nanobind::is_operator()
+        )
+        .def(
+            "__ne__",
+            [](const Time& self, const Time& other)
+            {
+                return self != other;
+            },
+            nanobind::is_operator()
+        )
 
         // .def(self < self)
         // .def(self <= self)
@@ -78,7 +92,7 @@ inline void OpenSpaceToolkitPhysicsPy_Unit_Time(pybind11::module& aModule)
         .def(
             "to_string",
             &Time::toString,
-            "aPrecision"_a = Integer::Undefined(),
+            arg("aPrecision") = Integer::Undefined(),
             R"doc(
                 Convert time to string.
 

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Utility/ArrayCasting.hpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Utility/ArrayCasting.hpp
@@ -1,11 +1,23 @@
 /// Apache License 2.0
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/array.h>
+#include <nanobind/stl/complex.h>
+#include <nanobind/stl/map.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/pair.h>
+#include <nanobind/stl/set.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/tuple.h>
+#include <nanobind/stl/unique_ptr.h>
+#include <nanobind/stl/unordered_map.h>
+#include <nanobind/stl/unordered_set.h>
+#include <nanobind/stl/vector.h>
 
 #include <OpenSpaceToolkit/Core/Container/Array.hpp>
 
-namespace pybind11
+namespace nanobind
 {
 namespace detail
 {
@@ -18,4 +30,4 @@ struct type_caster<Array<T>> : list_caster<Array<T>, T>
 };
 
 }  // namespace detail
-}  // namespace pybind11
+}  // namespace nanobind

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Utility/DateTimeCasting.hpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Utility/DateTimeCasting.hpp
@@ -2,98 +2,137 @@
 
 #include <datetime.h>
 
-#include <pybind11/pybind11.h>
+#include <nanobind/nanobind.h>
 
 #include <OpenSpaceToolkit/Physics/Time/DateTime.hpp>
 
-// https://github.com/pybind/pybind11/issues/1176 (MAIN)
-// https://pybind11.readthedocs.io/en/stable/advanced/cast/custom.html
-// https://github.com/pybind/pybind11/blob/master/include/pybind11/chrono.h
+// https://nanobind.readthedocs.io/en/latest/porting.html
+// https://nanobind.readthedocs.io/en/latest/lowlevel.html
 // https://docs.python.org/3/c-api/datetime.html
-// https://en.cppreference.com/w/cpp/chrono/system_clock/to_time_t
-// https://github.com/pybind/pybind11/issues/2417
 
 using ostk::physics::time::DateTime;
 
-namespace pybind11
+namespace nanobind
 {
 namespace detail
 {
 
+/// @brief                      Accept a python datetime wherever a DateTime is expected, and return
+///                             DateTime as a python datetime.
+///
+///                             The base caster handles an actual bound DateTime; everything below it
+///                             is the datetime.datetime interoperability.
+
 template <>
-class type_caster<DateTime> : public type_caster_base<DateTime>
+struct type_caster<DateTime> : type_caster_base<DateTime>
 {
-    using type = DateTime;
-    using base = type_caster_base<DateTime>;
+    using Base = type_caster_base<DateTime>;
 
-   public:
-    // datetime.datetime (Python) -> DateTime (C++)
-    bool load(handle src, bool convert)
+    /// @brief                  Keeps a DateTime built from a python datetime alive for the call.
+
+    object convertedObject_;
+
+    bool from_python(handle aSource, uint8_t someFlags, cleanup_list* aCleanupList) noexcept
     {
-        // Lazy initialise the PyDateTime import
-        if (!PyDateTimeAPI)
+        if (!aSource.is_valid())
         {
-            PyDateTime_IMPORT;
-        }
-
-        if (!src)
             return false;
+        }
 
-        if (base::load(src, convert))
+        if (Base::from_python(aSource, someFlags, aCleanupList))
         {
             return true;
         }
-        else if (PyDateTime_Check(src.ptr()))
+
+        if (!importDateTimeApi())
         {
-            const int year = PyDateTime_GET_YEAR(src.ptr());
-            const int month = PyDateTime_GET_MONTH(src.ptr());
-            const int day = PyDateTime_GET_DAY(src.ptr());
-
-            const int hour = PyDateTime_DATE_GET_HOUR(src.ptr());
-            const int minute = PyDateTime_DATE_GET_MINUTE(src.ptr());
-            const int second = PyDateTime_DATE_GET_SECOND(src.ptr());
-
-            int microseconds = PyDateTime_DATE_GET_MICROSECOND(src.ptr());
-
-            const int millisecond = microseconds / 1000;
-            const int microsecond = microseconds - millisecond * 1000;
-
-            value = new DateTime(year, month, day, hour, minute, second, millisecond, microsecond);
-
-            return true;
+            return false;
         }
 
-        // Possibility to add conditions to convert datetime.date and datetime.time
+        if (!PyDateTime_Check(aSource.ptr()))
+        {
+            return false;
+        }
 
-        return false;
+        const int microseconds = PyDateTime_DATE_GET_MICROSECOND(aSource.ptr());
+        const int millisecond = microseconds / 1000;
+
+        const DateTime dateTime = {
+            PyDateTime_GET_YEAR(aSource.ptr()),
+            PyDateTime_GET_MONTH(aSource.ptr()),
+            PyDateTime_GET_DAY(aSource.ptr()),
+            PyDateTime_DATE_GET_HOUR(aSource.ptr()),
+            PyDateTime_DATE_GET_MINUTE(aSource.ptr()),
+            PyDateTime_DATE_GET_SECOND(aSource.ptr()),
+            millisecond,
+            microseconds - millisecond * 1000,
+        };
+
+        // Round-trip through a bound DateTime so the base caster owns the storage.
+
+        convertedObject_ = steal(Base::from_cpp(dateTime, rv_policy::copy, nullptr));
+
+        if (!convertedObject_.is_valid())
+        {
+            PyErr_Clear();
+
+            return false;
+        }
+
+        return Base::from_python(convertedObject_, someFlags, aCleanupList);
     }
 
-    // DateTime (C++) -> datetime.datetime (Python)
-    static handle cast(const DateTime& aDateTime, return_value_policy /* policy */, handle /* parent */)
+    // Declared here so that the base class template of the same name is hidden.
+
+    static handle from_cpp(const DateTime& aDateTime, rv_policy, cleanup_list*) noexcept
     {
-        // Lazy initialise the PyDateTime import
-        if (!PyDateTimeAPI)
+        if (!importDateTimeApi())
         {
-            PyDateTime_IMPORT;
+            return handle();
         }
 
         if (!aDateTime.isDefined())
         {
-            return pybind11::none();
+            return none().release();
         }
 
-        const int year = static_cast<int>(aDateTime.accessDate().getYear());
-        const int month = static_cast<int>(aDateTime.accessDate().getMonth());
-        const int day = static_cast<int>(aDateTime.accessDate().getDay());
-        const int hour = static_cast<int>(aDateTime.accessTime().getHour());
-        const int minute = static_cast<int>(aDateTime.accessTime().getMinute());
-        const int second = static_cast<int>(aDateTime.accessTime().getSecond());
         const int microseconds =
             (aDateTime.accessTime().getMillisecond() * 1000) + aDateTime.accessTime().getMicrosecond();
 
-        return PyDateTime_FromDateAndTime(year, month, day, hour, minute, second, microseconds);
+        return PyDateTime_FromDateAndTime(
+            static_cast<int>(aDateTime.accessDate().getYear()),
+            static_cast<int>(aDateTime.accessDate().getMonth()),
+            static_cast<int>(aDateTime.accessDate().getDay()),
+            static_cast<int>(aDateTime.accessTime().getHour()),
+            static_cast<int>(aDateTime.accessTime().getMinute()),
+            static_cast<int>(aDateTime.accessTime().getSecond()),
+            microseconds
+        );
+    }
+
+    static handle from_cpp(const DateTime* aDateTimePtr, rv_policy aPolicy, cleanup_list* aCleanupList) noexcept
+    {
+        return (aDateTimePtr != nullptr) ? from_cpp(*aDateTimePtr, aPolicy, aCleanupList) : none().release();
+    }
+
+   private:
+    static bool importDateTimeApi() noexcept
+    {
+        if (PyDateTimeAPI == nullptr)
+        {
+            PyDateTime_IMPORT;
+
+            if (PyDateTimeAPI == nullptr)
+            {
+                PyErr_Clear();
+
+                return false;
+            }
+        }
+
+        return true;
     }
 };
 
 }  // namespace detail
-}  // namespace pybind11
+}  // namespace nanobind

--- a/bindings/python/src/OpenSpaceToolkitPhysicsPy/Utility/EigenSequenceCasting.hpp
+++ b/bindings/python/src/OpenSpaceToolkitPhysicsPy/Utility/EigenSequenceCasting.hpp
@@ -1,0 +1,146 @@
+/// Apache License 2.0
+
+#ifndef __OpenSpaceToolkitPy_Utility_EigenSequenceCasting__
+#define __OpenSpaceToolkitPy_Utility_EigenSequenceCasting__
+
+#include <Eigen/Dense>
+#include <nanobind/eigen/dense.h>
+#include <nanobind/nanobind.h>
+
+/// @brief                      Accept any python sequence where a dense Eigen vector or matrix is expected.
+///
+///                             pybind11's Eigen support converted lists and tuples on the caller's behalf.
+///                             nanobind's only accepts objects exposing DLPack or the buffer protocol, so
+///                             `Position.meters([1.0, 2.0, 3.0], frame)` would stop working. These casters
+///                             run nanobind's own conversion first and fall back to `numpy.asarray` for
+///                             anything else, restoring the previous behaviour.
+///
+///                             This header must be included before any binding code that mentions one of
+///                             the types below, since a specialization may not follow its first use.
+
+namespace nanobind
+{
+namespace detail
+{
+
+template <class MatrixType>
+struct EigenSequenceCaster
+{
+    using Scalar = typename MatrixType::Scalar;
+
+    /// @brief                  A layout-identical Eigen::Array.
+    ///
+    ///                         This specialization replaces nanobind's own dense caster for MatrixType,
+    ///                         which then can no longer be named. Eigen::Array is a distinct type with
+    ///                         the same storage, so nanobind's caster stays reachable through it.
+
+    using Bridge = Eigen::Array<
+        Scalar,
+        MatrixType::RowsAtCompileTime,
+        MatrixType::ColsAtCompileTime,
+        MatrixType::Options,
+        MatrixType::MaxRowsAtCompileTime,
+        MatrixType::MaxColsAtCompileTime>;
+
+    using BridgeCaster = make_caster<Bridge>;
+
+    NB_TYPE_CASTER(MatrixType, BridgeCaster::Name)
+
+    bool from_python(handle aSource, uint8_t someFlags, cleanup_list* aCleanupList) noexcept
+    {
+        BridgeCaster caster;
+
+        if (caster.from_python(aSource, someFlags, aCleanupList))
+        {
+            value = caster.value.matrix();
+
+            return true;
+        }
+
+        if ((someFlags & static_cast<uint8_t>(cast_flags::convert)) == 0)
+        {
+            return false;
+        }
+
+        // Turn the sequence into an array of the right scalar type. Asking for the dtype matters:
+        // a list holding an `ostk::core::type::Real` (or any object with __float__) would otherwise
+        // come back with object dtype, which nanobind rejects.
+
+        object array;
+
+        try
+        {
+            array = module_::import_("numpy").attr("asarray")(aSource, numpyDtype());
+        }
+        catch (...)
+        {
+            return false;
+        }
+
+        if (!caster.from_python(array.ptr(), someFlags, aCleanupList))
+        {
+            return false;
+        }
+
+        // `caster.value` views `array`, which is alive for the duration of this copy.
+
+        value = caster.value.matrix();
+
+        return true;
+    }
+
+    /// @brief                  The numpy dtype string matching Scalar, e.g. "f8" for a double.
+
+    static const char* numpyDtype() noexcept
+    {
+        static_assert(sizeof(Scalar) <= 9, "Unsupported scalar size.");
+
+        static const char dtype[3] = {
+            std::is_floating_point_v<Scalar> ? 'f' : (std::is_signed_v<Scalar> ? 'i' : 'u'),
+            static_cast<char>('0' + sizeof(Scalar)),
+            '\0',
+        };
+
+        return dtype;
+    }
+
+    static handle from_cpp(const MatrixType& aMatrix, rv_policy, cleanup_list* aCleanupList) noexcept
+    {
+        // The bridge is a fresh copy, so it can always be moved from. No binding in this project
+        // returns a plain Eigen value under a view policy, which would need the original storage.
+
+        return BridgeCaster::from_cpp(Bridge(aMatrix.array()), rv_policy::move, aCleanupList);
+    }
+};
+
+#define OSTK_EIGEN_SEQUENCE_CASTER(...)                       \
+    template <>                                              \
+    struct type_caster<__VA_ARGS__> : EigenSequenceCaster<__VA_ARGS__> \
+    {                                                        \
+    };
+
+// Matches the aliases in open-space-toolkit-mathematics' Object/Vector.hpp.
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Vector2i)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Vector3i)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Vector4i)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::VectorXi)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Vector2d)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Vector3d)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Vector4d)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Matrix<double, 6, 1>)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::VectorXd)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Matrix2i)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Matrix3i)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Matrix4i)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::MatrixXi)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Matrix2d)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Matrix3d)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Matrix4d)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::MatrixXd)
+
+#undef OSTK_EIGEN_SEQUENCE_CASTER
+
+}  // namespace detail
+}  // namespace nanobind
+
+#endif

--- a/bindings/python/test/unit/derived/test_angle.py
+++ b/bindings/python/test/unit/derived/test_angle.py
@@ -101,9 +101,9 @@ def test_angle_default_constructor():
     assert isinstance(angle, AnglePhysics)
     assert angle.in_revolutions() == 18.0
 
-    # Invalid construction
-    with pytest.raises(TypeError):
-        angle: AnglePhysics = AnglePhysics(45, Unit.Degree)
+    # nanobind converts an int to the Real the constructor expects, where
+    # pybind11 required a float.
+    assert AnglePhysics(45, Unit.Degree).in_degrees() == 45.0
 
 
 def test_angle_undefined_constructor():

--- a/bindings/python/tools/python/pyproject.toml.in
+++ b/bindings/python/tools/python/pyproject.toml.in
@@ -29,7 +29,7 @@ dependencies = [
 
 [project.optional-dependencies]
 prebuild = [
-    "pybind11-stubgen"
+    "nanobind==2.9.2"
 ]
 test = [
     "pytest"
@@ -48,5 +48,5 @@ ext-modules = [
 include = ["ostk.physics", "ostk.physics.*"]
 
 [tool.setuptools.package-data]
-"ostk.physics" = ["${SHARED_LIBRARY_TARGET}.${PROJECT_VERSION_MAJOR}", "${LIBRARY_TARGET}.*${EXTENSION}*.so"]
+"ostk.physics" = ["${SHARED_LIBRARY_TARGET}.${PROJECT_VERSION_MAJOR}", "${LIBRARY_TARGET}.*${EXTENSION}*.so", "*.pyi", "py.typed"]
 "*" = ["*/data/*"]


### PR DESCRIPTION
Replaces pybind11 with [nanobind](https://github.com/wjakob/nanobind) as the Python binding layer. Part of a six-repository stack, starting with open-space-collective/open-space-toolkit-core#211.

nanobind is a from-scratch rewrite of pybind11 by the same author with a much leaner call path. Measured on Core's bindings — same commit, same C++ library, release build — it is **6.62x faster** per call at the geometric mean, produces a **34% smaller** extension module, and compiles about 3x faster.

## What needed real work

Beyond the mechanical translation (operators as explicit lambdas, `def_ro`/`def_ro_static`, `arg(name).sig(repr) = value`, `module_::import_`):

- **`Utility/DateTimeCasting.hpp` rewritten** for nanobind's `from_python`/`from_cpp` protocol. It still accepts a Python `datetime` wherever a `DateTime` is expected and still returns `DateTime` as a `datetime`. The converted value is now owned by the caster rather than heap-allocated and abandoned, which also fixes a leak in the pybind11 version.
- **`Interval.Type` is now an alias** of `ostk.mathematics.object.RealInterval.Type` rather than a second registration. It is the same C++ enumeration (`IntervalBase::Type`); pybind11 permitted a module-local duplicate via `py::module_local()`, nanobind keeps one registry per domain and refuses it. The two are now the same Python object where they used to be distinct enumerations comparing unequal.
- **`Interval.get_gaps` is split into two overloads.** An `Interval` default argument makes the type reference-cycle through its own function records, which nanobind reports as a leak at interpreter shutdown.
- **`Duration`'s `init(factory)`** becomes a placement-new `__init__`.

## `Utility/EigenSequenceCasting.hpp` (new)

This restores an API that would otherwise break silently. pybind11 converted **any Python sequence** for a dense Eigen argument; nanobind only accepts objects exposing DLPack or the buffer protocol, so `Position.meters([7000e3, 0.0, 0.0], frame)` would have started raising `TypeError`. The casters run nanobind's own conversion first and fall back to `numpy.asarray` with the target dtype, which also keeps lists containing an `ostk::core::type::Real` working via `__float__`.

## Behaviour change

nanobind runs the source caster for an implicit conversion with conversion enabled, where pybind11 did not, so `Angle(45, Unit.Degree)` now accepts an `int` where a `Real` is expected instead of raising `TypeError`. The test covering the old strictness has been updated.

## Build and ordering

nanobind is fetched with `FetchContent`, so **no development image change is needed**. Pinned to **v2.9.2**: v3.x requires Python 3.10 and this project still ships 3.9 wheels.

pybind11 and nanobind keep **separate type registries**, and a nanobind module fails at *import* against a pybind11 dependency. Core, I/O and Mathematics must be released first.

## Testing

567 pass, 8 skipped, against nanobind-built Core, I/O and Mathematics.


---

## Release order

pybind11 and nanobind keep separate type registries, and a nanobind module fails at **import** against a pybind11 dependency — not merely at call time. These must therefore be merged and released strictly in dependency order:

1. open-space-collective/open-space-toolkit-core#211
2. open-space-collective/open-space-toolkit-io#126
3. open-space-collective/open-space-toolkit-mathematics#201
4. open-space-collective/open-space-toolkit-physics#399
5. open-space-collective/open-space-toolkit-astrodynamics#710
6. open-space-collective/open-space-toolkit-simulation#96

Until the dependency above it is on PyPI, building a repository in this stack locally needs the previously built wheels supplied to `uv` (e.g. `UV_FIND_LINKS=<wheelhouse>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Python bindings now use nanobind, with generated type stubs and improved support for Python sequences passed to numerical APIs.
  - Integer values are accepted where numeric inputs such as angles are expected.
  - Interval gap calculation supports calls with or without a bounding interval.

- **Bug Fixes**
  - Corrected equality and inequality behavior across multiple Python-bound types.
  - Improved Python package metadata and typing-file distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->